### PR TITLE
Ensure INI files are saved with UTF-8 encoding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [{*.patch,syntax_test_*}]
 trim_trailing_whitespace = false
 
-[{*.c,*.cpp,*.h}]
+[{*.c,*.cpp,*.h,*.ini}]
 charset = utf-8
 
 [{*.c,*.cpp,*.h,Makefile}]


### PR DESCRIPTION
### Description

Ensure *.ini files are saved with UTF-8 encoding.

### Benefits

With https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/526 hopefully getting merged soon, this ensures the `config.ini` file will be saved with the correct encoding.

### Related Issues

None

# Attention Developers!

Please install the [EditorConfig plugin](https://github.com/editorconfig/editorconfig-vscode). This will keep code tidy and ensure proper file encoding.