### PR TITLE
add miniUPS support in power failed

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -150,6 +150,10 @@
  * This function is suitable for Delta Printer.
  */
 //#define HOME_BEFORE_PLR
+// 
+#define BTT_MINI_UPS // Backup power / UPS to move the Z axis steppers on power loss
+#define POWER_LOSS_ZRAISE 10 // (mm) Z axis raise on resume (on power loss with UPS)
+
 
 // Prevent extrusion if the temperature is below set temperature
 #define PREVENT_COLD_EXTRUSION_MINTEMP 170

--- a/TFT/src/User/Menu/PowerFailed.c
+++ b/TFT/src/User/Menu/PowerFailed.c
@@ -145,11 +145,15 @@ bool powerOffGetData(void)
   mustStoreCacheCmd("%s\n", tool_change[infoBreakPoint.nozzle - NOZZLE0]);
   if(infoBreakPoint.feedrate != 0)
   {
-    mustStoreCacheCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS]);    
-    mustStoreCacheCmd("G1 Z%d\n", limitValue(0, infoBreakPoint.axis[Z_AXIS]+10, Z_MAX_POS));
+    mustStoreCacheCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS]
+      #ifdef BTT_MINI_UPS
+        + POWER_LOSS_ZRAISE
+      #endif
+      );    
+    mustStoreCacheCmd("G1 Z%d\n", limitValue(0, infoBreakPoint.axis[Z_AXIS]+POWER_LOSS_ZRAISE, Z_MAX_POS));
     #ifdef HOME_BEFORE_PLR
       mustStoreCacheCmd("G28\n");
-      mustStoreCacheCmd("G1 Z%d\n", limitValue(0, infoBreakPoint.axis[Z_AXIS]+10, Z_MAX_POS));
+      mustStoreCacheCmd("G1 Z%d\n", limitValue(0, infoBreakPoint.axis[Z_AXIS]+POWER_LOSS_ZRAISE, Z_MAX_POS));
     #else
       mustStoreCacheCmd("G28 X0 Y0\n");
     #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->
if miniUPS is used, printer will raise z axis in power failed, so dont need raise again before resume printing
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
