### PR TITLE
improve Serial Hal, fix random stop in printing when enable 'keep alive' in Marlin

### DIFF
--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -5,11 +5,18 @@ REQUEST_COMMAND_INFO requestCommandInfo;
 
 static void resetRequestCommandInfo(void) 
 {
+  requestCommandInfo.cmd_rev_buf = malloc(CMD_MAX_REV);
+  while(!requestCommandInfo.cmd_rev_buf); // malloc failed
   memset(requestCommandInfo.cmd_rev_buf,0,CMD_MAX_REV);
   requestCommandInfo.inWaitResponse = true;
   requestCommandInfo.inResponse = false;
   requestCommandInfo.done = false;
   requestCommandInfo.inError = false;
+}
+
+static void clearRequestCommandInfo(void) 
+{
+  free(requestCommandInfo.cmd_rev_buf);
 }
 
 /*
@@ -35,6 +42,7 @@ bool request_M21(void)
   {
     loopProcess();
   }
+  clearRequestCommandInfo();
   // Check reponse
   return !requestCommandInfo.inError;
 }
@@ -66,6 +74,7 @@ char *request_M20(void)
   {
     loopProcess();
   }
+  clearRequestCommandInfo();
   return requestCommandInfo.cmd_rev_buf;
 }
 
@@ -95,7 +104,9 @@ long request_M23(char *filename)
 
   // Find file size and report its.
   char *ptr;
-  return strtol(strstr(requestCommandInfo.cmd_rev_buf,"Size:")+5, &ptr, 10);
+  long size = strtol(strstr(requestCommandInfo.cmd_rev_buf,"Size:")+5, &ptr, 10);  
+  clearRequestCommandInfo();
+  return size;
 }
 
 /**

--- a/TFT/src/User/API/Gcode/gcode.h
+++ b/TFT/src/User/API/Gcode/gcode.h
@@ -14,7 +14,7 @@ typedef struct {
     bool inWaitResponse;            // true if waiting for start magic
     bool done;                      // true if command is executed and response is received
     bool inError;                   // true if error response
-    char cmd_rev_buf[CMD_MAX_REV]; // buffer where store the command response
+    char *cmd_rev_buf;              // buffer where store the command response
 } REQUEST_COMMAND_INFO;
 
 extern REQUEST_COMMAND_INFO requestCommandInfo;

--- a/TFT/src/User/API/Language/language_am.h
+++ b/TFT/src/User/API/Language/language_am.h
@@ -138,7 +138,7 @@
     #define AM_COOLDOWN             "Cool Down"
     #define AM_EMERGENCYSTOP        "EM. STOP"
     #define AM_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define AM_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define AM_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define AM_FORCE_SHUT_DOWN      "Force"
     #define AM_SHUTTING_DOWN        "Shutting down..."
 

--- a/TFT/src/User/API/Language/language_cz.h
+++ b/TFT/src/User/API/Language/language_cz.h
@@ -139,7 +139,7 @@
     #define CZ_COOLDOWN             "Cool Down"
     #define CZ_EMERGENCYSTOP        "EM. STOP"
     #define CZ_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define CZ_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define CZ_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define CZ_FORCE_SHUT_DOWN      "Force"
     #define CZ_SHUTTING_DOWN        "Shutting down..."
 

--- a/TFT/src/User/API/Language/language_de.h
+++ b/TFT/src/User/API/Language/language_de.h
@@ -138,7 +138,7 @@
     #define DE_COOLDOWN             "Cool Down"
     #define DE_EMERGENCYSTOP        "EM. STOP"
     #define DE_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define DE_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define DE_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define DE_FORCE_SHUT_DOWN      "Force"
     #define DE_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_en.h
+++ b/TFT/src/User/API/Language/language_en.h
@@ -138,7 +138,7 @@
     #define EN_COOLDOWN             "Cool Down"
     #define EN_EMERGENCYSTOP        "EM. STOP"
     #define EN_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define EN_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define EN_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define EN_FORCE_SHUT_DOWN      "Force"
     #define EN_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_es.h
+++ b/TFT/src/User/API/Language/language_es.h
@@ -138,7 +138,7 @@
     #define ES_COOLDOWN             "Cool Down"
     #define ES_EMERGENCYSTOP        "EM. STOP"
     #define ES_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define ES_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define ES_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define ES_FORCE_SHUT_DOWN      "Force"
     #define ES_SHUTTING_DOWN        "Shutting down..."
 

--- a/TFT/src/User/API/Language/language_fr.h
+++ b/TFT/src/User/API/Language/language_fr.h
@@ -138,7 +138,7 @@
     #define FR_COOLDOWN             "Refroidissement"
     #define FR_EMERGENCYSTOP        "Arrêt d'Urgence"
     #define FR_TOUCH_TO_EXIT        "Toucher n'importe où pour sortir"
-    #define FR_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define FR_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define FR_FORCE_SHUT_DOWN      "Force"
     #define FR_SHUTTING_DOWN        "Shutting down..."
 #endif

--- a/TFT/src/User/API/Language/language_it.h
+++ b/TFT/src/User/API/Language/language_it.h
@@ -138,7 +138,7 @@
     #define IT_COOLDOWN             "Blocco Freddo"
     #define IT_EMERGENCYSTOP        "EM. STOP"
     #define IT_TOUCH_TO_EXIT        "Premi ovunque per uscire"
-    #define IT_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define IT_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define IT_FORCE_SHUT_DOWN      "Force"
     #define IT_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_jp.h
+++ b/TFT/src/User/API/Language/language_jp.h
@@ -138,7 +138,7 @@
     #define JP_COOLDOWN             "Cool Down"
     #define JP_EMERGENCYSTOP        "EM. STOP"
     #define JP_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define JP_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define JP_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define JP_FORCE_SHUT_DOWN      "Force"
     #define JP_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_pt.h
+++ b/TFT/src/User/API/Language/language_pt.h
@@ -138,7 +138,7 @@
     #define PT_COOLDOWN             "Arrefecer"
     #define PT_EMERGENCYSTOP        "EMERGENCIA STOP"
     #define PT_TOUCH_TO_EXIT        "Toque em qualquer lugar para sair"
-    #define PT_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define PT_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define PT_FORCE_SHUT_DOWN      "Force"
     #define PT_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_ru.h
+++ b/TFT/src/User/API/Language/language_ru.h
@@ -138,7 +138,7 @@
     #define RU_COOLDOWN             "Cool Down"
     #define RU_EMERGENCYSTOP        "EM. STOP"
     #define RU_TOUCH_TO_EXIT        "Touch anywhere to exit"
-    #define RU_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than"STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
+    #define RU_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
     #define RU_FORCE_SHUT_DOWN      "Force shut down"
     #define RU_SHUTTING_DOWN        "Shutting down..."
     

--- a/TFT/src/User/API/Language/language_ru.h
+++ b/TFT/src/User/API/Language/language_ru.h
@@ -139,7 +139,7 @@
     #define RU_EMERGENCYSTOP        "EM. STOP"
     #define RU_TOUCH_TO_EXIT        "Touch anywhere to exit"
     #define RU_WAIT_TEMP_SHUT_DOWN  "Wait for the temperature of hotend to be lower than "STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP)"℃" // Wait for the temperature of hotend to be lower than 50℃
-    #define RU_FORCE_SHUT_DOWN      "Force shut down"
+    #define RU_FORCE_SHUT_DOWN      "Force"
     #define RU_SHUTTING_DOWN        "Shutting down..."
     
 #endif

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -3,35 +3,38 @@
 
 
 QUEUE infoCmd;       //
-QUEUE infoCacheCmd;  //only heatHasWaiting() is false 
-                     //the cmd in this cache will move to infoCmd 
+QUEUE infoCacheCmd;  // Only when heatHasWaiting() is false the cmd in this cache will move to infoCmd queue.
 
 static u8 cmd_index=0;
 
-//
+// Is there a code character in the current gcode command.
 static bool cmd_seen(char code)
 {  
   for(cmd_index = 0; infoCmd.queue[infoCmd.index_r].gcode[cmd_index] != 0 && cmd_index < CMD_MAX_CHAR; cmd_index++)
   {
     if(infoCmd.queue[infoCmd.index_r].gcode[cmd_index] == code)
     {
-      cmd_index+=1;
+      cmd_index += 1;
       return true;
     }
   }
   return false;
 }
 
+// Get the int after 'code', Call after cmd_seen('code').
 static u32 cmd_value(void)
 {
-  return (strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index],NULL,10));
+  return (strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL, 10));
 }
 
+// Get the float after 'code', Call after cmd_seen('code').
 static float cmd_float(void)
 {
-  return (strtod(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index],NULL));
+  return (strtod(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL));
 }
 
+// Store gcode cmd to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar.
 bool storeCmd(const char * format,...)
 {
   QUEUE *pQueue = &infoCmd;
@@ -54,6 +57,8 @@ bool storeCmd(const char * format,...)
   return true;
 }
 
+// Store gcode cmd to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar,  waiting for available queue and store the command.
 void mustStoreCmd(const char * format,...)
 {
   QUEUE *pQueue = &infoCmd;
@@ -75,6 +80,8 @@ void mustStoreCmd(const char * format,...)
   pQueue->count++;
 }
 
+// Store from UART cmd(such as: ESP3D, OctoPrint, else TouchScreen) to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar.
 bool storeCmdFromUART(uint8_t port, const char * gcode)
 {
   QUEUE *pQueue = &infoCmd;
@@ -94,6 +101,8 @@ bool storeCmdFromUART(uint8_t port, const char * gcode)
   return true;
 }
 
+// Store gcode cmd to infoCacheCmd queue, this cmd will be move to infoCmd in getGcodeFromFile() -> moveCacheToCmd(),
+// this function is only for restore printing status after power failed.
 void mustStoreCacheCmd(const char * format,...)
 {
   QUEUE *pQueue = &infoCacheCmd;
@@ -114,6 +123,7 @@ void mustStoreCacheCmd(const char * format,...)
   pQueue->count++;
 }
 
+// Move gcode cmd from infoCacheCmd to infoCmd queue.
 bool moveCacheToCmd(void)
 {
   if(infoCmd.count >= CMD_MAX_LIST) return false;
@@ -125,6 +135,7 @@ bool moveCacheToCmd(void)
   return true;
 }
 
+// Clear all gcode cmd in infoCmd queue for abort printing.
 void clearCmdQueue(void)
 {
   infoCmd.count = infoCmd.index_w = infoCmd.index_r =0;  
@@ -132,6 +143,7 @@ void clearCmdQueue(void)
   heatSetUpdateWaiting(false);
 }
 
+// Parse and send gcode cmd in infoCmd.
 void sendQueueCmd(void)
 {
   if(infoHost.wait == true)    return;  

--- a/TFT/src/User/API/interfaceCmd.h
+++ b/TFT/src/User/API/interfaceCmd.h
@@ -16,13 +16,12 @@ typedef struct
 typedef struct 
 {
   GCODE   queue[CMD_MAX_LIST];
-  uint8_t index_r ; // Ring buffer read position
-  uint8_t index_w ; // Ring buffer write position
-//    u8      parsed ;  //
-  uint8_t count ;   // Count of commands in the queue  
+  uint8_t index_r; // Ring buffer read position
+  uint8_t index_w; // Ring buffer write position
+  uint8_t count;   // Count of commands in the queue  
 }QUEUE;
 
-extern QUEUE infoCmd ;
+extern QUEUE infoCmd;
 extern QUEUE infoCacheCmd;
 
 

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1,7 +1,7 @@
 #include "includes.h"
 #include "parseACK.h"
 
-char *ack_rev_buf = dma_mem_buf[SERIAL_PORT];
+char dmaL2Cache[ACK_MAX_SIZE];
 static u16 ack_index=0;
 static u8 ack_cur_src = SERIAL_PORT;
 int MODEselect;
@@ -19,9 +19,9 @@ void setCurrentAckSrc(uint8_t src)
 static char ack_seen(const char *str)
 {
   u16 i;	
-  for(ack_index=0; ack_index<ACK_MAX_SIZE && ack_rev_buf[ack_index]!=0; ack_index++)
+  for(ack_index=0; ack_index<ACK_MAX_SIZE && dmaL2Cache[ack_index]!=0; ack_index++)
   {
-    for(i=0; str[i]!=0 && ack_rev_buf[ack_index+i]!=0 && ack_rev_buf[ack_index+i]==str[i]; i++)
+    for(i=0; str[i]!=0 && dmaL2Cache[ack_index+i]!=0 && dmaL2Cache[ack_index+i]==str[i]; i++)
     {}
     if(str[i]==0)
     {
@@ -34,25 +34,25 @@ static char ack_seen(const char *str)
 static char ack_cmp(const char *str)
 {
   u16 i;
-  for(i=0; i<ACK_MAX_SIZE && str[i]!=0 && ack_rev_buf[i]!=0; i++)
+  for(i=0; i<ACK_MAX_SIZE && str[i]!=0 && dmaL2Cache[i]!=0; i++)
   {
-    if(str[i] != ack_rev_buf[i])
+    if(str[i] != dmaL2Cache[i])
     return false;
   }
-  if(ack_rev_buf[i] != 0) return false;
+  if(dmaL2Cache[i] != 0) return false;
   return true;
 }
 
 
 static float ack_value()
 {
-  return (strtod(&ack_rev_buf[ack_index], NULL));
+  return (strtod(&dmaL2Cache[ack_index], NULL));
 }
 
 // Read the value after the / if exists
 static float ack_second_value()
 {
-  char *secondValue = strchr(&ack_rev_buf[ack_index],'/');
+  char *secondValue = strchr(&dmaL2Cache[ack_index],'/');
   if(secondValue != NULL)
   {
     return (strtod(secondValue+1, NULL));
@@ -66,15 +66,27 @@ static float ack_second_value()
 void ackPopupInfo(const char *info)
 {
   if(infoMenu.menu[infoMenu.cur] == menuTerminal) return;
-  popupReminder((u8* )info, (u8 *)ack_rev_buf + ack_index);
+  popupReminder((u8* )info, (u8 *)dmaL2Cache + ack_index);
+}
+
+void syncL2CacheFromL1(uint8_t port)
+{
+  uint16_t i = 0;
+  for (i = 0; dmaL1Data[port].rIndex != dmaL1Data[port].wIndex; i++)
+  {
+    dmaL2Cache[i] = dmaL1Data[port].cache[dmaL1Data[port].rIndex];
+    dmaL1Data[port].rIndex = (dmaL1Data[port].rIndex + 1) % DMA_TRANS_LEN;
+  }
+  dmaL2Cache[i] = 0; // End character
 }
 
 void parseACK(void)
-{
-startParse:  
+{ 
   if(infoHost.rx_ok[SERIAL_PORT] != true) return; //not get response data
   
+  syncL2CacheFromL1(SERIAL_PORT);
   infoHost.rx_ok[SERIAL_PORT] = false;
+  
   if(infoHost.connected == false) //not connected to Marlin
   {
     if((!ack_seen("T:") && !ack_seen("T0:")) || !ack_seen("ok"))  goto parse_end;  //the first response should be such as "T:25/50 ok\n"
@@ -89,9 +101,9 @@ startParse:
   }
   if(requestCommandInfo.inResponse)
   {
-    if(strlen(requestCommandInfo.cmd_rev_buf)+strlen(ack_rev_buf) < CMD_MAX_REV)
+    if(strlen(requestCommandInfo.cmd_rev_buf)+strlen(dmaL2Cache) < CMD_MAX_REV)
     {
-      strcat(requestCommandInfo.cmd_rev_buf,ack_rev_buf);
+      strcat(requestCommandInfo.cmd_rev_buf, dmaL2Cache);
       
       if(ack_seen(requestCommandInfo.errorMagic ))
       {
@@ -146,7 +158,7 @@ startParse:
     }
     else if(ack_seen("Mean:"))
     {
-      popupReminder((u8* )"Repeatability Test", (u8 *)ack_rev_buf + ack_index-5);
+      popupReminder((u8* )"Repeatability Test", (u8 *)dmaL2Cache + ack_index-5);
       //popupReminder((u8* )"Standard Deviation", (u8 *)&infoCmd.queue[infoCmd.index_r].gcode[5]);
     }
     else if(ack_seen("Probe Offset"))
@@ -179,7 +191,7 @@ startParse:
       // Parsing printing data
       // Exampre: SD printing byte 123/12345
       char *ptr;
-      u32 position = strtol(strstr(ack_rev_buf,"byte ")+5, &ptr, 10); 
+      u32 position = strtol(strstr(dmaL2Cache, "byte ")+5, &ptr, 10); 
       setPrintCur(position);
 //      powerFailedCache(position);
     }    
@@ -192,21 +204,18 @@ startParse:
     {
       for(u8 i = 0; i < aCount(ignoreEcho); i++)
       {
-        if(strstr(ack_rev_buf, ignoreEcho[i])) goto parse_end;
+        if(strstr(dmaL2Cache, ignoreEcho[i])) goto parse_end;
       }
       ackPopupInfo(echomagic);
     }
   }
   
-parse_end:
-  if(infoHost.rx_ok[SERIAL_PORT] == true) goto startParse;  // receive new data in parseing, so need parse again
-    
+parse_end:    
   if(ack_cur_src != SERIAL_PORT)
   {
-    Serial_Puts(ack_cur_src, ack_rev_buf);
+    Serial_Puts(ack_cur_src, dmaL2Cache);
   }
-  sendGcodeTerminalCache(ack_rev_buf, TERMINAL_ACK);
-  Serial_DMAReEnable(SERIAL_PORT);
+  sendGcodeTerminalCache(dmaL2Cache, TERMINAL_ACK);
 }
 
 void parseRcvGcode(void)
@@ -218,8 +227,8 @@ void parseRcvGcode(void)
       if(i != SERIAL_PORT && infoHost.rx_ok[i] == true)
       {
         infoHost.rx_ok[i] = false;
-        storeCmdFromUART(i, dma_mem_buf[i]);
-        Serial_DMAReEnable(i);
+        syncL2CacheFromL1(i);
+        storeCmdFromUART(i, dmaL2Cache);
       }
     }
   #endif

--- a/TFT/src/User/API/parseACK.h
+++ b/TFT/src/User/API/parseACK.h
@@ -7,6 +7,7 @@
 static const char errormagic[]        = "Error:";
 static const char echomagic[]         = "echo:";
 static const char busymagic[]         = "busy:";
+static const char unknowmagic[]       = "Unknown command:";
 #ifdef ONBOARD_SD_SUPPORT 
 static const char bsdprintingmagic[]   = "SD printing byte";
 static const char bsdnoprintingmagic[] = "Not SD printing";
@@ -14,7 +15,6 @@ static const char bsdnoprintingmagic[] = "Not SD printing";
 
 
 #define ACK_MAX_SIZE 1024
-extern char *ack_rev_buf;
 extern int MODEselect;
 
 void setCurrentAckSrc(uint8_t src);

--- a/TFT/src/User/Hal/stm32f10x/Serial.c
+++ b/TFT/src/User/Hal/stm32f10x/Serial.c
@@ -1,10 +1,10 @@
 #include "Serial.h"
 #include "includes.h"
 
-//dma rx buffer
-char dma_mem_buf[_USART_CNT][DMA_TRANS_LEN];
+// dma rx buffer
+DMA_CIRCULAR_BUFFER dmaL1Data[_USART_CNT];
 
-//Config for USART Channel
+// Config for USART Channel
 typedef struct
 {
   USART_TypeDef *uart;
@@ -17,91 +17,92 @@ static const SERIAL_CFG Serial[_USART_CNT] = {
   {USART2, RCC_AHBPeriph_DMA1, DMA1_Channel6},
   {USART3, RCC_AHBPeriph_DMA1, DMA1_Channel3},
   {UART4,  RCC_AHBPeriph_DMA2, DMA2_Channel3},
-  //{UART5,  -1, -1}, //UART5 don't support DMA
+  //{UART5,  -1, -1}, // UART5 don't support DMA
 };
 
 void Serial_DMA_Config(uint8_t port)
 {
   const SERIAL_CFG * cfg = &Serial[port];
   
-  RCC_AHBPeriphClockCmd(cfg->dma_rcc, ENABLE);  //DMA RCC EN
+  RCC_AHBPeriphClockCmd(cfg->dma_rcc, ENABLE);  // DMA RCC EN
 
-  cfg->uart->CR3 |= 1<<6;  //DMA enable receiver
+  cfg->dma_chanel->CCR &= ~(1<<0); // DMA disable
+  cfg->uart->CR3 |= 1<<6;  // DMA enable receiver
   
   cfg->dma_chanel->CPAR = (u32)(&cfg->uart->DR);
-  cfg->dma_chanel->CMAR = (u32)(&dma_mem_buf[port]);
+  cfg->dma_chanel->CMAR = (u32)(dmaL1Data[port].cache);
   cfg->dma_chanel->CNDTR = DMA_TRANS_LEN;
   cfg->dma_chanel->CCR = 0X00000000;
-  cfg->dma_chanel->CCR |= 3<<12;   //Channel priority level
-  cfg->dma_chanel->CCR |= 1<<7;    //Memory increment mode
-  cfg->dma_chanel->CCR |= 1<<0;    //DMA EN
+  cfg->dma_chanel->CCR |= 3<<12;   // Channel priority level
+  cfg->dma_chanel->CCR |= 1<<7;    // Memory increment mode
+  cfg->dma_chanel->CCR |= 1<<5;    // Circular mode enabled
+  cfg->dma_chanel->CCR |= 1<<0;    // DMA EN
 }
 
-void Serial_Config(u32 baud)
+void Serial_Config(uint8_t port, u32 baud)
 {
-  USART_Config(SERIAL_PORT, baud, USART_IT_IDLE);  //IDLE interrupt
-  Serial_DMA_Config(SERIAL_PORT);
+  dmaL1Data[port].rIndex = dmaL1Data[port].wIndex = 0;
+  dmaL1Data[port].cache = malloc(DMA_TRANS_LEN);
+  while(!dmaL1Data[port].cache); // malloc failed
+  USART_Config(port, baud, USART_IT_IDLE);  //IDLE interrupt
+  Serial_DMA_Config(port);
+}
+
+void Serial_DeConfig(uint8_t port)
+{
+  free(dmaL1Data[port].cache);
+  dmaL1Data[port].cache = NULL;
+  Serial[port].dma_chanel->CCR &= ~(1<<0); // Disable DMA
+  USART_DeConfig(port);
+}
+
+void Serial_Init(u32 baud)
+{
+  Serial_Config(SERIAL_PORT, baud);
   
   #ifdef SERIAL_PORT_2
-    USART_Config(SERIAL_PORT_2, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_2);
+    Serial_Config(SERIAL_PORT_2, baud);
   #endif
   
   #ifdef SERIAL_PORT_3
-    USART_Config(SERIAL_PORT_3, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_3);
+    Serial_Config(SERIAL_PORT_3, baud);
   #endif
   
   #ifdef SERIAL_PORT_4
-    USART_Config(SERIAL_PORT_4, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_4);
+    Serial_Config(SERIAL_PORT_4, baud);
   #endif
 }
 
-void Serial_DeConfig(void)
+void Serial_DeInit(void)
 {
-  USART_DeConfig(SERIAL_PORT);
+  Serial_DeConfig(SERIAL_PORT);
   
   #ifdef SERIAL_PORT_2
-    USART_DeConfig(SERIAL_PORT_2);
+    Serial_DeConfig(SERIAL_PORT_2);
   #endif
   
   #ifdef SERIAL_PORT_3
-    USART_DeConfig(SERIAL_PORT_3);
+    Serial_DeConfig(SERIAL_PORT_3);
   #endif
   
   #ifdef SERIAL_PORT_4
-    USART_DeConfig(SERIAL_PORT_4);
+    Serial_DeConfig(SERIAL_PORT_4);
   #endif
-}
-
-/*
-
-*/
-void Serial_DMAReEnable(uint8_t port)
-{
-  memset(dma_mem_buf[port], 0, DMA_TRANS_LEN);
-  Serial[port].dma_chanel->CCR &= ~(1<<0);
-  Serial[port].dma_chanel->CNDTR = DMA_TRANS_LEN;  
-  Serial[port].dma_chanel->CCR |= 1<<0;    //DMA			
 }
 
 void USART_IRQHandler(uint8_t port)
 {
-  u16 rx_len=0;
-
   if((Serial[port].uart->SR & (1<<4))!=0)
   {
-    Serial[port].uart->SR = ~(1<<4);
+    Serial[port].uart->SR;
     Serial[port].uart->DR;
 
-    rx_len = DMA_TRANS_LEN - Serial[port].dma_chanel->CNDTR;
-
-    if(dma_mem_buf[port][rx_len-1]=='\n' || (rx_len > DMA_TRANS_LEN - 5))  //receive completed or overflow buffer
+    dmaL1Data[port].wIndex = DMA_TRANS_LEN - Serial[port].dma_chanel->CNDTR;
+    uint16_t wIndex = (dmaL1Data[port].wIndex == 0) ? DMA_TRANS_LEN : dmaL1Data[port].wIndex;
+    if(dmaL1Data[port].cache[wIndex-1] == '\n')  // Receive completed
     {
-      dma_mem_buf[port][rx_len] = 0; //end character
-      infoHost.rx_ok[port]=true;
-    }    
+      infoHost.rx_ok[port] = true;
+    }
   }
 }
 

