### PR TITLE
PR-#Resetting all settings from within the UI menu.

### DIFF
--- a/TFT/src/User/API/Language/Language.c
+++ b/TFT/src/User/API/Language/Language.c
@@ -168,6 +168,10 @@ const char *const en_pack[LABEL_NUM]={
   EN_FILE_LISTMODE,
   EN_CURRENT_SETTING,
   EN_STEPS_SETTING,
+  EN_RESET,
+  EN_RESET_SETTINGS,
+  EN_RESET_SETTINGS_DONE,
+  EN_INFO
 };
 
 const char *const cn_pack[LABEL_NUM]={
@@ -322,6 +326,10 @@ const char *const cn_pack[LABEL_NUM]={
   CN_FILE_LISTMODE,
   CN_CURRENT_SETTING,
   CN_STEPS_SETTING,
+  CN_RESET,
+  CN_RESET_SETTINGS,
+  CN_RESET_SETTINGS_DONE,
+  CN_INFO
 };
 
 const char *const ru_pack[LABEL_NUM]={
@@ -476,6 +484,10 @@ const char *const ru_pack[LABEL_NUM]={
   RU_FILE_LISTMODE,
   RU_CURRENT_SETTING,
   RU_STEPS_SETTING,
+  RU_RESET,
+  RU_RESET_SETTINGS,
+  RU_RESET_SETTINGS_DONE,
+  RU_INFO  
 };
 
 const char *const jp_pack[LABEL_NUM]={
@@ -630,6 +642,10 @@ const char *const jp_pack[LABEL_NUM]={
   JP_FILE_LISTMODE,
   JP_CURRENT_SETTING,
   JP_STEPS_SETTING,
+  JP_RESET,
+  JP_RESET_SETTINGS,
+  JP_RESET_SETTINGS_DONE,
+  JP_INFO
 };
 
 const char *const am_pack[LABEL_NUM]={
@@ -784,6 +800,10 @@ const char *const am_pack[LABEL_NUM]={
   AM_FILE_LISTMODE,
   AM_CURRENT_SETTING,
   AM_STEPS_SETTING,
+  AM_RESET,
+  AM_RESET_SETTINGS,
+  AM_RESET_SETTINGS_DONE,
+  AM_INFO
 };
 
 const char *const de_pack[LABEL_NUM]={
@@ -938,6 +958,10 @@ const char *const de_pack[LABEL_NUM]={
   DE_FILE_LISTMODE,
   DE_CURRENT_SETTING,
   DE_STEPS_SETTING,
+  DE_RESET,
+  DE_RESET_SETTINGS,
+  DE_RESET_SETTINGS_DONE,
+  DE_INFO
 };
 
 const char *const cz_pack[LABEL_NUM]={
@@ -1092,6 +1116,10 @@ const char *const cz_pack[LABEL_NUM]={
   CZ_FILE_LISTMODE,
   CZ_CURRENT_SETTING,
   CZ_STEPS_SETTING,
+  CZ_RESET,
+  CZ_RESET_SETTINGS,
+  CZ_RESET_SETTINGS_DONE,
+  CZ_INFO
 };
 
 const char *const es_pack[LABEL_NUM]={
@@ -1246,6 +1274,10 @@ const char *const es_pack[LABEL_NUM]={
   ES_FILE_LISTMODE,
   ES_CURRENT_SETTING,
   ES_STEPS_SETTING,
+  ES_RESET,
+  ES_RESET_SETTINGS,
+  ES_RESET_SETTINGS_DONE,
+  ES_INFO
 };
 
 const char *const fr_pack[LABEL_NUM]={
@@ -1400,6 +1432,10 @@ const char *const fr_pack[LABEL_NUM]={
   FR_FILE_LISTMODE,
   FR_CURRENT_SETTING,
   FR_STEPS_SETTING,
+  FR_RESET,
+  FR_RESET_SETTINGS,
+  FR_RESET_SETTINGS_DONE,
+  FR_INFO
 };
 
 const char *const pt_pack[LABEL_NUM]={
@@ -1554,6 +1590,10 @@ const char *const pt_pack[LABEL_NUM]={
   PT_FILE_LISTMODE,
   PT_CURRENT_SETTING,
   PT_STEPS_SETTING,
+  PT_RESET,
+  PT_RESET_SETTINGS
+  PT_RESET_SETTINGS_DONE,
+  PT_INFO
 };
 
 const char *const it_pack[LABEL_NUM]={
@@ -1708,6 +1748,10 @@ const char *const it_pack[LABEL_NUM]={
   IT_FILE_LISTMODE,
   IT_CURRENT_SETTING,
   IT_STEPS_SETTING,
+  IT_RESET,
+  IT_RESET_SETTINGS,
+  IT_RESET_SETTINGS_DONE,
+  IT_INFO
 };
 
 const char *const pl_pack[LABEL_NUM]={
@@ -1862,6 +1906,10 @@ const char *const pl_pack[LABEL_NUM]={
   PL_FILE_LISTMODE,
   PL_CURRENT_SETTING,
   PL_STEPS_SETTING,
+  PL_RESET,
+  PL_RESET_SETTINGS,
+  PL_RESET_SETTINGS_DONE,
+  PL_INFO
 };
 
 const char *const sk_pack[LABEL_NUM]={
@@ -2016,6 +2064,10 @@ const char *const sk_pack[LABEL_NUM]={
   SK_FILE_LISTMODE,
   SK_CURRENT_SETTING,
   SK_STEPS_SETTING,
+  SK_RESET,
+  SK_RESET_SETTINGS,
+  SK_RESET_SETTINGS_DONE,
+  SK_INFO
 };
 
 const char *const du_pack[LABEL_NUM]={
@@ -2170,6 +2222,10 @@ const char *const du_pack[LABEL_NUM]={
   DU_FILE_LISTMODE,
   DU_CURRENT_SETTING,
   DU_STEPS_SETTING,
+  DU_RESET,
+  DU_RESET_SETTINGS,
+  DU_RESET_SETTINGS_DONE,
+  DU_INFO
 };
 
 const char *const hu_pack[LABEL_NUM]={

--- a/TFT/src/User/API/Language/Language.h
+++ b/TFT/src/User/API/Language/Language.h
@@ -179,6 +179,10 @@ enum
   LABEL_FILE_LISTMODE,
   LABEL_CURRENT_SETTING,
   LABEL_STEPS_SETTING,
+  LABEL_RESET,
+  LABEL_RESET_SETTINGS,
+  LABEL_RESET_SETTINGS_DONE,
+  LABEL_INFO,
   
   //add new keywords above this line only
   //keep the following always at the end of this list

--- a/TFT/src/User/API/Language/language_am.h
+++ b/TFT/src/User/API/Language/language_am.h
@@ -152,4 +152,9 @@
     #define AM_FILE_LISTMODE        "Files viewer List Mode"
     #define AM_CURRENT_SETTING      "Driver Current Settings"
     #define AM_STEPS_SETTING        "Steps per MM Settings"
+    #define AM_RESET                "Reset"
+    #define AM_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define AM_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define AM_INFO                 "Info"
+
 #endif

--- a/TFT/src/User/API/Language/language_cn.h
+++ b/TFT/src/User/API/Language/language_cn.h
@@ -152,5 +152,9 @@
     #define CN_FILE_LISTMODE        "文件浏览列表模式"
     #define CN_CURRENT_SETTING      "TMC驱动电流设置"
     #define CN_STEPS_SETTING        "电机每毫米脉冲数(Steps/mm)"
+    #define CN_RESET                "Reset"
+    #define CN_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define CN_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define CN_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_cz.h
+++ b/TFT/src/User/API/Language/language_cz.h
@@ -152,5 +152,9 @@
     #define CZ_FILE_LISTMODE        "Files viewer List Mode"
     #define CZ_CURRENT_SETTING      "Driver Current Settings"
     #define CZ_STEPS_SETTING        "Steps per MM Settings"
+    #define CZ_RESET                "Reset"
+    #define CZ_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define CZ_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define CZ_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_de.h
+++ b/TFT/src/User/API/Language/language_de.h
@@ -8,7 +8,7 @@
     #define DE_PRINT                "Drucken"
     #define DE_EXTRUDE              "Extruder"
     #define DE_FAN                  "Lüfter"
-    #define DE_SETTINGS             "Setup"
+    #define DE_SETTINGS             "Einstellung"
     #define DE_SCREEN_SETTINGS      "Bildschirm"
     #define DE_MACHINE_SETTINGS     "Drucker"
     #define DE_FEATURE_SETTINGS     "Feature"
@@ -130,7 +130,7 @@
     #define DE_UNIFIEDHEAT          "Heiz.Lüft."
     #define DE_COOLDOWN             "Abkühlen"
     #define DE_EMERGENCYSTOP        "NOT STOP!"
-    #define DE_TOUCH_TO_EXIT        "Zum verlassen, Bildschirm berühren"
+    #define DE_TOUCH_TO_EXIT        "Zum verlassen, Bildschirm berühren."
     #define DE_MAINMENU             "Menü"
     #define DE_WAIT_TEMP_SHUT_DOWN  "Warte bis Hotend-Temperatur unter " STRINGIFY(AUTO_SHUT_DOWN_MAXTEMP) "℃ fällt." // Wait for the temperature of hotend to be lower than 50℃
     #define DE_FORCE_SHUT_DOWN      "Erzwinge"
@@ -146,11 +146,15 @@
     #define DE_MOVE_SPEED           "Geschwindigkeit (XYZ)"
     #define DE_KNOB_LED             "Drehknopf LED Farbe"
     #define DE_M0_PAUSE             "Pause durch M0 kommando"
-    #define DE_SEND_START_GCODE     "Start-Gcode vor druck"
-    #define DE_SEND_END_GCODE       "End-Gcode nach druck"
+    #define DE_SEND_START_GCODE     "Start-Gcode vor Druck"
+    #define DE_SEND_END_GCODE       "End-Gcode nach Druck"
     #define DE_PERSISTANT_STATUS_INFO "Speicherungs-status Information"
     #define DE_FILE_LISTMODE        "Datei-Ansicht als Liste"
     #define DE_CURRENT_SETTING      "Driver Current Settings"
     #define DE_STEPS_SETTING        "Steps per MM Settings"
-    
+    #define DE_RESET                "Resetten"
+    #define DE_RESET_SETTINGS       "Hiermit werden alle Einstellungen auf Werkseinstellungen zurückgesetzt. Fortfahren?"
+    #define DE_RESET_SETTINGS_DONE  "Einstellungen wurden erfolgreich zurückgesetzt. Bitte starten Sie das Gerät neu."
+    #define DE_INFO                 "Info"
+
 #endif

--- a/TFT/src/User/API/Language/language_du.h
+++ b/TFT/src/User/API/Language/language_du.h
@@ -152,5 +152,9 @@
     #define DU_FILE_LISTMODE        "Files viewer List Mode"
     #define DU_CURRENT_SETTING      "Driver Current Settings"
     #define DU_STEPS_SETTING        "Steps per MM Settings"
+    #define DU_RESET                "Reset"
+    #define DU_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define DU_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define DU_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_en.h
+++ b/TFT/src/User/API/Language/language_en.h
@@ -105,7 +105,7 @@
     #define EN_ADJUST_FAILED        "Adjustment failed, Please Try Again"
     #define EN_WARNING              "Warning"
     #define EN_STOP_PRINT           "Stop printing?"
-    #define EN_CONFIRM              "Confirm"
+    #define EN_CONFIRM              "OK"                // String: Confirm - Usually reinterpreted and used as OK, so lets do it so.   
     #define EN_TFTSD                "TFT SD"
     #define EN_READ_TFTSD_ERROR     "Read TFT SD card error!"
     #define EN_TFTSD_INSERTED       "Card inserted!"
@@ -152,6 +152,9 @@
     #define EN_FILE_LISTMODE        "Files viewer List Mode"
     #define EN_CURRENT_SETTING      "Driver Current Settings"
     #define EN_STEPS_SETTING        "Steps per MM Settings"
-    
+    #define EN_RESET                "Reset"
+    #define EN_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define EN_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define EN_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_es.h
+++ b/TFT/src/User/API/Language/language_es.h
@@ -152,5 +152,9 @@
     #define ES_FILE_LISTMODE        "Files viewer List Mode"
     #define ES_CURRENT_SETTING      "Driver Current Settings"
     #define ES_STEPS_SETTING        "Steps per MM Settings"
+    #define ES_RESET                "Reset"
+    #define ES_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define ES_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define ES_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_fr.h
+++ b/TFT/src/User/API/Language/language_fr.h
@@ -152,5 +152,9 @@
     #define FR_FILE_LISTMODE        "Files viewer List Mode"
     #define FR_CURRENT_SETTING      "Driver Current Settings"
     #define FR_STEPS_SETTING        "Steps per MM Settings"
+    #define FR_RESET                "Reset"
+    #define FR_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define FR_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define FR_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_it.h
+++ b/TFT/src/User/API/Language/language_it.h
@@ -152,5 +152,9 @@
     #define IT_FILE_LISTMODE        "Files viewer List Mode"
     #define IT_CURRENT_SETTING      "Driver Current Settings"
     #define IT_STEPS_SETTING        "Steps per MM Settings"
+    #define IT_RESET                "Reset"
+    #define IT_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define IT_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define IT_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_jp.h
+++ b/TFT/src/User/API/Language/language_jp.h
@@ -152,5 +152,9 @@
     #define JP_FILE_LISTMODE        "Files viewer List Mode"
     #define JP_CURRENT_SETTING      "Driver Current Settings"
     #define JP_STEPS_SETTING        "Steps per MM Settings"
-    
+    #define JP_RESET                "Reset"
+    #define JP_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define JP_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define JP_INFO                 "Info"
+
 #endif

--- a/TFT/src/User/API/Language/language_pl.h
+++ b/TFT/src/User/API/Language/language_pl.h
@@ -152,5 +152,9 @@
     #define PL_FILE_LISTMODE        "Files viewer List Mode"
     #define PL_CURRENT_SETTING      "Driver Current Settings"
     #define PL_STEPS_SETTING        "Steps per MM Settings"
+    #define PL_RESET                "Reset"
+    #define PL_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define PL_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define PL_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_pt.h
+++ b/TFT/src/User/API/Language/language_pt.h
@@ -152,5 +152,9 @@
     #define PT_FILE_LISTMODE        "Files viewer List Mode"
     #define PT_CURRENT_SETTING      "Driver Current Settings"
     #define PT_STEPS_SETTING        "Steps per MM Settings"
+    #define PT_RESET                "Reset"
+    #define PT_RESET_SETTINGS       "All settings will be reset to it's default values. Continue?"
+    #define PT_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define PT_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_ru.h
+++ b/TFT/src/User/API/Language/language_ru.h
@@ -152,5 +152,9 @@
     #define RU_FILE_LISTMODE          "Файлы в режиме строк"
     #define RU_CURRENT_SETTING        "Настройка TMC драйверов"
     #define RU_STEPS_SETTING          "Настройка шагов на mm"
+    #define RU_RESET                  "Reset"
+    #define RU_RESET_SETTINGS         "All settings will be reset to it's default values. Continue?"
+    #define RU_RESET_SETTINGS_DONE    "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define RU_INFO                   "Info"
 
 #endif

--- a/TFT/src/User/API/Language/language_sk.h
+++ b/TFT/src/User/API/Language/language_sk.h
@@ -152,5 +152,9 @@
     #define SK_FILE_LISTMODE        "Files viewer List Mode"
     #define SK_CURRENT_SETTING      "Driver Current Settings"
     #define SK_STEPS_SETTING        "Steps per MM Settings"
+    #define SK_RESET                "Reset"
+    #define SK_RESET_SETTINGS       "All Settings will be reset to default Setting."
+    #define SK_RESET_SETTINGS_DONE  "Resetting all settings successfully done. To take full effect, please restart the device."
+    #define SK_INFO                 "Info"
 
 #endif

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -43,9 +43,6 @@ const LABEL itemMoveSpeed[ITEM_SPEED_NUM] = {
                                             };
 const  u8 item_movespeed[ITEM_SPEED_NUM] = {LABEL_NORMAL_SPEED, LABEL_SLOW_SPEED, LABEL_FAST_SPEED};
 
-#define ACTION_NUM   1
-const LABEL itemAction[ACTION_NUM]       = {LABEL_RESET};
-
 //
 //add key number index of the items
 //

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -234,7 +234,6 @@ void updateFeatureSettings(uint8_t key_val)
     #endif
 
     case SKEY_RESET_SETTINGS:
-    settingPage[item_index].valueLabel = itemAction[0];
     infoMenu.menu[++infoMenu.cur] = menuResetSettings;
     menuDrawListItem(&featureSettingsItems.items[key_val], key_val);
     break;

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -311,7 +311,6 @@ void loadFeatureSettings(){
         featureSettingsItems.items[i] = settingPage[item_index];
         break;
       case SKEY_RESET_SETTINGS:
-        settingPage[item_index].valueLabel = itemAction[0];
         featureSettingsItems.items[i] = settingPage[item_index];
         break;
       #ifdef LED_color_PIN

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -83,10 +83,14 @@ void menuPopup(void)
   }
 }
 
-void popupReminder(u8* info, u8* context)
+void popupReminder(u8* info, u8* context) { 
+  popupReminderIgnoreLCDMode(info, context, FALSE);
+}
+
+void popupReminderIgnoreLCDMode(u8* info, u8* context, const u8 ignore_lcd_mode)
 {
   #ifdef CLEAN_MODE_SWITCHING_SUPPORT
-    if (infoSettings.mode == LCD12864) return;
+    if (infoSettings.mode == LCD12864 && !ignore_lcd_mode) return;
   #endif
   popupDrawPage(&bottomSingleBtn , info, context, textSelect(LABEL_CONFIRM), NULL);
   if(infoMenu.menu[infoMenu.cur] != menuPopup)

--- a/TFT/src/User/Menu/Popup.h
+++ b/TFT/src/User/Menu/Popup.h
@@ -41,6 +41,7 @@ extern WINDOW window;
 void windowSetButton(const BUTTON *btn);
 void windowReDrawButton(uint8_t positon, uint8_t is_press);
 void popupDrawPage(BUTTON *btn, const uint8_t *title, const uint8_t *context, const uint8_t *yes, const uint8_t *no);
+void popupReminderIgnoreLCDMode(u8* info, u8* context, const u8 ignore_lcd_mode);
 void popupReminder(u8* info, u8* context);
 
 #endif


### PR DESCRIPTION
Able to reset the customer setting from the menu. It will bring a waring dialog to ensure to reset by mistake.  So no need to add a file to sd-card to reset the settings. Ignore lcd mode only if you reset all settings and to show the info dialog. Otherwise, it won't show if you currently in CLEAN_MODE_SWITCHING_SUPPORT.