### PR TITLE
Merge and fix includes.

### DIFF
--- a/TFT/src/User/API/Language/Language.c
+++ b/TFT/src/User/API/Language/Language.c
@@ -1,4 +1,4 @@
-#include "language.h"
+#include "Language.h"
 #include "includes.h"
 #include "language_en.h"
 #include "language_cn.h"

--- a/TFT/src/User/Hal/LCD_Init.c
+++ b/TFT/src/User/Hal/LCD_Init.c
@@ -1,4 +1,4 @@
-#include "LCD_init.h"
+#include "LCD_Init.h"
 #include "GPIO_Init.h"
 #include "includes.h"
 

--- a/TFT/src/User/Hal/stm32f10x/Serial.c
+++ b/TFT/src/User/Hal/stm32f10x/Serial.c
@@ -1,5 +1,5 @@
 #include "Serial.h"
-#include "USART.h"
+#include "usart.h"
 
 //Config for USART Channel
 #if SERIAL_PORT == _USART1

--- a/TFT/src/User/Hal/w25qxx.h
+++ b/TFT/src/User/Hal/w25qxx.h
@@ -1,7 +1,7 @@
 #ifndef _W25QXX_H_
 #define _W25QXX_H_
 
-#include "SPI.h"
+#include "spi.h"
 
 #define CMD_WRITE_ENABLE   0x06
 #define CMD_WRITE_DISABLE  0x04

--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -1,4 +1,4 @@
-#include "babystep.h"
+#include "BabyStep.h"
 #include "includes.h"
 
 //1��title(����), ITEM_PER_PAGE��item(ͼ��+��ǩ) 

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -1,4 +1,4 @@
-#include "extrude.h"
+#include "Extrude.h"
 #include "includes.h"
 
 //1��title(����), ITEM_PER_PAGE��item(ͼ��+��ǩ) 

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -1,4 +1,4 @@
-#include "fan.h"
+#include "Fan.h"
 #include "includes.h"
 
 

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -1,4 +1,4 @@
-#include "heat.h"
+#include "Heat.h"
 #include "includes.h"
 
 //1 title, ITEM_PER_PAGE items (icon+label) 

--- a/TFT/src/User/Menu/Home.c
+++ b/TFT/src/User/Menu/Home.c
@@ -1,4 +1,4 @@
-#include "home.h"
+#include "Home.h"
 #include "includes.h"
 
 //1个title(标题), ITEM_PER_PAGE个item(图标+标签) 

--- a/TFT/src/User/Menu/MainPage.c
+++ b/TFT/src/User/Menu/MainPage.c
@@ -1,4 +1,4 @@
-#include "mainpage.h"
+#include "MainPage.h"
 #include "includes.h"
 
 //1个title(标题), ITEM_PER_PAGE个item(图标+标签) 

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -1,4 +1,4 @@
-#include "mode.h"
+#include "Mode.h"
 #include "includes.h"
 
 

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -1,4 +1,4 @@
-#include "move.h"
+#include "Move.h"
 #include "includes.h"
 
 //1个title(标题), ITEM_PER_PAGE个item(图标+标签) 

--- a/TFT/src/User/Menu/PowerFailed.h
+++ b/TFT/src/User/Menu/PowerFailed.h
@@ -2,7 +2,7 @@
 #define _POWERFAILED_H_
 
 #include "variants.h"
-#include "heat.h"
+#include "Heat.h"
 #include "coordinate.h"
 #include "ff.h"
 #include "Configuration.h"

--- a/TFT/src/User/includes.h
+++ b/TFT/src/User/includes.h
@@ -17,13 +17,13 @@
 #include "boot.h"
 
 #include "lcd.h"
-#include "lcd_init.h"
+#include "LCD_Init.h"
 #include "lcd_dma.h"
 #include "GUI.h"
-#include "language.h"
+#include "Language.h"
 
 #include "usart.h"
-#include "serial.h"
+#include "Serial.h"
 #include "spi.h"
 #include "sw_spi.h"
 #include "spi_slave.h"
@@ -54,7 +54,7 @@
 
 //menu
 #include "menu.h"
-#include "Mainpage.h"
+#include "MainPage.h"
 
 #include "Heat.h"
 #include "Move.h"


### PR DESCRIPTION
Change #include filenames to match capitalization of actual files.
Required to compile on non-Microsoft operating systems.