--- a/TFT/src/User/Hal/stm32f10x/Serial.h
+++ b/TFT/src/User/Hal/stm32f10x/Serial.h
@@ -5,13 +5,19 @@
 #include "parseACK.h"
 #include "usart.h"
 
-#define DMA_TRANS_LEN  ACK_MAX_SIZE
-extern char dma_mem_buf[_USART_CNT][DMA_TRANS_LEN];
+typedef struct
+{
+  char *cache;
+  uint16_t wIndex;
+  uint16_t rIndex;
+}DMA_CIRCULAR_BUFFER;
 
-void Serial_DMAReEnable(uint8_t port);
-    
-void Serial_Config(u32 baud);
-void Serial_DeConfig(void);
+#define DMA_TRANS_LEN  ACK_MAX_SIZE
+
+extern DMA_CIRCULAR_BUFFER dmaL1Data[_USART_CNT];
+  
+void Serial_Init(u32 baud);
+void Serial_DeInit(void);
 void Serial_Puts(uint8_t port, char *s);
 
 #endif 

--- a/TFT/src/User/Hal/stm32f10x/spi_slave.c
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave.c
@@ -1,6 +1,7 @@
 #include "spi_slave.h"
 #include "spi.h"
 #include "GPIO_Init.h"
+#include "stdlib.h"
 
 #ifdef ST7920_SPI
 //TODO:
