### PR TITLE
improve rename of firmware/folder to be update to prevent duplicate u…

### DIFF
--- a/TFT/src/User/API/boot.h
+++ b/TFT/src/User/API/boot.h
@@ -16,11 +16,10 @@
 #define SMALL_ICON_START_ADDR   (INFOBOX_ADDR+0xA7F8)
 #define SMALL_ICON_ADDR(num)    ((num)*0x1000+SMALL_ICON_START_ADDR)
 
-#define BMP		(1<<1)
-#define FONT	(1<<2)
-
-#define BMP_ROOT_DIR "0:"ROOT_DIR"/bmp"
-#define FONT_ROOT_DIR "0:"ROOT_DIR"/font"
+#define ADMIN_MODE_FILE "0:admin.txt"
+#define FIRMWARE_NAME STRINGIFY(HARDWARE) "." STRINGIFY(SOFTWARE_VERSION)
+#define BMP_ROOT_DIR "0:" ROOT_DIR "/bmp"
+#define FONT_ROOT_DIR "0:" ROOT_DIR "/font"
 #define TFT_RESET_FILE "0:reset.txt"
 
 enum

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -148,3 +148,73 @@ bool Get_NewestGcode(const TCHAR* path)
   }
   return status;
 }
+
+bool f_file_exists(const TCHAR* path) {
+  FIL tmp;
+  if (f_open(&tmp, path, FA_OPEN_EXISTING) == FR_OK) {
+    f_close(&tmp);
+    return true;
+  }
+  return false;
+}
+
+bool f_dir_exists(const TCHAR* path) {
+  DIR tmp;
+  if (f_opendir(&tmp, path) == FR_OK) {
+    f_closedir(&tmp);
+    return true;
+  }
+  return false;
+}
+
+FRESULT f_remove_node (
+  TCHAR* path,    /* Path name buffer with the sub-directory to delete */
+  UINT sz_buff,   /* Size of path name buffer (items) */
+  FILINFO* fno    /* Name read buffer */
+)
+{
+  UINT i, j;
+  FRESULT fr;
+  DIR dir;
+
+  fr = f_opendir(&dir, path); /* Open the directory */
+  if (fr != FR_OK) return fr;
+
+  for (i = 0; path[i]; i++); /* Get current path length */
+  path[i++] = '/';
+
+  for (;;) {
+      fr = f_readdir(&dir, fno);  /* Get a directory item */
+      if (fr != FR_OK || !fno->fname[0]) break;   /* End of directory? */
+      j = 0;
+      do {    /* Make a path name */
+          if (i + j >= sz_buff) { /* Buffer over flow? */
+              fr = 100; break;    /* Fails with 100 when buffer overflow */
+          }
+          path[i + j] = fno->fname[j];
+      } while (fno->fname[j++]);
+      if (fno->fattrib & AM_DIR) {    /* Item is a directory */
+          fr = f_remove_node(path, sz_buff, fno);
+      } else {                        /* Item is a file */
+          fr = f_unlink(path);
+      }
+      if (fr != FR_OK) break;
+  }
+
+  path[--i] = 0;  /* Restore the path name */
+  f_closedir(&dir);
+
+  if (fr == FR_OK) fr = f_unlink(path);  /* Delete the empty directory */
+  return fr;
+}
+
+bool f_remove_full_dir(const TCHAR* path) {
+  #define BUFFER_SIZE 256
+  char dirBuffer[BUFFER_SIZE];
+  FILINFO tmpInfo;
+  strncpy(dirBuffer, path, BUFFER_SIZE);
+  if (f_remove_node(dirBuffer, BUFFER_SIZE, &tmpInfo) == FR_OK) {
+    return true;
+  }
+  return false;
+}

--- a/TFT/src/User/Fatfs/myfatfs.h
+++ b/TFT/src/User/Fatfs/myfatfs.h
@@ -2,9 +2,12 @@
 #define _MYFATFS_H_
 
 #include "stdbool.h"
-
 bool mountSDCard(void);
 bool mountUDisk(void);
 bool scanPrintFilesFatFs(void);
 
+bool f_remove_full_dir(const char* path);
+bool f_dir_exists(const char* path);
+bool f_file_exists(const char* path);
+  
 #endif


### PR DESCRIPTION
### Benefits

<!-- What does this fix or improve? -->

* rename firmware name to avoid duplicate update
* check and delete renamed firmware or folder to avoid rename failure
* add admin mode in updating, It would not rename if there is "admin.txt" in the root directory. This function is to update firmware in batch (one card can update multiple touch screens) 

### Related Issues
#340 
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
