### PR TITLE
env_default => default_envs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ build_dir   = .pioenvs
 lib_dir     = .piolib
 libdeps_dir = .piolibdeps
 boards_dir  = buildroot/boards
-env_default = BIGTREE_TFT35_V2_0
+default_envs = BIGTREE_TFT35_V2_0
 
 [common]
 default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x>


### PR DESCRIPTION
This PR fixes the "env_default" depreciation warning with PlatformIO 4.0.