### PR TITLE
Intercept M0/M1 command when printing from SD card on TFT controller

### DIFF
--- a/TFT/src/User/API/Language/Language.c
+++ b/TFT/src/User/API/Language/Language.c
@@ -166,6 +166,7 @@ const char *const en_pack[LABEL_NUM]={
   EN_INVERT_ZAXIS,
   EN_MOVE_SPEED,
   EN_KNOB_LED,
+  EN_M0_PAUSE,
 };
 
 const char *const cn_pack[LABEL_NUM]={
@@ -319,6 +320,7 @@ const char *const cn_pack[LABEL_NUM]={
   CN_INVERT_ZAXIS,
   CN_MOVE_SPEED,
   CN_KNOB_LED,
+  CN_M0_PAUSE,
 };
 
 const char *const ru_pack[LABEL_NUM]={
@@ -472,6 +474,7 @@ const char *const ru_pack[LABEL_NUM]={
   RU_INVERT_ZAXIS,
   RU_MOVE_SPEED,
   RU_KNOB_LED,
+  RU_M0_PAUSE,
 };
 
 const char *const jp_pack[LABEL_NUM]={
@@ -625,6 +628,7 @@ const char *const jp_pack[LABEL_NUM]={
   JP_INVERT_ZAXIS,
   JP_MOVE_SPEED,
   JP_KNOB_LED,
+  JP_M0_PAUSE,
 };
 
 const char *const am_pack[LABEL_NUM]={
@@ -778,6 +782,7 @@ const char *const am_pack[LABEL_NUM]={
   AM_INVERT_ZAXIS,
   AM_MOVE_SPEED,
   AM_KNOB_LED,
+  AM_M0_PAUSE,
 };
 
 const char *const de_pack[LABEL_NUM]={
@@ -931,6 +936,7 @@ const char *const de_pack[LABEL_NUM]={
   DE_INVERT_ZAXIS,
   DE_MOVE_SPEED,
   DE_KNOB_LED,
+  DE_M0_PAUSE,
 };
 
 const char *const cz_pack[LABEL_NUM]={
@@ -1084,6 +1090,7 @@ const char *const cz_pack[LABEL_NUM]={
   CZ_INVERT_ZAXIS,
   CZ_MOVE_SPEED,
   CZ_KNOB_LED,
+  CZ_M0_PAUSE,
 };
 
 const char *const es_pack[LABEL_NUM]={
@@ -1237,6 +1244,7 @@ const char *const es_pack[LABEL_NUM]={
   ES_INVERT_ZAXIS,
   ES_MOVE_SPEED,
   ES_KNOB_LED,
+  ES_M0_PAUSE,
 };
 
 const char *const fr_pack[LABEL_NUM]={
@@ -1390,6 +1398,7 @@ const char *const fr_pack[LABEL_NUM]={
   FR_INVERT_ZAXIS,
   FR_MOVE_SPEED,
   FR_KNOB_LED,
+  FR_M0_PAUSE,
 };
 
 const char *const pt_pack[LABEL_NUM]={
@@ -1543,6 +1552,7 @@ const char *const pt_pack[LABEL_NUM]={
   PT_INVERT_ZAXIS,
   PT_MOVE_SPEED,
   PT_KNOB_LED,
+  PT_M0_PAUSE,
 };
 
 const char *const it_pack[LABEL_NUM]={
@@ -1696,6 +1706,7 @@ const char *const it_pack[LABEL_NUM]={
   IT_INVERT_ZAXIS,
   IT_MOVE_SPEED,
   IT_KNOB_LED,
+  IT_M0_PAUSE,
 };
 
 const char *const pl_pack[LABEL_NUM]={
@@ -1849,6 +1860,7 @@ const char *const pl_pack[LABEL_NUM]={
   PL_INVERT_ZAXIS,
   PL_MOVE_SPEED,
   PL_KNOB_LED,
+  PL_M0_PAUSE,
 };
 
 const char *const sk_pack[LABEL_NUM]={
@@ -2002,6 +2014,7 @@ const char *const sk_pack[LABEL_NUM]={
   SK_INVERT_ZAXIS,
   SK_MOVE_SPEED,
   SK_KNOB_LED,
+  SK_M0_PAUSE,
 };
 
 const char *const du_pack[LABEL_NUM]={
@@ -2155,6 +2168,7 @@ const char *const du_pack[LABEL_NUM]={
   DU_INVERT_ZAXIS,
   DU_MOVE_SPEED,
   DU_KNOB_LED,
+  DU_M0_PAUSE,
 };
 
 u8 * textSelect(u8 sel)

--- a/TFT/src/User/API/Language/Language.h
+++ b/TFT/src/User/API/Language/Language.h
@@ -177,6 +177,7 @@ enum
   LABEL_INVERT_ZAXIS,
   LABEL_MOVE_SPEED,
   LABEL_KNOB_LED,
+  LABEL_M0_PAUSE,
 
   //add new keywords above this line only
   //keep the following always at the end of this list

--- a/TFT/src/User/API/Language/language_am.h
+++ b/TFT/src/User/API/Language/language_am.h
@@ -151,5 +151,6 @@
     #define AM_INVERT_ZAXIS         "Invert Z Axis"
     #define AM_MOVE_SPEED           "Move speed(X Y Z)"
     #define AM_KNOB_LED             "Rotary Knob LED"
+    #define AM_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_cn.h
+++ b/TFT/src/User/API/Language/language_cn.h
@@ -151,5 +151,6 @@
     #define CN_INVERT_ZAXIS         "Invert Z Axis"
     #define CN_MOVE_SPEED           "Move speed(X Y Z)"
     #define CN_KNOB_LED             "Rotary Knob LED"
+    #define CN_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_cz.h
+++ b/TFT/src/User/API/Language/language_cz.h
@@ -151,5 +151,6 @@
     #define CZ_INVERT_ZAXIS         "Invert Z Axis"
     #define CZ_MOVE_SPEED           "Move speed(X Y Z)"
     #define CZ_KNOB_LED             "Rotary Knob LED"
+    #define CZ_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_de.h
+++ b/TFT/src/User/API/Language/language_de.h
@@ -151,5 +151,6 @@
     #define DE_INVERT_ZAXIS         "Invert Z Axis"
     #define DE_MOVE_SPEED           "Move speed(X Y Z)"
     #define DE_KNOB_LED             "Rotary Knob LED"
+    #define DE_M0_PAUSE             "Paused by M0 command"
     
 #endif

--- a/TFT/src/User/API/Language/language_du.h
+++ b/TFT/src/User/API/Language/language_du.h
@@ -151,5 +151,6 @@
     #define DU_INVERT_ZAXIS         "Inverteer Z Axis"
     #define DU_MOVE_SPEED           "Bewegingssnelheid(X Y Z)"
     #define DU_KNOB_LED             "Rotary Knob LED"
+    #define DU_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_en.h
+++ b/TFT/src/User/API/Language/language_en.h
@@ -151,5 +151,6 @@
     #define EN_INVERT_ZAXIS         "Invert Z Axis"
     #define EN_MOVE_SPEED           "Move speed(X Y Z)"
     #define EN_KNOB_LED             "Rotary Knob LED"
+    #define EN_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_es.h
+++ b/TFT/src/User/API/Language/language_es.h
@@ -151,5 +151,6 @@
     #define ES_INVERT_ZAXIS         "Invert Z Axis"
     #define ES_MOVE_SPEED           "Move speed(X Y Z)"
     #define ES_KNOB_LED             "Rotary Knob LED"
+    #define ES_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_fr.h
+++ b/TFT/src/User/API/Language/language_fr.h
@@ -151,5 +151,6 @@
     #define FR_INVERT_ZAXIS         "Inverser Axe Z"
     #define FR_MOVE_SPEED           "Vitesse de déplacement (X Y Z)"
     #define FR_KNOB_LED             "Rotary Knob LED"
+    #define FR_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_it.h
+++ b/TFT/src/User/API/Language/language_it.h
@@ -151,5 +151,6 @@
     #define IT_INVERT_ZAXIS         "Invert Z Axis"
     #define IT_MOVE_SPEED           "Move speed(X Y Z)"
     #define IT_KNOB_LED             "Rotary Knob LED"
+    #define IT_M0_PAUSE             "Paused by M0 command"
     
 #endif

--- a/TFT/src/User/API/Language/language_jp.h
+++ b/TFT/src/User/API/Language/language_jp.h
@@ -151,5 +151,6 @@
     #define JP_INVERT_ZAXIS         "Invert Z Axis"
     #define JP_MOVE_SPEED           "Move speed(X Y Z)"
     #define JP_KNOB_LED             "Rotary Knob LED"
+    #define JP_M0_PAUSE             "Paused by M0 command"
     
 #endif

--- a/TFT/src/User/API/Language/language_pl.h
+++ b/TFT/src/User/API/Language/language_pl.h
@@ -151,5 +151,6 @@
     #define PL_INVERT_ZAXIS         "Invert Z Axis"
     #define PL_MOVE_SPEED           "Move speed(X Y Z)"
     #define PL_KNOB_LED             "Rotary Knob LED"
+    #define PL_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/Language/language_pt.h
+++ b/TFT/src/User/API/Language/language_pt.h
@@ -151,5 +151,6 @@
     #define PT_INVERT_ZAXIS         "Invert Z Axis"
     #define PT_MOVE_SPEED           "Move speed(X Y Z)"
     #define PT_KNOB_LED             "Rotary Knob LED"
+    #define PT_M0_PAUSE             "Paused by M0 command"
     
 #endif

--- a/TFT/src/User/API/Language/language_ru.h
+++ b/TFT/src/User/API/Language/language_ru.h
@@ -151,5 +151,6 @@
     #define RU_INVERT_ZAXIS         "Инверсия оси Z"
     #define RU_MOVE_SPEED           "Скорость (X Y Z)"
     #define RU_KNOB_LED             "Rotary Knob LED"
+    #define RU_M0_PAUSE             "Paused by M0 command"
     
 #endif

--- a/TFT/src/User/API/Language/language_sk.h
+++ b/TFT/src/User/API/Language/language_sk.h
@@ -152,5 +152,6 @@
     #define SK_INVERT_ZAXIS         "Invert Z Axis"
     #define SK_MOVE_SPEED           "Move speed(X Y Z)"
     #define SK_KNOB_LED             "Rotary Knob LED"
+    #define SK_M0_PAUSE             "Paused by M0 command"
 
 #endif

--- a/TFT/src/User/API/extend.c
+++ b/TFT/src/User/API/extend.c
@@ -138,7 +138,7 @@ void loopFILRunoutDetect(void)
   if (!FIL_IsRunout()) return; // Filament not runout yet, need constant scanning to filter interference
   if (!isPrinting() || isPause())  return; // No printing or printing paused
   
-  if (setPrintPause(true))
+  if (setPrintPause(true,false))
   {
     popupReminder(textSelect(LABEL_WARNING), textSelect(LABEL_FILAMENT_RUNOUT));
   }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -157,6 +157,16 @@ void sendQueueCmd(void)
       cmd=strtol(&infoCmd.queue[infoCmd.index_r].gcode[1],NULL,10);
       switch(cmd)
       {
+        case 0:
+          if (isPrinting()) {
+            setPrintPause(true,true);
+          }
+          break;
+        case 1:
+          if (isPrinting()) {
+            setPrintPause(true,true);
+          }
+          break;
         case 18: //M18/M84 disable steppers
         case 84:
           coordinateSetClear(false);

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -209,6 +209,10 @@ void parseACK(void)
     {
       busyIndicator(STATUS_BUSY);
     }
+    else if(ack_seen(echomagic) && ack_seen(busymagic) && ack_seen("paused for user"))
+    {
+      goto parse_end;
+    }
     else if(ack_seen("X driver current: "))
     {
       Get_parameter_value[0] = ack_value();

--- a/TFT/src/User/Menu/More.c
+++ b/TFT/src/User/Menu/More.c
@@ -13,7 +13,7 @@ void menuIsPause(void)
     switch(key_num)
     {
       case KEY_POPUP_CONFIRM:
-				if(setPrintPause(true))
+				if(setPrintPause(true,false))
 			    infoMenu.menu[infoMenu.cur]=menuExtrude;
 			  break;
 

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -259,7 +259,11 @@ bool setPrintPause(bool is_pause, bool is_m0pause)
       }
       else
       {
-      if(isM0_Pause() == true) {  setM0Pause(is_m0pause);break;}
+      if(isM0_Pause() == true) {
+        setM0Pause(is_m0pause);
+        mustStoreCmd("M108\n");
+        break;
+        }
         if (isCoorRelative == true)     mustStoreCmd("G90\n");
         if (isExtrudeRelative == true)  mustStoreCmd("M82\n");
         
@@ -419,10 +423,6 @@ void menuPrinting(void)
     {
       case KEY_ICON_0:
         setPrintPause(!isPause(),false);
-        if(isM0_Pause() == true){
-          storeCmd("M108\n");
-          }
-
         break;
       
       case KEY_ICON_3:

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -240,7 +240,11 @@ bool setPrintPause(bool is_pause, bool is_m0pause)
       {
         //restore status before pause
         //if pause was triggered through M0/M1 then break
-      if(is_m0pause == true) {setM0Pause(is_m0pause);break;}
+      if(is_m0pause == true) {
+        setM0Pause(is_m0pause);
+        popupReminder(textSelect(LABEL_PAUSE), textSelect(LABEL_M0_PAUSE));
+        break;
+        }
       
         coordinateGetAll(&tmp);
         if (isCoorRelative == true)     mustStoreCmd("G90\n");
@@ -261,7 +265,7 @@ bool setPrintPause(bool is_pause, bool is_m0pause)
       {
       if(isM0_Pause() == true) {
         setM0Pause(is_m0pause);
-        mustStoreCmd("M108\n");
+        Serial_Puts(SERIAL_PORT, "M108\n");
         break;
         }
         if (isCoorRelative == true)     mustStoreCmd("G90\n");

--- a/TFT/src/User/Menu/Printing.h
+++ b/TFT/src/User/Menu/Printing.h
@@ -14,6 +14,7 @@ typedef struct
   u8      progress;
   bool    printing; // 1 means printing, 0 means idle
   bool    pause; //1 means paused
+  bool    m0_pause; //pause triggered through M0/M1 gcode
 }PRINTING;
 
 void exitPrinting(void);
@@ -21,10 +22,12 @@ void endPrinting(void);
 void completePrinting(void);
 void abortPrinting(void);
 
-bool setPrintPause(bool is_pause);
+void setM0Pause(bool m0_pause);
+bool setPrintPause(bool is_pause,bool is_m0pause);
 
 bool isPrinting(void);	
 bool isPause(void);
+bool isM0_Pause(void);
 void setPrintingTime(u32 RTtime);
 
 void setPrintSize(u32 size);


### PR DESCRIPTION
enable detection of M0/M1 command when printing from SD card on TFT controller and prevent 'paused for user' prompt (issue #211)

**requires `EMERGENCY_PARSER` to be enabled in marlin firmware**