### PR TITLE
Fix Emergency_Parser warning to show only on first boot and settings …

### DIFF
--- a/TFT/src/User/API/flashStore.c
+++ b/TFT/src/User/API/flashStore.c
@@ -7,6 +7,7 @@
 
 extern u32 TSC_Para[7];        //
 extern SETTINGS infoSettings;  //
+bool wasRestored = false;
 
 void wordToByte(u32 word, u8 *bytes)  //
 {
@@ -51,6 +52,7 @@ bool readStoredPara(void)
   sign = byteToWord(data + (index += 4), 4);
   if(sign != PARA_SIGN) // If the settings parameter is illegal, reset settings parameter
   {
+    wasRestored = true;
     infoSettingsReset();
   }
   else

--- a/TFT/src/User/API/flashStore.h
+++ b/TFT/src/User/API/flashStore.h
@@ -5,6 +5,8 @@
 #include "variants.h"
 #include "Settings.h"
 
+extern bool wasRestored;
+
 bool readStoredPara(void);
 void storePara(void);
 

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -55,8 +55,8 @@ void setupMachine(void){
       storeCmd("M420 S1\n");
     }
   #endif
-  if (infoMachineSettings.emergencyParser != 1){
-    statusScreen_setMsg(textSelect(LABEL_WARNING), textSelect(LABEL_EMERGENCYPARSER));
+  if (infoMachineSettings.emergencyParser != 1 && wasRestored == true){
+    popupReminder(textSelect(LABEL_WARNING), textSelect(LABEL_EMERGENCYPARSER));
   }
 }
 


### PR DESCRIPTION
Fix Emergency_Parser warning to show a Pop-up instead of showing in Infobox only on first boot and settings reset.

Resolves #538, resolves #468 