### PR TITLE
improve LCD led control, add common PWM Hal library

### DIFF
--- a/TFT/src/User/API/LCD_Encoder.c
+++ b/TFT/src/User/API/LCD_Encoder.c
@@ -107,7 +107,9 @@ void LCD_loopCheckEncoder() {
   if(LCD_CheckEncoderState() ||           // Check for any encoder changes
      LCD_ReadBtn(LCD_BUTTON_INTERVALS))   // Check for encoder button press
   {
-    LCD_Dim_Idle_Timer_Reset();           // Reset LCD dim idle timer if enabled.
+    #ifdef LCD_LED_PWM_CHANNEL
+      LCD_Dim_Idle_Timer_Reset();           // Reset LCD dim idle timer if enabled.
+    #endif
   }
 }
 

--- a/TFT/src/User/API/UI/touch_process.c
+++ b/TFT/src/User/API/UI/touch_process.c
@@ -158,7 +158,7 @@ void loopTouchScreen(void) // Handle in interrupt
     if(touch >= 20) // 20ms
     {
       touchScreenIsPress = true;
-      #ifdef LCD_LED_PIN
+      #ifdef LCD_LED_PWM_CHANNEL
         LCD_Dim_Idle_Timer_Reset();
       #endif
     }
@@ -171,7 +171,7 @@ void loopTouchScreen(void) // Handle in interrupt
   {
     touchScreenIsPress = false;
     touch = 0;
-    #ifdef LCD_LED_PIN
+    #ifdef LCD_LED_PWM_CHANNEL
       LCD_Dim_Idle_Timer();
     #endif
   }

--- a/TFT/src/User/API/flashStore.c
+++ b/TFT/src/User/API/flashStore.c
@@ -74,7 +74,7 @@ bool readStoredPara(void)
     infoSettings.persistent_info     = byteToWord(data + (index += 4), 4);
     infoSettings.file_listmode       = byteToWord(data + (index += 4), 4);
     infoSettings.knob_led_color      = byteToWord(data + (index += 4), 4);
-    #ifdef LCD_LED_PIN
+    #ifdef LCD_LED_PWM_CHANNEL
     infoSettings.lcd_brightness      = byteToWord(data + (index += 4), 4);
     infoSettings.lcd_idle_brightness = byteToWord(data + (index += 4), 4);
     infoSettings.lcd_idle_timer      = byteToWord(data + (index += 4), 4);
@@ -115,7 +115,7 @@ void storePara(void)
   wordToByte(infoSettings.persistent_info,    data + (index += 4));
   wordToByte(infoSettings.file_listmode,      data + (index += 4));
   wordToByte(infoSettings.knob_led_color,     data + (index += 4));
-  #ifdef LCD_LED_PIN
+  #ifdef LCD_LED_PWM_CHANNEL
   wordToByte(infoSettings.lcd_brightness,      data + (index += 4));
   wordToByte(infoSettings.lcd_idle_brightness, data + (index += 4));
   wordToByte(infoSettings.lcd_idle_timer,      data + (index += 4));

--- a/TFT/src/User/Hal/LCD_Init.h
+++ b/TFT/src/User/Hal/LCD_Init.h
@@ -5,7 +5,7 @@
 #include "variants.h"
 #include "menu.h"
 
-#ifdef LCD_LED_PIN
+#ifdef LCD_LED_PWM_CHANNEL
   #define LCD_5_PERCENT    5
   #define LCD_10_PERCENT   10
   #define LCD_20_PERCENT   20
@@ -52,12 +52,8 @@
   void LCD_Dim_Idle_Timer(void);
   void LCD_LED_PWM_Init(void);
 
-  #if defined(TFT35_V1_2) || defined(TFT35_V2_0) || defined(TFT35_V3_0)
-    #define Set_LCD_Brightness(level) TIM4->CCR1= (uint32_t)(level * (F_CPUM/100));
-  #else
-    #define Set_LCD_Brightness(level) ;
-  #endif
-#endif //LCD_LED_PIN
+   #define Set_LCD_Brightness(percentage) TIM_PWM_SetDutyCycle(LCD_LED_PWM_CHANNEL, percentage)
+#endif // LCD_LED_PWM_CHANNEL
 
 //TFT35 V1.0 V1.1 RM68042 8bit
 //TFT35 V1.2 ili9488 16bit

