### PR TITLE
ST7920_BANNER_TEXT can be disabled

### DIFF
--- a/TFT/src/User/API/UI/ST7920_Simulator.c
+++ b/TFT/src/User/API/UI/ST7920_Simulator.c
@@ -5,10 +5,6 @@
 
 #ifdef ST7920_SPI
 
-#ifndef ST7920_BANNER_TEXT
-  #define ST7920_BANNER_TEXT "LCD12864 Simulator"
-#endif
-
 ST7920_PIXEL       st7920 = {ST7920_XSTART, ST7920_YSTART, 0};
 ST7920_CTRL_STATUS status = ST7920_IDLE;
 
@@ -132,9 +128,11 @@ void menuST7920(void)
   GUI_Clear(infoSettings.bg_color);
   GUI_SetColor(infoSettings.font_color);
   GUI_SetBkColor(infoSettings.bg_color);
-  #ifndef ST7920_FULLSCREEN
+  
+  #if defined(ST7920_BANNER_TEXT) && !(defined(ST7920_FULLSCREEN))
     GUI_DispStringInRect(0, 0, LCD_WIDTH, SIMULATOR_YSTART, (u8*)ST7920_BANNER_TEXT, 0);
   #endif
+  
   SPI_Slave();
   SPI_Slave_CS_Config();
   

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -75,7 +75,7 @@
 // Show BTT bootscreen when starting up
 #define SHOW_BTT_BOOTSCREEN
 
-// Text displayed at the top of the LCD in 12864 mode
+// Text displayed at the top of the LCD in 12864 mode. Comment out to disable.
 #define ST7920_BANNER_TEXT "LCD12864 Simulator"
 
 // Make the simulator run fullscreen, Not recommended for TFT24

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -69,12 +69,21 @@ u32 select_mode [SELECTMODE]={
 #if LCD_ENCODER_SUPPORT
 void menuMode(void)
 {  
-  RADIO modeRadio = {
-    {(u8*)"Serial Touch Screen", (u8*)ST7920_BANNER_TEXT, (u8*)"LCD2004 Simulator"},
-    SIMULATOR_XSTART, SIMULATOR_YSTART,
-    BYTE_HEIGHT*2, 2,
-    0
-  };
+  #if defined(ST7920_BANNER_TEXT)
+    RADIO modeRadio = {
+      {(u8*)"Serial Touch Screen", (u8*)ST7920_BANNER_TEXT, (u8*)"LCD2004 Simulator"},
+      SIMULATOR_XSTART, SIMULATOR_YSTART,
+      BYTE_HEIGHT*2, 2,
+      0
+      };
+  #else
+    RADIO modeRadio = {
+      {(u8*)"Serial Touch Screen", (u8*)"12864 Simulator", (u8*)"LCD2004 Simulator"},
+      SIMULATOR_XSTART, SIMULATOR_YSTART,
+      BYTE_HEIGHT*2, 2,
+      0
+      };
+  #endif
   
   MKEY_VALUES  key_num = MKEY_IDLE;
   MODEselect = 1;


### PR DESCRIPTION
### Description

You can now simply comment out `ST7920_BANNER_TEXT` to disable the "LCD12864 Simulator" text at the top of 12864 mode.

### Benefits

It's now easier to disable the "LCD12864 Simulator" text.