### PR TITLE
Add bug report, feature request, and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] (short description)'
+labels: ''
+assignees: ''
+
+---
+<!--
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use the BigTreeTech Facebook group: https://www.facebook.com/groups/505736576548648 or BigTreeTech Subreddit: https://www.reddit.com/r/BIGTREETECH/.
+-->
+### Description
+
+<!-- Description of the bug -->
+
+### Steps to reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior**
+<!-- What you expect to happen -->
+
+**Actual behavior**
+<!-- What actually happens -->
+
+### Additional Information
+* Include a ZIP file containing your `Configuration.h` or use [Pastebin](https://pastebin.com/) and paste a link in this issue.
+* Provide pictures or links to videos that clearly demonstrate the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: BigTreeTech Facebook group
+    url: https://www.facebook.com/groups/505736576548648
+    about: Please ask and answer questions here.
+  - name: BigTreeTech Subreddit
+    url: https://www.reddit.com/r/BIGTREETECH/
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FR] (feature request title)'
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### Requirements
+
+* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.
+
+### Description
+
+<!--
+
+We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.
+
+-->
+
+### Benefits
+
+<!-- What does this fix or improve? -->
+
+### Related Issues
+
+<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->


### PR DESCRIPTION
### Description

Creating new bug reports, feature requests, and pull requests will now use templates.

### Benefits

Standardize requested info from users/PRs:

**New bug report/feature request:**
![image](https://user-images.githubusercontent.com/13375512/69806492-d2a53e00-1197-11ea-93a5-7d3b0c5d2074.png)

**New PR:**
![image](https://user-images.githubusercontent.com/13375512/69806552-008a8280-1198-11ea-9610-cc593c6b9833.png)