@@ -22,30 +23,32 @@ SPI_QUEUE SPISlave;
 
 void SPI_ReEnable(u8 mode)
 {
-  ST7920_SPI_NUM->CR1 = (0<<15)  //0:双线双向 1:单线双向
-                      | (0<<14)  //单线双向时使用（0:只收 1:只发）
-                      | (0<<13)  //1:启用硬件CRC
-                      | (0<<12)  //0:下一个发送的值来自发送缓冲区 1:下一个发送的值来自发送CRC寄存器。
-                      | (0<<11)  //0:8位数据帧 1:16位数据帧
-                      | (1<<10)  //0:全双工 1:只接收
-                      | (1<<9)   //0:硬件NSS 1:软件NSS
-                      | (0<<8)   //SSM位为’1’时有意义。它决定了NSS上的电平
-                      | (0<<7)   //0:MSB 1:LSB
-                      | (7<<3)   //bit3-5   000： fPCLK/2 001： fPCLK/4 010： fPCLK/8 011： fPCLK/16
-                                 //         100： fPCLK/32 101： fPCLK/64 110： fPCLK/128 111： fPCLK/256
-                      | (0<<2)   //0:从设备 1:主设备
-                      | (mode<<1)   //CPOL
-                      | (mode<<0);  //CPHA
+  ST7920_SPI_NUM->CR1 = (0<<15)  // 0:2-line 1: 1-line
+                      | (0<<14)  // in bidirectional mode 0:read only 1: read/write
+                      | (0<<13)  // 0:disable CRC 1:enable CRC
+                      | (0<<12)  // 0:Data phase (no CRC phase) 1:Next transfer is CRC (CRC phase)
+                      | (0<<11)  // 0:8-bit data frame 1:16-bit data frame
+                      | (1<<10)  // 0:Full duplex 1:Receive-only
+                      | (1<<9)   // 0:enable NSS 1:disable NSS (Software slave management)
+                      | (0<<8)   // This bit has an effect only when the SSM bit is set. The value of this bit is forced onto the NSS pin and the IO value of the NSS pin is ignored
+                      | (0<<7)   // 0:MSB 1:LSB
+                      | (7<<3)   // bit3-5   000:fPCLK/2    001:fPCLK/4    010:fPCLK/8     011:fPCLK/16
+                                 //          100:fPCLK/32   101:fPCLK/64   110:fPCLK/128   111:fPCLK/256
+                      | (0<<2)   // 0:Slave 1:Master
+                      | (mode<<1)   // CPOL
+                      | (mode<<0);  // CPHA
             
-  ST7920_SPI_NUM->CR2 |= 1<<6;  //接收中断使能 SPI_I2S_IT_RXNE
+  ST7920_SPI_NUM->CR2 |= 1<<6; // RX buffer not empty interrupt enable SPI_I2S_IT_RXNE
 }
 
 void SPI_Slave(void) 
 {
   NVIC_InitTypeDef   NVIC_InitStructure;
 
+  SPISlave.data = malloc(SPI_SLAVE_MAX);
+  while(!SPISlave.data); // malloc failed
   SPI_GPIO_Init(ST7920_SPI);  
-  GPIO_InitSet(PB12, MGPIO_MODE_IPU, 0);  //CS
+  GPIO_InitSet(PB12, MGPIO_MODE_IPU, 0);  // CS
   
   NVIC_InitStructure.NVIC_IRQChannel = SPI2_IRQn; 
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1; 
@@ -70,6 +73,8 @@ void SPI_SlaveDeInit(void)
   
   RCC_APB1PeriphResetCmd(RCC_APB1Periph_SPI2, ENABLE); 
   RCC_APB1PeriphResetCmd(RCC_APB1Periph_SPI2, DISABLE);  
+  free(SPISlave.data);
+  SPISlave.data = NULL;
 }
 
 

