### PR TITLE
Adds display of fan as a percentage

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -230,6 +230,10 @@ void parseACK(void)
       ackPopupInfo(echomagic);
     }
   }
+  if (ack_seen(" F0:"))
+  {
+      fanSetSpeed(0, ack_value());
+  }
   
 parse_end:    
   if(ack_cur_src != SERIAL_PORT)

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -35,10 +35,10 @@
 #define EXTRUDER_NUM 1    // set in 1~6
 #define FAN_NUM      1    // set in 1~6
 
-//                       PLA      PETG       ABS     "CUSTOM1" "CUSTOM2"
-#define PREHEAT_BED      {55,      85,       100,       55,       55}
-#define PREHEAT_HOTEND   {205,     230,      230,       200,      200}
-//#define PREHEAT_TEXT     {"PLA",  "PETG",   "ABS",     "T2:",    "T3:"}
+//                       PLA      PETG       NYL     "CUSTOM1" "CUSTOM2"
+#define PREHEAT_BED      {60,      70,       65,       55,       55}
+#define PREHEAT_HOTEND   {200,     250,      255,       200,      200}
+#define PREHEAT_TEXT     {"PLA",  "PETG",   "NYL",     "T2:",    "T3:"}
 
 #define HEAT_MAX_TEMP    {150,    275,       275,       275,       275,       275,       275}    //max temperature can be set
 #define HEAT_SIGN_ID     {"B:",   "T0:",     "T1:",     "T2:",     "T3:",     "T4:",     "T5:"}
@@ -129,7 +129,7 @@
  * It is friendly to display long file name, but the model preview feature is not available
  * Disable this if you want to use the model preview feature
  */
-//#define GCODE_LIST_MODE
+// #define GCODE_LIST_MODE
 
 
 //-------RESET SETTINGS & TOUCH SCREEN CALIBRATION------||
@@ -152,7 +152,7 @@
 //#define HOME_BEFORE_PLR
 
 // Prevent extrusion if the temperature is below set temperature
-#define PREVENT_COLD_EXTRUSION_MINTEMP 170
+#define PREVENT_COLD_EXTRUSION_MINTEMP 150
 
 /**
   * Maximum hotend temperature of automatic shut down after printing.
@@ -162,6 +162,8 @@
 #define AUTO_SHUT_DOWN_MAXTEMP 50
 
 #define EXTRUDE_STEPS  100.0f
+
+#define SHOW_FAN_PERCENTAGE // enable to show fan speed as a percentage instead of a value
 
 /**
  * Support up to 7 custom gcodes, uncomment CUSTOM_X_LABEL and CUSTOM_X_GCODE to enable custom gcode

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -35,10 +35,10 @@
 #define EXTRUDER_NUM 1    // set in 1~6
 #define FAN_NUM      1    // set in 1~6
 
-//                       PLA      PETG       NYL     "CUSTOM1" "CUSTOM2"
-#define PREHEAT_BED      {60,      70,       65,       55,       55}
-#define PREHEAT_HOTEND   {200,     250,      255,       200,      200}
-#define PREHEAT_TEXT     {"PLA",  "PETG",   "NYL",     "T2:",    "T3:"}
+//                       PLA      PETG       ABS     "CUSTOM1" "CUSTOM2"
+#define PREHEAT_BED      {60,      70,       100,       55,       55}
+#define PREHEAT_HOTEND   {200,     250,      230,       200,      200}
+#define PREHEAT_TEXT     {"PLA",  "PETG",   "ABS",     "T2:",    "T3:"}
 
 #define HEAT_MAX_TEMP    {150,    275,       275,       275,       275,       275,       275}    //max temperature can be set
 #define HEAT_SIGN_ID     {"B:",   "T0:",     "T1:",     "T2:",     "T3:",     "T4:",     "T5:"}
@@ -129,7 +129,7 @@
  * It is friendly to display long file name, but the model preview feature is not available
  * Disable this if you want to use the model preview feature
  */
-// #define GCODE_LIST_MODE
+//#define GCODE_LIST_MODE
 
 
 //-------RESET SETTINGS & TOUCH SCREEN CALIBRATION------||
@@ -152,7 +152,7 @@
 //#define HOME_BEFORE_PLR
 
 // Prevent extrusion if the temperature is below set temperature
