### PR TITLE
User-Definable 12864 Mode Colors & Color Cleanup

### DIFF
--- a/TFT/src/User/API/UI/ST7920_Simulator.h
+++ b/TFT/src/User/API/UI/ST7920_Simulator.h
@@ -2,9 +2,17 @@
 #define _ST7920_SIMULATOR_H_
 
 #include "stdint.h"
+#include "../../Configuration.h"
 
-#define ST7920_BKCOLOR   (BLACK)
-#define ST7920_FNCOLOR   (GREEN)
+// User-defined colors for 12864 mode from Configuration.h
+#ifndef ST7920_BKCOLOR
+  #define ST7920_BKCOLOR (BLACK)
+#endif
+
+#ifndef ST7920_FNCOLOR
+  #define ST7920_FNCOLOR (GREEN)
+#endif
+
 #define ST7920_XSTART    (0x80)
 #define ST7920_YSTART    (0x80)
 

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -31,7 +31,7 @@
 
 /**
  * 12864 Mode Background & Font Color Options
- * Current color options from lcd.h: BLACK, BLUE, BRED, BROWN, BRRED, CYAN, GBLUE, GRAY, GRED, GREEN, MAGENTA, RED, WHITE, YELLOW
+ * Current color options from lcd.h: BLACK, BLUE, BROWN, BRRED, CYAN, GBLUE, GRAY, GREEN, MAGENTA, RED, WHITE, YELLOW
  */
 #define ST7920_BKCOLOR BLACK
 #define ST7920_FNCOLOR WHITE

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -29,6 +29,12 @@
 #define Y_MAX_POS 300
 #define Z_MAX_POS 400
 
+/**
+ * 12864 Mode Background & Font Color Options
+ * Current color options from lcd.h: BLACK, BLUE, BRED, BROWN, BRRED, CYAN, GBLUE, GRAY, GRED, GREEN, MAGENTA, RED, WHITE, YELLOW
+ */
+#define ST7920_BKCOLOR BLACK
+#define ST7920_FNCOLOR WHITE
 
 #define SUPPOR_PWC 
 

--- a/TFT/src/User/Hal/stm32f10x/lcd.h
+++ b/TFT/src/User/Hal/stm32f10x/lcd.h
@@ -48,19 +48,17 @@
 
 //
 #define WHITE                 0xFFFF
-#define BLACK                 0x0000    
-#define BLUE                  0x001F  
-#define BRED                  0XF81F
-#define GRED                  0XFFE0
+#define BLACK                 0x0000
+#define BLUE                  0x001F
 #define GBLUE                 0X07FF
 #define RED                   0xF800
 #define MAGENTA               0xF81F
 #define GREEN                 0x07E0
 #define CYAN                  0x7FFF
 #define YELLOW                0xFFE0
-#define BROWN                 0XBC40 //
-#define BRRED                 0XFC07 //
-#define GRAY                  0X8430 //
+#define BROWN                 0XBC40
+#define BRRED                 0XFC07
+#define GRAY                  0X8430
 
 void LCD_HardwareConfig(void);
 uint16_t LCD_RD_DATA(void);

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -20,7 +20,7 @@ WINDOW window = {
   10,                      //四角圆弧的半径
   3,                       //外边的线宽
   0x5D7B,                  //外边和标题栏的背景色
-  {BRED, 0x5D7B, POPUP_TITLE_HEIGHT},   //标题栏 字体色/背景色/高度
+  {MAGENTA, 0x5D7B, POPUP_TITLE_HEIGHT},   //标题栏 字体色/背景色/高度
   {WHITE, BLACK, POPUP_TEXT_HEIGHT},    //文本栏 字体色/背景色/高度
   {WHITE, GRAY,  POPUP_BOTTOM_HEIGHT},  //底部 (字体色)/背景色/(高度)
 };


### PR DESCRIPTION
Users can now change the 12864 mode background & font colors in `Configuration.h`. The black background looks the best due to letterboxing.

Current color options from lcd.h: BLACK, BLUE, BROWN, BRRED, CYAN, GBLUE, GRAY, GREEN, MAGENTA, RED, WHITE, YELLOW

Also, I removed duplicate colors since `BRED` = `MAGENTA` (both were `0XF81F`) & `GRED` = `YELLOW` (both were `0XFFE0`).