--- a/TFT/src/User/Hal/stm32f10x/spi_slave.h
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave.h
@@ -7,7 +7,7 @@
 
 typedef struct
 {
-  u8  data[SPI_SLAVE_MAX];
+  u8  *data;
   u16 rIndex;
   u16 wIndex;
 }SPI_QUEUE;

--- a/TFT/src/User/Hal/stm32f2xx/Serial.c
+++ b/TFT/src/User/Hal/stm32f2xx/Serial.c
@@ -1,11 +1,11 @@
 #include "Serial.h"
 #include "includes.h"
 
-//dma rx buffer
-char dma_mem_buf[_USART_CNT][DMA_TRANS_LEN];
+// dma rx buffer
+DMA_CIRCULAR_BUFFER dmaL1Data[_USART_CNT];
 
 
-//Config for USART Channel
+// Config for USART Channel
 //USART1 RX DMA2 Channel4 Steam2/5
 //USART2 RX DMA1 Channel4 Steam5
 //USART3 RX DMA1 Channel4 Steam1
@@ -13,7 +13,7 @@ char dma_mem_buf[_USART_CNT][DMA_TRANS_LEN];
 //UART5  RX DMA1 Channel4 Steam0
 //USART6 RX DMA2 Channel5 Steam1/2
 
