### PR TITLE
Added define for cancel print gcode

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -198,4 +198,5 @@
 //#define CUSTOM_6_LABEL "Custom6"
 //#define CUSTOM_6_GCODE "M105\n"
 
+#define CANCEL_PRINT_GCODE "G28 X0 Y0\n"
 #endif

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -480,7 +480,7 @@ void abortPrinting(void)
   heatClearIsWaiting();
   
   mustStoreCmd("G0 Z%d F3000\n", limitValue(0, (int)coordinateGetAxisTarget(Z_AXIS) + 10, Z_MAX_POS));
-  mustStoreCmd("G28 X0 Y0\n");
+  mustStoreCmd(CANCEL_PRINT_GCODE);
 
   endPrinting();
   exitPrinting();


### PR DESCRIPTION
Description: adds a define in Configuration.h for the gcode to run at the end of a canceled print

Benefits: better user experience and code management to have custom gcode run at the end of a print instead of directly modifying the abortPrinting function in Printing.c

Related Issues: N/A