--- a/TFT/src/User/Hal/stm32f10x/timer_pwm.c
+++ b/TFT/src/User/Hal/stm32f10x/timer_pwm.c
@@ -1,0 +1,59 @@
+#include "timer_pwm.h"
+
+typedef struct {
+  TIM_TypeDef* tim;
+  volatile uint32_t* rcc_src;
+  uint8_t rcc_bit;
+}TIMER;
+
+static const TIMER pwmTimer[_TIM_CNT] = {
+  {TIM1,  &RCC->APB2ENR, 11}, // Timer1  APB2 bit11
+  {TIM2,  &RCC->APB1ENR, 0},  // Timer2  APB1 bit0
+  {TIM3,  &RCC->APB1ENR, 1},  // Timer3  APB1 bit1
+  {TIM4,  &RCC->APB1ENR, 2},  // Timer4  APB1 bit2
+  {TIM5,  &RCC->APB1ENR, 3},  // Timer5  APB1 bit3
+  {TIM6,  &RCC->APB1ENR, 4},  // Timer6  APB1 bit4
+  {TIM7,  &RCC->APB1ENR, 5},  // Timer7  APB1 bit5
+  {TIM8,  &RCC->APB2ENR, 13}, // Timer8  APB2 bit13
+};
+
+void TIM_PWM_SetDutyCycle(uint16_t tim_ch, uint8_t duty)
+{
+  uint16_t timerIndex = TIMER_GET_TIM(tim_ch);
+  uint16_t channel = TIMER_GET_CH(tim_ch);
+  const TIMER* timer = &pwmTimer[timerIndex];
+  switch (channel) {
+    case 0: timer->tim->CCR1 = duty; break;
+    case 1: timer->tim->CCR2 = duty; break;
+    case 2: timer->tim->CCR3 = duty; break;
+    case 3: timer->tim->CCR4 = duty; break;
+  }
+}
+
+void TIM_PWM_Init(uint16_t tim_ch)
+{
+  uint16_t timerIndex = TIMER_GET_TIM(tim_ch);
+  uint16_t channel = TIMER_GET_CH(tim_ch);
+  const TIMER* timer = &pwmTimer[timerIndex];
+
+  *timer->rcc_src |= (1 << timer->rcc_bit); // Enable timer clock
+
+  // Set PWM frequency to 10kHz
+  timer->tim->ARR = 100 - 1;
+  timer->tim->PSC = F_CPUM - 1;
+
+  switch (channel) {
+    case 0: timer->tim->CCMR1 |= (6<<4)  | (1<<3);   break; // CH1 PWM1 mode
+    case 1: timer->tim->CCMR1 |= (6<<12) | (1<<11);  break; // CH2 PWM1 mode
+    case 2: timer->tim->CCMR2 |= (6<<4)  | (1<<3);   break; // CH3 PWM1 mode
+    case 3: timer->tim->CCMR2 |= (6<<12) | (1<<11);  break; // CH4 PWM1 mode
+  }
+
+  timer->tim->CCER |= 1 << (4 * channel);
+  timer->tim->CR1 = (1 << 7)  // Auto-reload preload enable
+                  | (1 << 0); // Enbale timer
+
+  if (timer->tim == TIM1 || timer->tim == TIM8) {// TIM1 & TIM8 advanced timer need config BDTR register for PWM
+    timer->tim->BDTR |= 1 << 15; // Main output enable
+  }
+}