-//Config for USART Channel
+// Config for USART Channel
 typedef struct
 {
   USART_TypeDef *uart;
@@ -35,60 +35,76 @@ void Serial_DMA_Config(uint8_t port)
 {
   const SERIAL_CFG * cfg = &Serial[port];
   
-  RCC_AHB1PeriphClockCmd(cfg->dma_rcc, ENABLE);  //DMA RCC EN
+  RCC_AHB1PeriphClockCmd(cfg->dma_rcc, ENABLE);  // DMA RCC EN
 
-  cfg->uart->CR3 |= 1<<6;  //DMA enable receiver  
+  cfg->dma_stream->CR &= ~(1<<0); // Disable DMA
+  Serial_DMAClearFlag(port);
+  cfg->uart->CR3 |= 1<<6;  // DMA enable receiver  
   
   cfg->dma_stream->PAR = (u32)(&cfg->uart->DR);
-  cfg->dma_stream->M0AR = (u32)(&dma_mem_buf[port]);
+  cfg->dma_stream->M0AR = (u32)(dmaL1Data[port].cache);
   cfg->dma_stream->NDTR = DMA_TRANS_LEN;
   
   cfg->dma_stream->CR = cfg->dma_channel << 25;
   cfg->dma_stream->CR |= 3<<16;  // Priority level: Very high
-  cfg->dma_stream->CR |= 0<<13;  //Memory data size: 8
-  cfg->dma_stream->CR |= 0<<11;  //Peripheral data size: 8
-  cfg->dma_stream->CR |= 1<<10;  //Memory increment mode
-  cfg->dma_stream->CR |= 0<<9;   //Peripheral not increment mode
-  cfg->dma_stream->CR |= 0<<6;   //Data transfer direction: Peripheral-to-memory
-  cfg->dma_stream->CR |= 1<<0;   //enable DMA
-  Serial_DMAReEnable(port);
+  cfg->dma_stream->CR |= 0<<13;  // Memory data size: 8
+  cfg->dma_stream->CR |= 0<<11;  // Peripheral data size: 8
+  cfg->dma_stream->CR |= 1<<10;  // Memory increment mode
+  cfg->dma_stream->CR |= 0<<9;   // Peripheral not increment mode
+  cfg->dma_stream->CR |= 1<<8;   // Circular mode enabled
+  cfg->dma_stream->CR |= 0<<6;   // Data transfer direction: Peripheral-to-memory
+  cfg->dma_stream->CR |= 1<<0;   // Enable DMA
 }
 
-void Serial_Config(u32 baud)
+void Serial_Config(uint8_t port, u32 baud)
 {
-  USART_Config(SERIAL_PORT, baud, USART_IT_IDLE);  //IDLE interrupt
-  Serial_DMA_Config(SERIAL_PORT);
+  dmaL1Data[port].rIndex = dmaL1Data[port].wIndex = 0;
+  dmaL1Data[port].cache = malloc(DMA_TRANS_LEN);
+  while(!dmaL1Data[port].cache); // malloc failed
+  USART_Config(port, baud, USART_IT_IDLE);  // IDLE interrupt
+  Serial_DMA_Config(port);
+}
+
+void Serial_DeConfig(uint8_t port)
+{
+  free(dmaL1Data[port].cache);
+  dmaL1Data[port].cache = NULL;
+  Serial[port].dma_stream->CR &= ~(1<<0); // Disable DMA
+  Serial_DMAClearFlag(port);
+  USART_DeConfig(port);
+}
+
+void Serial_Init(u32 baud)
+{
+  Serial_Config(SERIAL_PORT, baud);
   
   #ifdef SERIAL_PORT_2
-    USART_Config(SERIAL_PORT_2, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_2);
+    Serial_Config(SERIAL_PORT_2, baud);
   #endif
   
   #ifdef SERIAL_PORT_3
-    USART_Config(SERIAL_PORT_3, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_3);
+    Serial_Config(SERIAL_PORT_3, baud);
   #endif
   
   #ifdef SERIAL_PORT_4
-    USART_Config(SERIAL_PORT_4, baud, USART_IT_IDLE);  //IDLE interrupt
-    Serial_DMA_Config(SERIAL_PORT_4);
+    Serial_Config(SERIAL_PORT_4, baud);
   #endif
 }
 
-void Serial_DeConfig(void)
+void Serial_DeInit(void)
 {
-  USART_DeConfig(SERIAL_PORT);
+  Serial_DeConfig(SERIAL_PORT);
   
   #ifdef SERIAL_PORT_2
-    USART_DeConfig(SERIAL_PORT_2);
+    Serial_DeConfig(SERIAL_PORT_2);
   #endif
   
   #ifdef SERIAL_PORT_3
-    USART_DeConfig(SERIAL_PORT_3);
+    Serial_DeConfig(SERIAL_PORT_3);
   #endif
   
   #ifdef SERIAL_PORT_4
-    USART_DeConfig(SERIAL_PORT_4);
+    Serial_DeConfig(SERIAL_PORT_4);
   #endif
 }
 
@@ -96,39 +112,28 @@ void Serial_DMAClearFlag(uint8_t port)
 {
   switch(port)
   {
-    case _USART1: DMA2->LIFCR = (0x3F << 16); break;  //DMA2_Stream2 low  bits:16-21
-    case _USART2: DMA1->HIFCR = (0xFC << 4);  break;  //DMA1_Stream5 high bits: 6-11
-    case _USART3: DMA1->LIFCR = (0xFC << 4);  break;  //DMA1_Stream1 low  bits: 6-11
-    case _UART4:  DMA1->LIFCR = (0x3F << 16); break;  //DMA1_Stream2 low  bits:16-21
-    case _UART5:  DMA1->LIFCR = (0x3F << 0);  break;  //DMA1_Stream0 low  bits: 0-5
-    case _USART6: DMA2->LIFCR = (0xFC << 4);  break;  //DMA2_Stream1 low  bits: 6-11
+    case _USART1: DMA2->LIFCR = (0x3F << 16); break;  // DMA2_Stream2 low  bits:16-21
+    case _USART2: DMA1->HIFCR = (0xFC << 4);  break;  // DMA1_Stream5 high bits: 6-11
+    case _USART3: DMA1->LIFCR = (0xFC << 4);  break;  // DMA1_Stream1 low  bits: 6-11
+    case _UART4:  DMA1->LIFCR = (0x3F << 16); break;  // DMA1_Stream2 low  bits:16-21
+    case _UART5:  DMA1->LIFCR = (0x3F << 0);  break;  // DMA1_Stream0 low  bits: 0-5
+    case _USART6: DMA2->LIFCR = (0xFC << 4);  break;  // DMA2_Stream1 low  bits: 6-11
   }
 }
 
-void Serial_DMAReEnable(uint8_t port)
-{
-  memset(dma_mem_buf,0,DMA_TRANS_LEN);
-  Serial[port].dma_stream->CR &= ~(1<<0);
-  Serial[port].dma_stream->NDTR = DMA_TRANS_LEN;  
-  Serial_DMAClearFlag(port);  //clear ISR for rx complete
-  Serial[port].dma_stream->CR |= 1<<0;  //DMA			
-}
 
 void USART_IRQHandler(uint8_t port)
 {
-  u16 rx_len=0;
-
   if((Serial[port].uart->SR & (1<<4))!=0)
   {
-    Serial[port].uart->SR = ~(1<<4);
+    Serial[port].uart->SR;
     Serial[port].uart->DR;
 
-    rx_len = DMA_TRANS_LEN - Serial[port].dma_stream->NDTR;
-
-    if(dma_mem_buf[port][rx_len-1]=='\n' || (rx_len > DMA_TRANS_LEN - 5))  //receive completed or overflow buffer
+    dmaL1Data[port].wIndex = DMA_TRANS_LEN - Serial[port].dma_stream->NDTR;
+    uint16_t wIndex = (dmaL1Data[port].wIndex == 0) ? DMA_TRANS_LEN : dmaL1Data[port].wIndex;
+    if(dmaL1Data[port].cache[wIndex-1] == '\n')  // Receive completed
     {
-      dma_mem_buf[port][rx_len] = 0; //end character
-      infoHost.rx_ok[port]=true;
+      infoHost.rx_ok[port] = true;
     }
   }
 }

--- a/TFT/src/User/Hal/stm32f2xx/Serial.h
+++ b/TFT/src/User/Hal/stm32f2xx/Serial.h
@@ -4,13 +4,20 @@
 #include "parseACK.h"
 #include "usart.h"
 
-#define DMA_TRANS_LEN  ACK_MAX_SIZE
-extern char dma_mem_buf[_USART_CNT][DMA_TRANS_LEN];
+typedef struct
+{
+  char *cache;
+  uint16_t wIndex;
+  uint16_t rIndex;
+}DMA_CIRCULAR_BUFFER;
 
-void Serial_DMAReEnable(uint8_t port);
-    
-void Serial_Config(u32 baud);
-void Serial_DeConfig(void);
+#define DMA_TRANS_LEN  ACK_MAX_SIZE
+
+extern DMA_CIRCULAR_BUFFER dmaL1Data[_USART_CNT];
+
+void Serial_DMAClearFlag(uint8_t port);
+void Serial_Init(u32 baud);
+void Serial_DeInit(void);
 void Serial_Puts(uint8_t port, char *s);
 
 #endif 

--- a/TFT/src/User/Hal/stm32f2xx/spi_slave.c
+++ b/TFT/src/User/Hal/stm32f2xx/spi_slave.c
@@ -1,6 +1,7 @@
 #include "spi_slave.h"
 #include "spi.h"
 #include "GPIO_Init.h"
+#include "stdlib.h"
 
 //TODO:
 //now support SPI2 and PB12 CS only
@@ -21,30 +22,32 @@ SPI_QUEUE SPISlave;
 
 void SPI_ReEnable(u8 mode)
 {
-  ST7920_SPI_NUM->CR1 = (0<<15)  //0:双线双向 1:单线双向
-                      | (0<<14)  //单线双向时使用（0:只收 1:只发）
-                      | (0<<13)  //1:启用硬件CRC
-                      | (0<<12)  //0:下一个发送的值来自发送缓冲区 1:下一个发送的值来自发送CRC寄存器。
-                      | (0<<11)  //0:8位数据帧 1:16位数据帧
-                      | (1<<10)  //0:全双工 1:只接收
-                      | (1<<9)   //0:硬件NSS 1:软件NSS
-                      | (0<<8)   //SSM位为’1’时有意义。它决定了NSS上的电平
-                      | (0<<7)   //0:MSB 1:LSB
-                      | (7<<3)   //bit3-5   000： fPCLK/2 001： fPCLK/4 010： fPCLK/8 011： fPCLK/16
-                                 //         100： fPCLK/32 101： fPCLK/64 110： fPCLK/128 111： fPCLK/256
-                      | (0<<2)   //0:从设备 1:主设备
-                      | (mode<<1)   //CPOL
-                      | (mode<<0);  //CPHA
+  ST7920_SPI_NUM->CR1 = (0<<15)  // 0:2-line 1: 1-line
+                      | (0<<14)  // in bidirectional mode 0:read only 1: read/write
+                      | (0<<13)  // 0:disable CRC 1:enable CRC
+                      | (0<<12)  // 0:Data phase (no CRC phase) 1:Next transfer is CRC (CRC phase)
+                      | (0<<11)  // 0:8-bit data frame 1:16-bit data frame
+                      | (1<<10)  // 0:Full duplex 1:Receive-only
+                      | (1<<9)   // 0:enable NSS 1:disable NSS (Software slave management)
+                      | (0<<8)   // This bit has an effect only when the SSM bit is set. The value of this bit is forced onto the NSS pin and the IO value of the NSS pin is ignored
+                      | (0<<7)   // 0:MSB 1:LSB
+                      | (7<<3)   // bit3-5   000:fPCLK/2    001:fPCLK/4    010:fPCLK/8     011:fPCLK/16
+                                 //          100:fPCLK/32   101:fPCLK/64   110:fPCLK/128   111:fPCLK/256
+                      | (0<<2)   // 0:Slave 1:Master
+                      | (mode<<1)   // CPOL
+                      | (mode<<0);  // CPHA
             
-  ST7920_SPI_NUM->CR2 |= 1<<6;  //接收中断使能 SPI_I2S_IT_RXNE
+  ST7920_SPI_NUM->CR2 |= 1<<6; // RX buffer not empty interrupt enable SPI_I2S_IT_RXNE
 }
 
 void SPI_Slave(void) 
 {
   NVIC_InitTypeDef   NVIC_InitStructure;
 
+  SPISlave.data = malloc(SPI_SLAVE_MAX);
+  while(!SPISlave.data); // malloc failed
   SPI_GPIO_Init(ST7920_SPI);  
-  GPIO_InitSet(PB12, MGPIO_MODE_IPU, 0);  //CS
+  GPIO_InitSet(PB12, MGPIO_MODE_IPU, 0);  // CS
   
   NVIC_InitStructure.NVIC_IRQChannel = SPI2_IRQn; 
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1; 
@@ -57,7 +60,7 @@ void SPI_Slave(void)
 }
 
 void SPI_SlaveDeInit(void)
-{  
+{
   NVIC_InitTypeDef   NVIC_InitStructure;
   NVIC_InitStructure.NVIC_IRQChannel = SPI2_IRQn; 
   NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
@@ -67,6 +70,8 @@ void SPI_SlaveDeInit(void)
   NVIC_Init(&NVIC_InitStructure);
   
   SPI_I2S_DeInit(ST7920_SPI_NUM);
+  free(SPISlave.data);
+  SPISlave.data = NULL;
 }
 
 void SPI2_IRQHandler(void) 

--- a/TFT/src/User/Hal/stm32f2xx/spi_slave.h
+++ b/TFT/src/User/Hal/stm32f2xx/spi_slave.h
@@ -7,7 +7,7 @@
 
 typedef struct
 {
-  u8  data[SPI_SLAVE_MAX];
+  u8  *data;
   u16 rIndex;
   u16 wIndex;
 }SPI_QUEUE;

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -10,7 +10,7 @@ void Serial_ReSourceDeInit(void)
 #ifdef BUZZER_PIN
   Buzzer_DeConfig();
 #endif
-  Serial_DeConfig();
+  Serial_DeInit();
 }
 
 void Serial_ReSourceInit(void)
@@ -18,7 +18,7 @@ void Serial_ReSourceInit(void)
 #ifdef BUZZER_PIN
   Buzzer_Config();
 #endif
-  Serial_Config(infoSettings.baudrate);
+  Serial_Init(infoSettings.baudrate);
   
 #ifdef U_DISK_SUPPROT
   USBH_Init(&USB_OTG_Core, USB_OTG_FS_CORE_ID, &USB_Host, &USBH_MSC_cb, &USR_cb);
@@ -101,6 +101,7 @@ void menuMode(void)
   {
     lcd_frame_display(rect_of_mode[i].x0,rect_of_mode[i].y0-BYTE_HEIGHT,selecticonw,selecticonw,ICON_ADDR(select_mode[i]));
   }
+  TSC_ReDrawIcon = NULL; // Disable icon redraw callback function
   
   selectmode(nowMode);
   

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -391,7 +391,7 @@ void menuPrinting(void)
       
       case KEY_ICON_3:
         if(isPrinting())				
-          infoMenu.menu[++infoMenu.cur]=menuStopPrinting;	
+          infoMenu.menu[++infoMenu.cur] = menuStopPrinting;	
         else
         {
           exitPrinting();
@@ -456,7 +456,7 @@ void completePrinting(void)
   }
 }
 
