### PR TITLE
User-Definable "LCD12864 Simulator" Text

### DIFF
--- a/TFT/src/User/API/UI/ST7920_Simulator.c
+++ b/TFT/src/User/API/UI/ST7920_Simulator.c
@@ -1,8 +1,13 @@
 #include "ST7920_Simulator.h"
 #include "includes.h"
 #include "GUI.h"
+#include "../../Configuration.h"
 
 #ifdef ST7920_SPI
+
+#ifndef ST7920_BANNER_TEXT
+  #define ST7920_BANNER_TEXT "LCD12864 Simulator"
+#endif
 
 ST7920_PIXEL       st7920 = {ST7920_XSTART, ST7920_YSTART, 0};
 ST7920_CTRL_STATUS status = ST7920_IDLE;
@@ -127,7 +132,7 @@ void menuST7920(void)
   GUI_Clear(BLACK);
   GUI_SetColor(ST7920_FNCOLOR);
   GUI_SetBkColor(ST7920_BKCOLOR);
-  GUI_DispStringInRect(0, 0, LCD_WIDTH, SIMULATOR_YSTART, "LCD12864 Simulator", 0);
+  GUI_DispStringInRect(0, 0, LCD_WIDTH, SIMULATOR_YSTART, ST7920_BANNER_TEXT, 0);
   SPI_Slave();
   SPI_Slave_CS_Config();
   

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -34,6 +34,9 @@
 
 #define PWC_ON_LCD 
 
+// Text displayed at the top of the LCD in 12864 mode
+#define ST7920_BANNER_TEXT "LCD12864 Simulator"
+
 // Ability to print gcode from Board SD via Gcode functions.
 #define ONBOARD_SD_SUPPORT
 #ifdef ONBOARD_SD_SUPPORT


### PR DESCRIPTION
"LCD12864 Simulator" is now definable in `Configuration.h`.