### PR TITLE
fix settingPage array out of bound bug, cause some crash

### DIFF
--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -227,7 +227,7 @@ void loadFeatureSettings(){
         featureSettingsItems.items[i] = settingPage[item_index];
         break;
 
-		case SKEY_INVERT_X:
+      case SKEY_INVERT_X:
         settingPage[item_index].icon = toggleitem[infoSettings.invert_axis[X_AXIS]];
         featureSettingsItems.items[i] = settingPage[item_index];
         break;
@@ -244,16 +244,16 @@ void loadFeatureSettings(){
 
       #ifdef PS_ON_PIN
         case SKEY_POWER:
-        settingPage[item_index].icon = toggleitem[infoSettings.auto_off];
-        featureSettingsItems.items[i] = settingPage[item_index];
-        break;
+          settingPage[item_index].icon = toggleitem[infoSettings.auto_off];
+          featureSettingsItems.items[i] = settingPage[item_index];
+          break;
       #endif
 
       #ifdef FIL_RUNOUT_PIN
         case SKEY_RUNOUT:
-        settingPage[item_index].valueLabel = itemRunout[infoSettings.runout];
-        featureSettingsItems.items[i] = settingPage[item_index];
-        break;
+          settingPage[item_index].valueLabel = itemRunout[infoSettings.runout];
+          featureSettingsItems.items[i] = settingPage[item_index];
+          break;
       #endif
 
       case SKEY_SPEED:
@@ -283,14 +283,13 @@ void loadFeatureSettings(){
 
       #ifdef LED_color_PIN
         case SKEY_KNOB:
-        settingPage[item_index].valueLabel = itemLedcolor[infoSettings.knob_led_color];
-        featureSettingsItems.items[i] = settingPage[item_index];
-        break;
+          settingPage[item_index].valueLabel = itemLedcolor[infoSettings.knob_led_color];
+          featureSettingsItems.items[i] = settingPage[item_index];
+          break;
       #endif
 
       default:
-        settingPage[item_index].icon = ICONCHAR_BACKGROUND;
-        featureSettingsItems.items[i] = settingPage[item_index];
+        featureSettingsItems.items[i].icon = ICONCHAR_BACKGROUND;
       break;
     }
   }


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
* Steps to reproduce the bug
"Setting->Feature->down->down"
When you go to the last page of Feature, `settingPage[]` arry will out of bound, and damage other important data in RAM, then you go to "Gcode" terminal interface，touch screen will crash.
### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