--- a/TFT/src/User/Hal/stm32f10x/timer_pwm.h
+++ b/TFT/src/User/Hal/stm32f10x/timer_pwm.h
@@ -1,0 +1,62 @@
+#ifndef _TIMER_PWM_H_
+#define _TIMER_PWM_H_
+
+#include "stm32f10x.h"
+
+#define _TIM1    0
+#define _TIM2    1
+#define _TIM3    2
+#define _TIM4    3
+#define _TIM5    4
+#define _TIM6    5 // NOTE: TIM6 & TIM7 basic timer, can not PWM generation
+#define _TIM7    6
+#define _TIM8    7
+#define _TIM_CNT 8
+
+#define _TIM1_CH1  (((_TIM1)<<8) + 0)
+#define _TIM1_CH2  (((_TIM1)<<8) + 1)
+#define _TIM1_CH3  (((_TIM1)<<8) + 2)
+#define _TIM1_CH4  (((_TIM1)<<8) + 3)
+
+#define _TIM2_CH1  (((_TIM2)<<8) + 0)
+#define _TIM2_CH2  (((_TIM2)<<8) + 1)
+#define _TIM2_CH3  (((_TIM2)<<8) + 2)
+#define _TIM2_CH4  (((_TIM2)<<8) + 3)
+
+#define _TIM3_CH1  (((_TIM3)<<8) + 0)
+#define _TIM3_CH2  (((_TIM3)<<8) + 1)
+#define _TIM3_CH3  (((_TIM3)<<8) + 2)
+#define _TIM3_CH4  (((_TIM3)<<8) + 3)
+
+#define _TIM4_CH1  (((_TIM4)<<8) + 0)
+#define _TIM4_CH2  (((_TIM4)<<8) + 1)
+#define _TIM4_CH3  (((_TIM4)<<8) + 2)
+#define _TIM4_CH4  (((_TIM4)<<8) + 3)
+
+#define _TIM5_CH1  (((_TIM5)<<8) + 0)
+#define _TIM5_CH2  (((_TIM5)<<8) + 1)
+#define _TIM5_CH3  (((_TIM5)<<8) + 2)
+#define _TIM5_CH4  (((_TIM5)<<8) + 3)
+
+#define _TIM6_CH1  (((_TIM6)<<8) + 0)
+#define _TIM6_CH2  (((_TIM6)<<8) + 1)
+#define _TIM6_CH3  (((_TIM6)<<8) + 2)
+#define _TIM6_CH4  (((_TIM6)<<8) + 3)
+
+#define _TIM7_CH1  (((_TIM7)<<8) + 0)
+#define _TIM7_CH2  (((_TIM7)<<8) + 1)
+#define _TIM7_CH3  (((_TIM7)<<8) + 2)
+#define _TIM7_CH4  (((_TIM7)<<8) + 3)
+
+#define _TIM8_CH1  (((_TIM8)<<8) + 0)
+#define _TIM8_CH2  (((_TIM8)<<8) + 1)
+#define _TIM8_CH3  (((_TIM8)<<8) + 2)
+#define _TIM8_CH4  (((_TIM8)<<8) + 3)
+
+#define TIMER_GET_TIM(n) ((n>>8) & 0xFF)
+#define TIMER_GET_CH(n) (n & 0xFF)
+
+void TIM_PWM_SetDutyCycle(uint16_t tim_ch, uint8_t duty);
+void TIM_PWM_Init(uint16_t tim_ch);
+
+#endif

