### PR TITLE
Fix string varible type warning

### DIFF
--- a/TFT/src/User/API/UI/ST7920_Simulator.c
+++ b/TFT/src/User/API/UI/ST7920_Simulator.c
@@ -132,7 +132,7 @@ void menuST7920(void)
   GUI_Clear(BLACK);
   GUI_SetColor(ST7920_FNCOLOR);
   GUI_SetBkColor(ST7920_BKCOLOR);
-  GUI_DispStringInRect(0, 0, LCD_WIDTH, SIMULATOR_YSTART, ST7920_BANNER_TEXT, 0);
+  GUI_DispStringInRect(0, 0, LCD_WIDTH, SIMULATOR_YSTART, (u8*)ST7920_BANNER_TEXT, 0);
   SPI_Slave();
   SPI_Slave_CS_Config();
   

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -58,7 +58,7 @@ void infoMenuSelect(void)
 void menuMode(void)
 {  
   RADIO modeRadio = {
-    {"Serial Touch Screen", "LCD12864 Simulator", "LCD2004 Simulator"},
+    {(u8*)"Serial Touch Screen", (u8*)ST7920_BANNER_TEXT, (u8*)"LCD2004 Simulator"},
     SIMULATOR_XSTART, SIMULATOR_YSTART,
     BYTE_HEIGHT*2, 2,
     0


### PR DESCRIPTION
fix variable type, from char* to uint8*