-void haltPrinting(void)
+void abortPrinting(void)
 {
   switch (infoFile.source)
   {
@@ -491,7 +491,7 @@ void menuStopPrinting(void)
     switch(key_num)
     {
       case KEY_POPUP_CONFIRM:
-        haltPrinting();
+        abortPrinting();
         infoMenu.cur-=2;
         break;
 

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -542,11 +542,8 @@ void menuShutDown(void)
           mustStoreCmd("%s S0\n", fanCmd[i]);  
         }
         mustStoreCmd("M81\n");
-        popupDrawPage(NULL, textSelect(LABEL_SHUT_DOWN), textSelect(LABEL_SHUTTING_DOWN), NULL, NULL);
-        while(1)
-        {
-          loopProcess();
-        }
+        infoMenu.cur--;
+        popupReminder(textSelect(LABEL_SHUT_DOWN), textSelect(LABEL_SHUTTING_DOWN));
     }
     loopProcess();
   }

--- a/TFT/src/User/Menu/Printing.h
+++ b/TFT/src/User/Menu/Printing.h
@@ -19,7 +19,7 @@ typedef struct
 void exitPrinting(void);
 void endPrinting(void);
 void completePrinting(void);
-void haltPrinting(void);
+void abortPrinting(void);
 
 bool setPrintPause(bool is_pause);
 

