### PR TITLE
Always home before Probe Repeatability Test

### DIFF
--- a/TFT/src/User/Menu/leveling.c
+++ b/TFT/src/User/Menu/leveling.c
@@ -41,7 +41,7 @@ void menuAutoLeveling(void)
         storeCmd("M280 P0 S120\n");
         break;
       case KEY_ICON_4:
-        storeCmd("M48\n");
+        storeCmd("G28\nM48\n");
         break;
       case KEY_ICON_5:
         storeCmd("M851\n");

--- a/TFT/src/User/Menu/leveling.c
+++ b/TFT/src/User/Menu/leveling.c
@@ -41,7 +41,8 @@ void menuAutoLeveling(void)
         storeCmd("M280 P0 S120\n");
         break;
       case KEY_ICON_4:
-        storeCmd("G28\nM48\n");
+        storeCmd("G28\n");
+        storeCmd("M48\n");
         break;
       case KEY_ICON_5:
         storeCmd("M851\n");


### PR DESCRIPTION
### Description

Always home before [Probe Repeatability Test](https://marlinfw.org/docs/gcode/M048.html) (run G28 before M48).

### Benefits

Users won't have to home manually before running Probe Accuracy Test through the TFT's ABL menu if the hotend position is unknown.

### Related Issues

Fixes https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/549

Tested on a TFT35 V3 & TFT35 E3 V3.