### PR TITLE
Fix TFT35 E3 V3 backlight timeout

### DIFF
--- a/TFT/src/User/Hal/LCD_Init.c
+++ b/TFT/src/User/Hal/LCD_Init.c
@@ -104,7 +104,7 @@ void LCD_Dim_Idle_Timer()
 
 void LCD_LED_PWM_Init()
 {
-#if defined(TFT35_V1_2) || defined(TFT35_V2_0) || defined(TFT35_V3_0)
+#if LCD_DRIVER_IS(ILI9488)
   GPIO_InitSet(LCD_LED_PIN, MGPIO_MODE_AF_PP, GPIO_AF_TIM4);
 
   TIM_OCInitTypeDef outputChannelInit = {0,};

--- a/TFT/src/User/Hal/LCD_Init.h
+++ b/TFT/src/User/Hal/LCD_Init.h
@@ -52,7 +52,7 @@
   void LCD_Dim_Idle_Timer(void);
   void LCD_LED_PWM_Init(void);
 
-  #if defined(TFT35_V1_2) || defined(TFT35_V2_0) || defined(TFT35_V3_0)
+  #if LCD_DRIVER_IS(ILI9488)
     #define Set_LCD_Brightness(level) TIM4->CCR1= (uint32_t)(level * (F_CPUM/100));
   #else
     #define Set_LCD_Brightness(level) ;


### PR DESCRIPTION
### Description

Due to the introduction of `BIGTREE_TFT35_E3_V3_0` variant, some code was not being enabled properly to allow the backlight timeout feature to work on the TFT35 E3 V3.

The TFT type was simplified with the `LCD_DRIVER_IS()` macro, so I switched out the `if` statements to include all the compatible TFTs (`TFT35_V1_2`, `TFT35_V2_0`, `TFT35_V3_0`, and `TFT35_E3_V3_0`).

Changes were verified on a TFT35 V3 and TFT35 E3 V3.

### Benefits

Backlight timeout works on the TFT35 E3 V3.

### Related Issues

None.