### PR TITLE
Override default LD Script using LINKFLAGS build scope

### DIFF
--- a/buildroot/boards/STM32F103VC.json
+++ b/buildroot/boards/STM32F103VC.json
@@ -14,7 +14,6 @@
         "0x0004"
       ]
     ],
-    "ldscript": "BIGTREE_TFT35_V1.ld",
     "mcu": "stm32f103vct6",
     "variant": "stm32f1"
   },

--- a/buildroot/boards/STM32F105RC.json
+++ b/buildroot/boards/STM32F105RC.json
@@ -14,7 +14,6 @@
         "0x0004"
       ]
     ],
-    "ldscript": "BIGTREE_TFT35_V1.ld",
     "mcu": "stm32f105rct6",
     "variant": "stm32f1"
   },

--- a/buildroot/scripts/stm32f10x_0x3000_iap.py
+++ b/buildroot/scripts/stm32f10x_0x3000_iap.py
@@ -1,4 +1,12 @@
+import os
+
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08003000
-env.Replace(LDSCRIPT_PATH="buildroot/ldscripts/stm32f10x_0x3000_iap.ld")
+custom_ld_script = os.path.abspath("buildroot/ldscripts/stm32f10x_0x3000_iap.ld")
+
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script

--- a/buildroot/scripts/stm32f10x_0x6000_iap.py
+++ b/buildroot/scripts/stm32f10x_0x6000_iap.py
@@ -1,4 +1,12 @@
+import os
+
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08006000
-env.Replace(LDSCRIPT_PATH="buildroot/ldscripts/stm32f10x_0x6000_iap.ld")
+custom_ld_script = os.path.abspath("buildroot/ldscripts/stm32f10x_0x6000_iap.ld")
+
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script

--- a/buildroot/scripts/stm32f2xx_0x8000_iap.py
+++ b/buildroot/scripts/stm32f2xx_0x8000_iap.py
@@ -1,4 +1,12 @@
+import os
+
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08008000
-env.Replace(LDSCRIPT_PATH="buildroot/ldscripts/stm32f2xx_0x8000_iap.ld")
+custom_ld_script = os.path.abspath("buildroot/ldscripts/stm32f2xx_0x8000_iap.ld")
+
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script


### PR DESCRIPTION
Resolves https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/126

This is a temporary low-level solution that works with previous PIO Core versions and will work with the future. However, there is a better way to do this via `board_build.ldscript`. There is a bug in ST STM32 dev/platform which overrides user custom LD Script declared in `board_build.ldscript` way. We will fix it soon. So, you can simplify your configuration later.

Sorry for the issue.