### PR TITLE
Update 'Stop' button to 'Back' when print is finished

### DIFF
--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -672,6 +672,9 @@ void endPrinting(void)
   if(infoSettings.send_end_gcode == 1){
     endGcodeExecute();
   }
+  printingItems.items[KEY_ICON_7].icon = ICON_BACK;
+  printingItems.items[KEY_ICON_7].label.index = LABEL_BACK;
+  menuDrawItem(&printingItems.items[KEY_ICON_7], KEY_ICON_7);
 }
 
 


### PR DESCRIPTION
### Description

When print is finished on unified menu, the screen still show the 'Stop' button (which is not logical) and when you click on it it will go to the previous screen.
Now the button decoration is changes to 'Back'.

### Benefits

* Visually showing on the screen that the print is finished
* Showing real effect of the button