--- a/TFT/src/User/Hal/stm32f2xx/timer_pwm.c
+++ b/TFT/src/User/Hal/stm32f2xx/timer_pwm.c
@@ -1,0 +1,65 @@
+#include "timer_pwm.h"
+
+typedef struct {
+  TIM_TypeDef* tim;
+  volatile uint32_t* rcc_src;
+  uint8_t rcc_bit;
+}TIMER;
+
+static const TIMER pwmTimer[_TIM_CNT] = {
+  {TIM1,  &RCC->APB2ENR, 0},  // Timer1  APB2 bit0
+  {TIM2,  &RCC->APB1ENR, 0},  // Timer2  APB1 bit0
+  {TIM3,  &RCC->APB1ENR, 1},  // Timer3  APB1 bit1
+  {TIM4,  &RCC->APB1ENR, 2},  // Timer4  APB1 bit2
+  {TIM5,  &RCC->APB1ENR, 3},  // Timer5  APB1 bit3
+  {TIM6,  &RCC->APB1ENR, 4},  // Timer6  APB1 bit4
+  {TIM7,  &RCC->APB1ENR, 5},  // Timer7  APB1 bit5
+  {TIM8,  &RCC->APB2ENR, 1},  // Timer8  APB2 bit1
+  {TIM9,  &RCC->APB2ENR, 16}, // Timer9  APB2 bit16
+  {TIM10, &RCC->APB2ENR, 17}, // Timer10 APB2 bit17
+  {TIM11, &RCC->APB2ENR, 18}, // Timer11 APB2 bit18
+  {TIM12, &RCC->APB1ENR, 6},  // Timer12 APB1 bit6
+  {TIM13, &RCC->APB1ENR, 7},  // Timer13 APB1 bit7
+  {TIM14, &RCC->APB1ENR, 8},  // Timer14 APB1 bit8
+};
+
+void TIM_PWM_SetDutyCycle(uint16_t tim_ch, uint8_t duty)
+{
+  uint16_t timerIndex = TIMER_GET_TIM(tim_ch);
+  uint16_t channel = TIMER_GET_CH(tim_ch);
+  const TIMER* timer = &pwmTimer[timerIndex];
+  switch (channel) {
+    case 0: timer->tim->CCR1 = duty; break;
+    case 1: timer->tim->CCR2 = duty; break;
+    case 2: timer->tim->CCR3 = duty; break;
+    case 3: timer->tim->CCR4 = duty; break;
+  }
+}
+
+void TIM_PWM_Init(uint16_t tim_ch)
+{
+  uint16_t timerIndex = TIMER_GET_TIM(tim_ch);
+  uint16_t channel = TIMER_GET_CH(tim_ch);
+  const TIMER* timer = &pwmTimer[timerIndex];
+
+  *timer->rcc_src |= (1 << timer->rcc_bit); // Enable timer clock
+
+  // Set PWM frequency to 10kHz
+  timer->tim->ARR = 100 - 1;
+  timer->tim->PSC = F_CPUM - 1;
+
+  switch (channel) {
+    case 0: timer->tim->CCMR1 |= (6<<4)  | (1<<3);   break; // CH1 PWM1 mode
+    case 1: timer->tim->CCMR1 |= (6<<12) | (1<<11);  break; // CH2 PWM1 mode
+    case 2: timer->tim->CCMR2 |= (6<<4)  | (1<<3);   break; // CH3 PWM1 mode
+    case 3: timer->tim->CCMR2 |= (6<<12) | (1<<11);  break; // CH4 PWM1 mode
+  }
+
+  timer->tim->CCER |= 1 << (4 * channel);
+  timer->tim->CR1 = (1 << 7)  // Auto-reload preload enable
+                  | (1 << 0); // Enbale timer
+
+  if (timer->tim == TIM1 || timer->tim == TIM8) {// TIM1 & TIM8 advanced timer need config BDTR register for PWM
+    timer->tim->BDTR |= 1 << 15; // Main output enable
+  }
+}

