### PR TITLE
fix M906 TMC Current 

### DIFF
--- a/TFT/src/User/API/parseACK.h
+++ b/TFT/src/User/API/parseACK.h
@@ -6,7 +6,6 @@
 
 static const char errormagic[]        = "Error:";
 static const char echomagic[]         = "echo:";
-static const char busymagic[]         = "busy:";
 static const char unknowmagic[]       = "Unknown command:";
 #ifdef ONBOARD_SD_SUPPORT
 static const char bsdprintingmagic[]   = "SD printing byte";


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
1. Adjust the position of the ACK string parsing, and sort it from top to bottom according to the possible frequency of occurrence
2. fixed can only get TMC X driver current after #401 , #401 parse each `'\n'` segment separately,
```
X driver current: 580
Y driver current: 580
Z driver current: 580
E driver current: 650
ok
```
each axis has a `'\n'` which means there is only one axis current in the same segment

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
