### PR TITLE
Adding BIGTREE_TFT28_V3_0  target to build test

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -27,6 +27,8 @@ jobs:
         run: platformio run --environment BIGTREE_TFT35_V1_0
       - name: Build TFT28 V1.0
         run: platformio run --environment BIGTREE_TFT28_V1_0
+      - name: Build TFT28 V3.0
+        run: platformio run --environment BIGTREE_TFT28_V3_0
       - name: Build TFT24 V1.1
         run: platformio run --environment BIGTREE_TFT24_V1_1
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@
 ;BIGTREE_TFT35_V2_0
 ;BIGTREE_TFT35_V3_0
 ;BIGTREE_TFT28_V1_0
+;BIGTREE_TFT28_V3_0
 ;BIGTREE_TFT24_V1_1
 [platformio]
 src_dir      = TFT
@@ -118,6 +119,7 @@ build_flags   = ${stm32f10x.build_flags}
   -DHARDWARE="BIQU_TFT35_APP1_V2.0" 
   -DTFT35_V2_0=
 monitor_speed = 250000
+
 #
 # BIGTREE_TFT35_V3.0
 #


### PR DESCRIPTION
### Description

Minor change, just for completeness; adding BIGTREE_TFT28_V3_0 target to build test configuration.

### Benefits

build test for all targets