--- a/TFT/src/User/Hal/stm32f2xx/timer_pwm.h
+++ b/TFT/src/User/Hal/stm32f2xx/timer_pwm.h
@@ -1,0 +1,104 @@
+#ifndef _TIMER_PWM_H_
+#define _TIMER_PWM_H_
+
+#include "stm32f2xx.h"
+
+#define _TIM1    0
+#define _TIM2    1
+#define _TIM3    2
+#define _TIM4    3
+#define _TIM5    4
+#define _TIM6    5 // NOTE: TIM6 & TIM7 basic timer, can not PWM generation
+#define _TIM7    6
+#define _TIM8    7
+#define _TIM9    8
+#define _TIM10   9
+#define _TIM11   10
+#define _TIM12   11
+#define _TIM13   12
+#define _TIM14   13
+#define _TIM15   14
+#define _TIM_CNT 15
+
+#define _TIM1_CH1  (((_TIM1)<<8) + 0)
+#define _TIM1_CH2  (((_TIM1)<<8) + 1)
+#define _TIM1_CH3  (((_TIM1)<<8) + 2)
+#define _TIM1_CH4  (((_TIM1)<<8) + 3)
+
+#define _TIM2_CH1  (((_TIM2)<<8) + 0)
+#define _TIM2_CH2  (((_TIM2)<<8) + 1)
+#define _TIM2_CH3  (((_TIM2)<<8) + 2)
+#define _TIM2_CH4  (((_TIM2)<<8) + 3)
+
+#define _TIM3_CH1  (((_TIM3)<<8) + 0)
+#define _TIM3_CH2  (((_TIM3)<<8) + 1)
+#define _TIM3_CH3  (((_TIM3)<<8) + 2)
+#define _TIM3_CH4  (((_TIM3)<<8) + 3)
+
+#define _TIM4_CH1  (((_TIM4)<<8) + 0)
+#define _TIM4_CH2  (((_TIM4)<<8) + 1)
+#define _TIM4_CH3  (((_TIM4)<<8) + 2)
+#define _TIM4_CH4  (((_TIM4)<<8) + 3)
+
+#define _TIM5_CH1  (((_TIM5)<<8) + 0)
+#define _TIM5_CH2  (((_TIM5)<<8) + 1)
+#define _TIM5_CH3  (((_TIM5)<<8) + 2)
+#define _TIM5_CH4  (((_TIM5)<<8) + 3)
+
+#define _TIM6_CH1  (((_TIM6)<<8) + 0)
+#define _TIM6_CH2  (((_TIM6)<<8) + 1)
+#define _TIM6_CH3  (((_TIM6)<<8) + 2)
+#define _TIM6_CH4  (((_TIM6)<<8) + 3)
+
+#define _TIM7_CH1  (((_TIM7)<<8) + 0)
+#define _TIM7_CH2  (((_TIM7)<<8) + 1)
+#define _TIM7_CH3  (((_TIM7)<<8) + 2)
+#define _TIM7_CH4  (((_TIM7)<<8) + 3)
+
+#define _TIM8_CH1  (((_TIM8)<<8) + 0)
+#define _TIM8_CH2  (((_TIM8)<<8) + 1)
+#define _TIM8_CH3  (((_TIM8)<<8) + 2)
+#define _TIM8_CH4  (((_TIM8)<<8) + 3)
+
+#define _TIM9_CH1  (((_TIM9)<<8) + 0)
+#define _TIM9_CH2  (((_TIM9)<<8) + 1)
+#define _TIM9_CH3  (((_TIM9)<<8) + 2)
+#define _TIM9_CH4  (((_TIM9)<<8) + 3)
+
+#define _TIM10_CH1 (((_TIM10)<<8) + 0)
+#define _TIM10_CH2 (((_TIM10)<<8) + 1)
+#define _TIM10_CH3 (((_TIM10)<<8) + 2)
+#define _TIM10_CH4 (((_TIM10)<<8) + 3)
+
+#define _TIM11_CH1 (((_TIM11)<<8) + 0)
+#define _TIM11_CH2 (((_TIM11)<<8) + 1)
+#define _TIM11_CH3 (((_TIM11)<<8) + 2)
+#define _TIM11_CH4 (((_TIM11)<<8) + 3)
+
+#define _TIM12_CH1 (((_TIM12)<<8) + 0)
+#define _TIM12_CH2 (((_TIM12)<<8) + 1)
+#define _TIM12_CH3 (((_TIM12)<<8) + 2)
+#define _TIM12_CH4 (((_TIM12)<<8) + 3)
+
+#define _TIM13_CH1 (((_TIM13)<<8) + 0)
+#define _TIM13_CH2 (((_TIM13)<<8) + 1)
+#define _TIM13_CH3 (((_TIM13)<<8) + 2)
+#define _TIM13_CH4 (((_TIM13)<<8) + 3)
+
+#define _TIM14_CH1 (((_TIM14)<<8) + 0)
+#define _TIM14_CH2 (((_TIM14)<<8) + 1)
+#define _TIM14_CH3 (((_TIM14)<<8) + 2)
+#define _TIM14_CH4 (((_TIM14)<<8) + 3)
+
+#define _TIM15_CH1 (((_TIM15)<<8) + 0)
+#define _TIM15_CH2 (((_TIM15)<<8) + 1)
+#define _TIM15_CH3 (((_TIM15)<<8) + 2)
+#define _TIM15_CH4 (((_TIM15)<<8) + 3)
+
+#define TIMER_GET_TIM(n) ((n>>8) & 0xFF)
+#define TIMER_GET_CH(n) (n & 0xFF)
+
+void TIM_PWM_SetDutyCycle(uint16_t tim_ch, uint8_t duty);
+void TIM_PWM_Init(uint16_t tim_ch);
+
+#endif

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -66,7 +66,7 @@ void infoMenuSelect(void)
         Buzzer_DeConfig();  // Disable buzzer in LCD12864 Simulations mode.
       #endif
 
