### PR TITLE
Fix 'Missing braces warning' and compile error for TFT28_V3

### DIFF
--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -97,8 +97,8 @@ void menuFan(void)
     switch(key_num)
     {
       case KEY_ICON_0:
-        if (fanSpeed[curIndex] > 0)
-            #ifdef SHOW_FAN_PERCENTAGE
+        if (fanSpeed[curIndex] > 0) {
+            #ifdef SHOW_FAN_PERCENTAGE 
               if ((fanSpeed[curIndex]-2) > 0) {
                 fanSpeed[curIndex]-=2; //2.55 is 1 percent, rounding down
               } else {
@@ -107,6 +107,7 @@ void menuFan(void)
             #else
               fanSpeed[curIndex]--;
             #endif   
+        }
         break;
         
       case KEY_ICON_3:

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -103,12 +103,6 @@ static u32 update_time = 50; // 1 seconds is 100
 void menuMove(void)
 {
   KEY_VALUES  key_num = KEY_IDLE;
-  uint32_t B0;
-  uint32_t B1;
-  uint32_t B2;
-  uint32_t B5;
-  uint32_t B6;
-  uint32_t B7;
 
 
   #ifdef ALTERNATIVE_MOVE_MENU

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -307,7 +307,6 @@ void parametersetting(void)
 void temp_Change(void)
 {
     //static FP_MENU NUM[MAX_MENU_DEPTH];
-    char tempstr[10];
     static int16_t compare [2];
   
     if(infoHost.connected == false || infoMenu.menu[infoMenu.cur] == menuPrinting)    return;

--- a/TFT/src/User/Menu/StatusScreen.h
+++ b/TFT/src/User/Menu/StatusScreen.h
@@ -43,7 +43,7 @@ void gantry_inc(int n, float val);
   #define STATUS_GANTRY_YOFFSET       6
 
 
-#elif defined(TFT28_V1_0) || defined(TFT24_V1_1)
+#elif defined(TFT28_V1_0) || defined(TFT24_V1_1) || defined(TFT28_V3_0)
 
   #define SSICON_VAL_Y0           47
   //#define  statusicon_val_charcount  7

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ default_src_filter = +<src/*> -<src/Libraries> -<src/User/Hal/stm32f10x> -<src/U
 build_flags = -fmax-errors=5
   -g
   -ggdb
+  -Wno-missing-braces
   -DUSE_STDPERIPH_DRIVER=
   -D__STATIC_INLINE=
   -ITFT/src/Libraries/cmsis/Core-CM3


### PR DESCRIPTION
- Fix 'missing braces around initializer' warning due to which some other warning were overlooked by the compiler.
- fix compile error for TFT28_V3
- remove some unnecessary variables.