### PR TITLE
Include MKS TFTs in build test

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -15,20 +15,23 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -U platformio
-      - name: Build TFT35 V3
-        run: platformio run --environment BIGTREE_TFT35_V3_0     
-      - name: Build TFT35 V2
-        run: platformio run --environment BIGTREE_TFT35_V2_0
-      - name: Build TFT35 V1.2
-        run: platformio run --environment BIGTREE_TFT35_V1_2
-      - name: Build TFT35 V1.1
-        run: platformio run --environment BIGTREE_TFT35_V1_1
       - name: Build TFT35 V1.0
         run: platformio run --environment BIGTREE_TFT35_V1_0
+      - name: Build TFT35 V1.1
+        run: platformio run --environment BIGTREE_TFT35_V1_1
+      - name: Build TFT35 V1.2
+        run: platformio run --environment BIGTREE_TFT35_V1_2
+      - name: Build TFT35 V2.0
+        run: platformio run --environment BIGTREE_TFT35_V2_0
+      - name: Build TFT35 V3.0
+        run: platformio run --environment BIGTREE_TFT35_V3_0
       - name: Build TFT28 V1.0
         run: platformio run --environment BIGTREE_TFT28_V1_0
       - name: Build TFT28 V3.0
         run: platformio run --environment BIGTREE_TFT28_V3_0
       - name: Build TFT24 V1.1
         run: platformio run --environment BIGTREE_TFT24_V1_1
-
+      - name: Build MKS TFT32 V1.4
+        run: platformio run --environment MKS_32_V1_4
+      - name: Build MKS TFT32 V1.4 No Bootloader
+        run: platformio run --environment MKS_32_V1_4_NOBL

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,9 @@
 ;BIGTREE_TFT28_V1_0
 ;BIGTREE_TFT28_V3_0
 ;BIGTREE_TFT24_V1_1
+;MKS_32_V1_4
+;MKS_32_V1_4_NOBL
+
 [platformio]
 src_dir      = TFT
 boards_dir   = buildroot/boards
@@ -61,7 +64,7 @@ build_flags = ${common.build_flags}
               -ITFT/src/Libraries/fwlib/stm32f2xx/inc
               -ITFT/src/User/Hal/stm32f2xx
 #
-# BIGTREE_TFT35_V1.0
+# BIGTREE TFT35 V1.0
 #
 [env:BIGTREE_TFT35_V1_0]
 platform      = ststm32
@@ -72,11 +75,11 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIQU_TFT35_V1.0" 
+  -DHARDWARE="BIQU_TFT35_V1.0"
   -DTFT35_V1_0=
 
 #
-# BIGTREE_TFT35_V1.1
+# BIGTREE TFT35 V1.1
 #
 [env:BIGTREE_TFT35_V1_1]
 platform      = ststm32
@@ -87,11 +90,11 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIQU_TFT35_V1.1" 
+  -DHARDWARE="BIQU_TFT35_V1.1"
   -DTFT35_V1_1=
 
 #
-# BIGTREE_TFT35_V1.2
+# BIGTREE TFT35 V1.2
 #
 [env:BIGTREE_TFT35_V1_2]
 platform      = ststm32
@@ -102,11 +105,11 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIQU_TFT35_V1.2" 
+  -DHARDWARE="BIQU_TFT35_V1.2"
   -DTFT35_V1_2=
 
 #
-# BIGTREE_TFT35_V2.0
+# BIGTREE TFT35 V2.0
 #
 [env:BIGTREE_TFT35_V2_0]
 platform      = ststm32
@@ -117,12 +120,12 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x3000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIQU_TFT35_APP1_V2.0" 
+  -DHARDWARE="BIQU_TFT35_APP1_V2.0"
   -DTFT35_V2_0=
 monitor_speed = 250000
 
 #
-# BIGTREE_TFT35_V3.0
+# BIGTREE TFT35 V3.0
 #
 [env:BIGTREE_TFT35_V3_0]
 platform      = ststm32
@@ -133,11 +136,11 @@ src_filter    = ${stm32f2xx.default_src_filter} +<src/Libraries/Startup/stm32f2x
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f2xx_0x8000_iap.py
 build_flags   = ${stm32f2xx.build_flags}
-  -DHARDWARE="BIGTREE_TFT35_V3.0" 
+  -DHARDWARE="BIGTREE_TFT35_V3.0"
   -DTFT35_V3_0=
 
 #
-# BIGTREE_TFT28_V1.0
+# BIGTREE TFT28 V1.0
 #
 [env:BIGTREE_TFT28_V1_0]
 platform      = ststm32
@@ -148,11 +151,11 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIQU_TFT28_V1.0" 
+  -DHARDWARE="BIQU_TFT28_V1.0"
   -DTFT28_V1_0=
 
 #
-# BIGTREE_TFT28_V3.0
+# BIGTREE TFT28 V3.0
 #
 [env:BIGTREE_TFT28_V3_0]
 platform      = ststm32
@@ -163,11 +166,11 @@ src_filter    = ${stm32f2xx.default_src_filter} +<src/Libraries/Startup/stm32f2x
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f2xx_0x8000_iap.py
 build_flags   = ${stm32f2xx.build_flags}
-  -DHARDWARE="BIGTREE_TFT28_V3.0" 
+  -DHARDWARE="BIGTREE_TFT28_V3.0"
   -DTFT28_V3_0=
 
 #
-# BIGTREE_TFT24_V1.1
+# BIGTREE TFT24 V1.1
 #
 [env:BIGTREE_TFT24_V1_1]
 platform      = ststm32
@@ -178,9 +181,12 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="BIGTREE_TFT24_V1.1" 
+  -DHARDWARE="BIGTREE_TFT24_V1.1"
   -DTFT24_V1_1=
 
+#
+# MKS TFT32 V1.4
+#
 [env:MKS_32_V1_4]
 platform      = ststm32
 framework     = stm32cube
@@ -191,11 +197,13 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x7000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="MKS_32_V1_4" 
+  -DHARDWARE="MKS_32_V1_4"
   -DMKS_32_V1_4=
   -DVECT_TAB_FLASH=0x08007000
 
-
+#
+# MKS TFT32 V1.4 No Bootloader
+#
 [env:MKS_32_V1_4_NOBL]
 platform      = ststm32
 framework     = stm32cube
@@ -206,6 +214,6 @@ src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10
 extra_scripts = pre:buildroot/scripts/custom_filename.py
                 buildroot/scripts/stm32f10x_0x0000_iap.py
 build_flags   = ${stm32f10x.build_flags}
-  -DHARDWARE="MKS_32_V1_4" 
+  -DHARDWARE="MKS_32_V1_4"
   -DMKS_32_V1_4=
   -DVECT_TAB_FLASH=0x08000000


### PR DESCRIPTION
### Description

Include MKS TFTs in build test

### Benefits

More thorough testing of supported builds

### Related Issues

None

CCing @darkspr1te as they contributed the original code for these TFTs.