-      #ifdef LED_color_PIN
+      #ifdef LED_COLOR_PIN
         #ifndef KEEP_KNOB_LED_COLOR_MARLIN_MODE
           knob_LED_DeInit();
         #endif

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -26,7 +26,7 @@ void infoSettingsReset(void)
   infoSettings.send_end_gcode       = 0;
   infoSettings.persistent_info      = 1;
   infoSettings.file_listmode        = 1;
-  #ifdef LCD_LED_PIN
+  #ifdef LCD_LED_PWM_CHANNEL
   infoSettings.lcd_brightness       = (DEFAULT_LCD_BRIGHTNESS - 1);
   infoSettings.lcd_idle_brightness  = (DEFAULT_LCD_IDLE_BRIGHTNESS - 1);
   infoSettings.lcd_idle_timer       = (DEFAULT_LCD_IDLE_TIMER - 1);

--- a/TFT/src/User/Menu/Settings.h
+++ b/TFT/src/User/Menu/Settings.h
@@ -26,7 +26,7 @@ typedef struct
   uint8_t  invert_axis[TOTAL_AXIS];
   uint8_t  move_speed;
   uint8_t  knob_led_color;
-  #ifdef LCD_LED_PIN
+  #ifdef LCD_LED_PWM_CHANNEL
   uint8_t  lcd_brightness;
   uint8_t  lcd_idle_brightness;
   uint8_t  lcd_idle_timer;

--- a/TFT/src/User/Menu/ledcolor.c
+++ b/TFT/src/User/Menu/ledcolor.c
@@ -3,7 +3,7 @@
 #include "includes.h"
 
 
