### PR TITLE
Enable fullscreen Marlin Mode by default

### DIFF
--- a/TFT/src/User/API/UI/ST7920_Simulator.h
+++ b/TFT/src/User/API/UI/ST7920_Simulator.h
@@ -16,7 +16,7 @@
 #define ST7920_XSTART    (0x80)
 #define ST7920_YSTART    (0x80)
 
-#ifndef ST7920_FULLSCREEN
+#ifdef ST7920_WINDOWED
   #define LCD_XROWS 128
   #define LCD_YROWS 64
 #else

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -64,10 +64,10 @@
 //#define ST7920_BANNER_TEXT "LCD12864 Simulator"
 
 /**
- * Run Marlin Mode fullscreen.
- * Not recommended for TFT24.
+ * Disable fullscreen Marlin Mode
+ * Recommended for TFT24
  */
-//#define ST7920_FULLSCREEN
+//#define ST7920_WINDOWED
 
 /**
  * CLEAN MODE SWITCHING SUPPORT

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -2,7 +2,7 @@
 #define _CONFIGRATION_H_
 
 //===========================================================================
-//=========================== Marlin Mode Settings ===========================
+//=========================== Marlin Mode Settings ==========================
 //===========================================================================
 
 /**
@@ -12,6 +12,8 @@
  *
  * Current color options from lcd.h: BLACK, BLUE, BROWN, BRRED, CYAN, GBLUE, GRAY, GREEN, MAGENTA, RED, WHITE, YELLOW
  */
+#define ST7920_BKCOLOR BLACK
+#define ST7920_FNCOLOR YELLOW
 
 /**
  * This setting determines the communication speed of the printer.
@@ -52,11 +54,6 @@
  */
 #define LCD_FEEDBACK_FREQUENCY_DURATION_L_US 11   // Default 11
 #define LCD_FEEDBACK_FREQUENCY_H_US          3    // Default 3
-
-// Marlin Mode Background & Font Color Options
-// Current color options from lcd.h: BLACK, BLUE, BROWN, BRRED, CYAN, GBLUE, GRAY, GREEN, MAGENTA, RED, WHITE, YELLOW
-#define ST7920_BKCOLOR BLACK
-#define ST7920_FNCOLOR YELLOW
 
 /**
  *  Text displayed at the top of the LCD in Marlin Mode.

--- a/TFT/src/User/SanityCheck.h
+++ b/TFT/src/User/SanityCheck.h
@@ -25,5 +25,8 @@
   #define STARTUP_KNOB_LED_COLOR 1
 #endif
 
+#ifdef ST7920_FULLSCREEN
+  #error "Fullscreen Marlin Mode is enabled by default and ST7920_FULLSCREEN is now ST7920_WINDOWED. Please update your configuration."
+#endif
 
 #endif


### PR DESCRIPTION
### Requirements

All supported TFTs except for TFT24.

### Description

Enable fullscreen Marlin Mode by default.

### Benefits

Use full LCD screen for Marlin Mode.

### Related Issues

None.

CCing @guruathwal for comment/review.