--- a/TFT/src/User/Menu/SendGcode.c
+++ b/TFT/src/User/Menu/SendGcode.c
@@ -217,7 +217,7 @@ void menuTerminal(void)
   GUI_SetColor(BLACK);
   GUI_SetBkColor(GRAY);
   GUI_ClearRect(CURSOR_START_X, CURSOR_START_Y, CURSOR_END_X, CURSOR_END_Y);
-  TSC_ReDrawIcon = NULL; // Close icon redraw callback function
+  TSC_ReDrawIcon = NULL; // Disable icon redraw callback function
 
   while(infoMenu.menu[infoMenu.cur] == menuTerminal)
   {

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -48,10 +48,10 @@ void menuDisconnect(void)
   GUI_DispStringInRect(20, 0, LCD_WIDTH-20, LCD_HEIGHT, textSelect(LABEL_DISCONNECT_INFO));
   GUI_DispStringInRect(20, LCD_HEIGHT - (BYTE_HEIGHT*2), LCD_WIDTH-20, LCD_HEIGHT, textSelect(LABEL_TOUCH_TO_EXIT));
 
-  Serial_DeConfig();
+  Serial_DeInit();
   while(!isPress());
   while(isPress());
-  Serial_Config(infoSettings.baudrate);
+  Serial_Init(infoSettings.baudrate);
   
   infoMenu.cur--;
 }
