### PR TITLE
Disable "LCD12864 Simulator" Banner by Default

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -18,8 +18,8 @@
 #define ST7920_BKCOLOR BLACK
 #define ST7920_FNCOLOR GREEN
 
-// Text displayed at the top of the LCD in Marlin Mode. Comment out to disable.
-#define ST7920_BANNER_TEXT "LCD12864 Simulator"
+// Text displayed at the top of the LCD in Marlin Mode.
+//#define ST7920_BANNER_TEXT "LCD12864 Simulator"
 
 // Run Marlin Mode fullscreen. Not recommended for TFT24.
 //#define ST7920_FULLSCREEN


### PR DESCRIPTION
### Description

We don't really need to have the "LCD12864 Simulator" banner enabled by default since users will know which mode they are in.

Uncomment `ST7920_BANNER_TEXT` to enable & you can customize text as before.

### Benefits

Cleaner default UI.