-#define PREVENT_COLD_EXTRUSION_MINTEMP 150
+#define PREVENT_COLD_EXTRUSION_MINTEMP 170
 
 /**
   * Maximum hotend temperature of automatic shut down after printing.

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -54,14 +54,32 @@ void fanSetSendWaiting(u8 i, bool isWaiting)
 void showFanSpeed(void)
 {
   const GUI_RECT rect = {exhibitRect.x0, CENTER_Y-BYTE_HEIGHT, exhibitRect.x1, CENTER_Y};
+  u8 fs;
+  #ifdef SHOW_FAN_PERCENTAGE
+    fs = (fanSpeed[curIndex]*100)/255;
+  #else
+    fs = fanSpeed[curIndex]
+  #endif 
   GUI_ClearRect(rect.x0, rect.y0, rect.x1, rect.y1);
   GUI_DispStringInPrect(&rect, (u8*)fanID[curIndex]);
-  GUI_DispDec(CENTER_X-BYTE_WIDTH, CENTER_Y, fanSpeed[curIndex], 3, LEFT);
+  #ifdef SHOW_FAN_PERCENTAGE
+    char fan_s[5];
+    sprintf(fan_s, "%3d%%", fs); 
+    GUI_DispString(CENTER_X-BYTE_WIDTH, CENTER_Y, (u8 *)fan_s);
+  #else
+    GUI_DispDec(CENTER_X-BYTE_WIDTH, CENTER_Y, fs, 3, LEFT);
+  #endif 
 }
 
 void fanSpeedReDraw(void)
 {
-  GUI_DispDec(CENTER_X-BYTE_WIDTH, CENTER_Y, fanSpeed[curIndex], 3, LEFT);
+  #ifdef SHOW_FAN_PERCENTAGE
+    char fan_s[5] = "";
+    sprintf(fan_s, "%3d%%", (fanSpeed[curIndex]*100)/255); 
+    GUI_DispString(CENTER_X-BYTE_WIDTH, CENTER_Y, (u8 *)fan_s);
+  #else
+    GUI_DispDec(CENTER_X-BYTE_WIDTH, CENTER_Y, fanSpeed[curIndex];, 3, LEFT);
+  #endif   
 }
 
 void menuFan(void)
@@ -80,12 +98,29 @@ void menuFan(void)
     {
       case KEY_ICON_0:
         if (fanSpeed[curIndex] > 0)
-          fanSpeed[curIndex]--;
+            #ifdef SHOW_FAN_PERCENTAGE
+              if ((fanSpeed[curIndex]-2) > 0) {
+                fanSpeed[curIndex]-=2; //2.55 is 1 percent, rounding down
+              } else {
+                fanSpeed[curIndex]=0;
+              }
+            #else
+              fanSpeed[curIndex]--;
+            #endif   
         break;
         
       case KEY_ICON_3:
-        if (fanSpeed[curIndex] < fanMaxPWM[curIndex])
-          fanSpeed[curIndex]++;
+        if (fanSpeed[curIndex] < fanMaxPWM[curIndex]){
+            #ifdef SHOW_FAN_PERCENTAGE
+              if (fanSpeed[curIndex]+2 <= fanMaxPWM[curIndex]){
+                fanSpeed[curIndex]+=2; //2.55 is 1 percent, rounding down
+              } else {
+                fanSpeed[curIndex]=fanMaxPWM[curIndex];
+              }
+            #else
+              fanSpeed[curIndex]++;
+            #endif   
+        }
         break;
         
       case KEY_ICON_4:
@@ -127,3 +162,4 @@ void menuFan(void)
     loopProcess();
   }
 }
+

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -45,7 +45,6 @@ static float yaxis;
 static float zaxis;
 static bool gantryCmdWait = false;
 
-
 TOOL current_Ext = NOZZLE0;
 int current_fan = 0;
 int current_speedID = 0;
@@ -151,7 +150,15 @@ void drawTemperature(void)
   menuDrawItem(&ToolItems[2],2);                                          //Fan icon
   GUI_DispStringInPrect(&rectA[2],(u8 *)fanID[current_fan]);              //Fan label
   GUI_SetColor(VAL_COLOR);
-  my_sprintf(tempstr, "%d", fanGetSpeed(current_fan)); 
+  
+  u8 fs;
+  #ifdef SHOW_FAN_PERCENTAGE
+    fs = (fanGetSpeed(current_fan)*100)/255;
+    my_sprintf(tempstr, "%d%%", fs); 
+  #else
+    fs = fanSpeed[curIndex];
+    my_sprintf(tempstr, "%d", fs);
+  #endif 
   GUI_DispStringInPrect(&rectB[2], (u8 *)tempstr);                        //Fan value
 
   GUI_SetColor(HEADING_COLOR);
@@ -167,7 +174,9 @@ void drawTemperature(void)
   my_sprintf(tempstr, "X: %.2f   Y: %.2f   Z: %.2f", xaxis, yaxis, zaxis);
   GUI_DispStringInPrect(&RecGantry,(u8 *)tempstr);
   
-  GUI_RestoreColorDefault();
+  GUI_SetBkColor(BK_COLOR);
+  GUI_SetColor(FK_COLOR);
+  //GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
 }
 
 void storegantry(int n, float val){
@@ -247,12 +256,16 @@ float getAxisLocation(u8 n){
   {
   case 0:
     return xaxis;
+    break;
   case 1:
     return yaxis;
+    break;
   case 2:
     return zaxis;
+    break;
   default:
     return xaxis;
+    break;
   }
 }
 
@@ -273,17 +286,15 @@ void drawStatusScreenMsg(void)
 //GUI_ClearRect(RectInfo.x0,RectInfo.y0,RectInfo.x1,RectInfo.y1);
   GUI_SetTextMode(GUI_TEXTMODE_TRANS);
  
-  //GUI_SetColor(INFOBOX_BKCOLOR);
-  //GUI_FillRect(RectInfo.x0, RectInfo.y0, RectInfo.x1, RectInfo.y1);
+  GUI_SetColor(INFOBOX_BKCOLOR);
+  GUI_FillRect(RectInfo.x0, RectInfo.y0, RectInfo.x1, RectInfo.y1);
   
-  //GUI_SetColor(INFOBOX_BORDER);
-  //GUI_DrawRect(RectInfo.x0, RectInfo.y0, RectInfo.x1, RectInfo.y1);
-  lcd_frame_display(RectInfo.x0, RectInfo.y0, INFOBOX_P1_WIDTH, ICON_HEIGHT, ICON_ADDR(ICON_INFOBOX_PART1));
-  lcd_frame_display(RectInfo.x0+INFOBOX_P1_WIDTH, RectInfo.y0, INFOBOX_P2_WIDTH, ICON_HEIGHT, ICON_ADDR(ICON_INFOBOX_PART2));
+  GUI_SetColor(INFOBOX_BORDER);
+  GUI_DrawRect(RectInfo.x0, RectInfo.y0, RectInfo.x1, RectInfo.y1);
 
   GUI_SetColor(INFOMSG_BKCOLOR);
   GUI_DispString(RectInfo.x0 + STATUS_MSG_ICON_XOFFSET, RectInfo.y0 + STATUS_MSG_ICON_YOFFSET,IconCharSelect(ICONCHAR_INFO));
-  //GUI_FillRect(RectInfo.x0, msgRect.y0, RectInfo.x1, msgRect.y1); //rectangle for msg scroller
+  GUI_FillRect(RectInfo.x0, msgRect.y0, RectInfo.x1, msgRect.y1); //rectangle for msg scroller
 
   GUI_DispString(RectInfo.x0 + BYTE_HEIGHT+ STATUS_MSG_TITLE_XOFFSET,RectInfo.y0 + STATUS_MSG_ICON_YOFFSET,(u8*)msgtitle); 
   GUI_SetBkColor(INFOMSG_BKCOLOR);
@@ -291,14 +302,17 @@ void drawStatusScreenMsg(void)
   
   Scroll_CreatePara(&msgScroll, (u8 *)msgbody, &msgRect);
 
-  GUI_RestoreColorDefault();
+  GUI_SetBkColor(BK_COLOR);
+  GUI_SetColor(FK_COLOR);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
 }
 
 void scrollMsg(void){
   GUI_SetBkColor(INFOMSG_BKCOLOR);
   GUI_SetColor(INFOMSG_COLOR);
   Scroll_DispString(&msgScroll,CENTER); 
-  GUI_RestoreColorDefault();
+  GUI_SetBkColor(BK_COLOR);
+  GUI_SetColor(FK_COLOR);
 }
 
 void toggleTool(void)

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = TFT
 boards_dir   = buildroot/boards
-default_envs = BIGTREE_TFT35_V3_0
+default_envs = BIGTREE_TFT24_V1_1
 
 [common]
 default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x> -<src/User/Hal/stm32f2xx>

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = TFT
 boards_dir   = buildroot/boards
-default_envs = BIGTREE_TFT24_V1_1
+default_envs = BIGTREE_TFT35_V3_0
 
 [common]
 default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x> -<src/User/Hal/stm32f2xx>


### PR DESCRIPTION
Description:
This adds the ability to display the fan speed as a percentage rather than the pwm value. It also adds parsing of a fan speed token in the temperature output (F0). A feature for adding the fan speed to the temperature output in marlin has been submitted.

Benefits
Showing the fan speed as a percentage is more user friendly than a number from 0 - 255. Adding the fan speed token parsing allows for the fan speed to be updated when gcode is being sent from another host (eg octoprint)