-#ifdef LED_color_PIN
+#ifdef LED_COLOR_PIN
 
 //preset color list
   const LABEL itemLedcolor[LED_color_NUM] = {
@@ -35,8 +35,8 @@ void knob_LED_Init(void) // 12 11
 {
     uint16_t psc = _PSC;
     uint16_t arr = _ARR;
-    GPIO_InitSet(LED_color_PIN,MGPIO_MODE_OUT_PP,0);
-    GPIO_SetLevel(LED_color_PIN,0);
+    GPIO_InitSet(LED_COLOR_PIN,MGPIO_MODE_OUT_PP,0);
+    GPIO_SetLevel(LED_COLOR_PIN,0);
 	//Turn on the clock
 	RCC->APB1ENR|=1<<4;//TIM6Clock enable
 	//Reset
@@ -53,7 +53,7 @@ void knob_LED_Init(void) // 12 11
 
 void knob_LED_DeInit(void)
 {
-    GPIO_InitSet(LED_color_PIN,MGPIO_MODE_IPN,0);
+    GPIO_InitSet(LED_COLOR_PIN,MGPIO_MODE_IPN,0);
 }
 
 void set_knob_color(int color_index){
@@ -82,12 +82,12 @@ void ws2812_send_DAT(uint32_t ws2812_dat)
             TIM6->ARR=3;
             now_flag=3;
             }
-            GPIO_SetLevel(LED_color_PIN,1);
+            GPIO_SetLevel(LED_COLOR_PIN,1);
             while(!(TIM6->SR)){};
             TIM6->CNT=0;
             TIM6->SR=0;
             TIM6->ARR=11-now_flag;
-            GPIO_SetLevel(LED_color_PIN,0);
+            GPIO_SetLevel(LED_COLOR_PIN,0);
             while(!(TIM6->SR)){};
             ws2812_dat<<=1;
         }

--- a/TFT/src/User/Menu/ledcolor.h
+++ b/TFT/src/User/Menu/ledcolor.h
@@ -153,7 +153,7 @@
 #define COLOR_BLACK                 0x000000
 
 //preset color list
-#ifdef LED_color_PIN
+#ifdef LED_COLOR_PIN
   #define _PSC  6 //presacler register
   #define _ARR  5 //reload value of the timer counter
 

--- a/TFT/src/User/SanityCheck.h
+++ b/TFT/src/User/SanityCheck.h
@@ -9,7 +9,7 @@
   #endif
 #endif
 
-#ifdef LED_color_PIN
+#ifdef LED_COLOR_PIN
   #ifdef STARTUP_KNOB_LED_COLOR
     #if STARTUP_KNOB_LED_COLOR < 1
     #error "STARTUP_knob_LED_COLOR cannot be less than 1"

--- a/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
@@ -35,7 +35,9 @@
 //#define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-#define LCD_LED_PIN   PD14
+#define LCD_LED_PIN            PD14
+#define LCD_LED_PIN_ALTERNATE  0
+#define LCD_LED_PWM_CHANNEL    _TIM4_CH3
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -99,6 +101,6 @@
   //#define FIL_RUNOUT_PIN PD11
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/pin_TFT24_V1_1.h
+++ b/TFT/src/User/Variants/pin_TFT24_V1_1.h
@@ -35,7 +35,9 @@
 #define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-#define LCD_LED_PIN   PA8
+#define LCD_LED_PIN            PA8
+#define LCD_LED_PIN_ALTERNATE  0
+#define LCD_LED_PWM_CHANNEL    _TIM1_CH1
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -95,6 +97,6 @@
   //#define FIL_RUNOUT_PIN PD11
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/pin_TFT35_E3_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_E3_V3_0.h
@@ -6,7 +6,7 @@
   #define HARDWARE_VERSION "TFT35_E3_V3.0"
 #endif
 
-#define LED_color_PIN PC7
+#define LED_COLOR_PIN PC7
 
 #include "pin_TFT35_V3_0.h"
 

--- a/TFT/src/User/Variants/pin_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V1_0.h
@@ -35,7 +35,9 @@
 //#define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-//#define LCD_LED_PIN   PA8
+//#define LCD_LED_PIN            PA8
+//#define LCD_LED_PIN_ALTERNATE  0
+//#define LCD_LED_PWM_CHANNEL    _TIM1_CH1
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -97,6 +99,6 @@
   //#define FIL_RUNOUT_PIN PD11
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/pin_TFT35_V2_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V2_0.h
@@ -35,7 +35,9 @@
 //#define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-//#define LCD_LED_PIN   PA8
+//#define LCD_LED_PIN            PA8
+//#define LCD_LED_PIN_ALTERNATE  0
+//#define LCD_LED_PWM_CHANNEL    _TIM1_CH1
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -99,6 +101,6 @@
   #define FIL_RUNOUT_PIN PD11
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/pin_TFT35_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V3_0.h
@@ -35,7 +35,9 @@
 //#define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-#define LCD_LED_PIN   PD12
+#define LCD_LED_PIN            PD12
+#define LCD_LED_PIN_ALTERNATE  GPIO_AF_TIM4
+#define LCD_LED_PWM_CHANNEL    _TIM4_CH1
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -95,6 +97,6 @@
   #define FIL_RUNOUT_PIN PA15
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/pin_Template.h
+++ b/TFT/src/User/Variants/pin_Template.h
@@ -35,7 +35,9 @@
 //#define DISABLE_DEBUG // free all pins
 
 // LCD Backlight pin (PWM can adjust brightness)
-//#define LCD_LED_PIN   PA8
+//#define LCD_LED_PIN            PA8
+//#define LCD_LED_PIN_ALTERNATE  0
+//#define LCD_LED_PWM_CHANNEL    _TIM1_CH1
 
 /*
  * SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
@@ -95,6 +97,6 @@
   //#define FIL_RUNOUT_PIN PD11
 #endif
 
-//#define LED_color_PIN PC7
+//#define LED_COLOR_PIN PC7
 
 #endif

--- a/TFT/src/User/Variants/variants.h
+++ b/TFT/src/User/Variants/variants.h
@@ -5,9 +5,9 @@
 
 /*
 * hardware source
-* TIM4 for OS Timer
 * TIM3 for Buzzer timer
 * TIM6 for Neopixel RGB
+* TIM7 for OS Timer
 */
 
 // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].

--- a/TFT/src/User/includes.h
+++ b/TFT/src/User/includes.h
@@ -27,6 +27,7 @@
 #include "spi.h"
 #include "sw_spi.h"
 #include "spi_slave.h"
+#include "timer_pwm.h"
 
 #include "usbh_core.h"
 #include "usbh_usr.h"

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -7,7 +7,7 @@ void Hardware_GenericInit(void)
 {
   NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
   Delay_init(F_CPUM);
-  OS_TimerInit(999, F_CPUM-1);  // System clock timer, cycle 1ms
+  OS_TimerInit(1000-1, F_CPUM-1);  // System clock timer, cycle 1ms
 
   #ifdef DISABLE_JTAG
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
@@ -46,7 +46,7 @@ void Hardware_GenericInit(void)
     FIL_Runout_Init();
   #endif
 
-  #ifdef LED_color_PIN
+  #ifdef LED_COLOR_PIN
     knob_LED_Init();
   #else
     #define STARTUP_KNOB_LED_COLOR 1
@@ -60,8 +60,8 @@ void Hardware_GenericInit(void)
     TSC_Calibration();
     storePara();
   }
-  #ifdef LCD_LED_PIN
-  Set_LCD_Brightness(LCD_BRIGHTNESS[infoSettings.lcd_brightness]);
+  #ifdef LCD_LED_PWM_CHANNEL
+    Set_LCD_Brightness(LCD_BRIGHTNESS[infoSettings.lcd_brightness]);
   #endif
   GUI_RestoreColorDefault();
   infoMenuSelect();

--- a/TFT/src/User/os_timer.c
+++ b/TFT/src/User/os_timer.c
@@ -8,24 +8,24 @@ void OS_TimerInit(uint16_t psc, uint16_t arr)
 {
   NVIC_InitTypeDef NVIC_InitStructure;
 
-  NVIC_InitStructure.NVIC_IRQChannel = TIM4_IRQn;
+  NVIC_InitStructure.NVIC_IRQChannel = TIM7_IRQn;
   NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 2;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
 
-  RCC->APB1ENR |= 1<<2;
-  TIM4->ARR = arr;
-  TIM4->PSC = psc;
-  TIM4->SR = (uint16_t)~(1<<0);
-  TIM4->DIER |= 1<<0;
-  TIM4->CR1 |= 0x01;
+  RCC->APB1ENR |= 1<<5;
+  TIM7->ARR = arr;
+  TIM7->PSC = psc;
+  TIM7->SR = (uint16_t)~(1<<0);
+  TIM7->DIER |= 1<<0;
+  TIM7->CR1 |= 0x01;
 }
 
-void TIM4_IRQHandler(void)
+void TIM7_IRQHandler(void)
 {
-  if ((TIM4->SR & 0x01) != 0) {   // update interrupt flag
-    TIM4->SR = (uint16_t)~(1<<0); // clear interrupt flag
+  if ((TIM7->SR & 0x01) != 0) {   // update interrupt flag
+    TIM7->SR = (uint16_t)~(1<<0); // clear interrupt flag
 
     os_counter++;
 


### PR DESCRIPTION
### Description
* add common PWM Hal library for LCD back light control
* modify "LED_color_PIN" to "LCD_COLOR_PIN" (Macro definition all caps principle)
* add Marlin mode and backlight control macro switch in feature settings menu
* change os timer from tim4 to basic tim7, free tim4 for PWM backlight control
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