@@ -125,7 +125,8 @@ void menuSettings(void)
         settingsItems.items[key_num] = itemBaudrate[item_baudrate_i];
         menuDrawItem(&settingsItems.items[key_num], key_num);
         infoSettings.baudrate = item_baudrate[item_baudrate_i];
-        Serial_Config(infoSettings.baudrate);
+        Serial_DeInit(); // Serial_Init() will malloc a dynamic memory, so Serial_DeInit() first to free, then malloc again.
+        Serial_Init(infoSettings.baudrate);
         break;
 
       case KEY_ICON_7:

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -48,6 +48,7 @@ void Hardware_GenericInit(void)
 
 int main(void)
 {
+
   SCB->VTOR = VECT_TAB_FLASH;
  
   Hardware_GenericInit();

--- a/buildroot/ldscripts/stm32f10x_0x3000_iap.ld
+++ b/buildroot/ldscripts/stm32f10x_0x3000_iap.ld
@@ -36,8 +36,8 @@ ENTRY(Reset_Handler)
 _estack = 0x2000C000;    /* end of 48K RAM */
 
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2000;      /* required amount of heap  */
-_Min_Stack_Size = 0x2000; /* required amount of stack */
+_Min_Heap_Size = 0x5000;      /* required amount of heap  */
+_Min_Stack_Size = 0x1000; /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/buildroot/ldscripts/stm32f10x_0x6000_iap.ld
+++ b/buildroot/ldscripts/stm32f10x_0x6000_iap.ld
@@ -36,8 +36,8 @@ ENTRY(Reset_Handler)
 _estack = 0x2000C000;    /* end of 48K RAM */
 
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2000;      /* required amount of heap  */
-_Min_Stack_Size = 0x2000; /* required amount of stack */
+_Min_Heap_Size = 0x5000;      /* required amount of heap  */
+_Min_Stack_Size = 0x1000; /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/buildroot/ldscripts/stm32f2xx_0x8000_iap.ld
+++ b/buildroot/ldscripts/stm32f2xx_0x8000_iap.ld
@@ -11,8 +11,8 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */ 
 _estack = 0x2000c000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2000;      /* required amount of heap  */
-_Min_Stack_Size = 0x2000;     /* required amount of stack */
+_Min_Heap_Size = 0x5000;      /* required amount of heap  */
+_Min_Stack_Size = 0x1000;     /* required amount of stack */
 
 /* Specify the memory areas */
 MEMORY

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = TFT
 boards_dir   = buildroot/boards
-default_envs = BIGTREE_TFT35_V3_0
+default_envs = BIGTREE_TFT35_V2_0
 
 [common]
 default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x> -<src/User/Hal/stm32f2xx>

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = TFT
 boards_dir   = buildroot/boards
-default_envs = BIGTREE_TFT35_V2_0
+default_envs = BIGTREE_TFT35_V3_0
 
 [common]
 default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x> -<src/User/Hal/stm32f2xx>


### PR DESCRIPTION
1. improve Serial Hal, fix random stop in printing when enable 'keep alive' in Marlin
2. improve memory allocation， using malloc() dynamic memory instead of static array