### PR TITLE
fix filament runout init / gcode queue for M109 & M190

### DIFF
--- a/TFT/src/User/API/extend.c
+++ b/TFT/src/User/API/extend.c
@@ -37,7 +37,7 @@ void positionSetUpdateWaiting(bool isWaiting)
 
 void FIL_Runout_Init(void)
 {
-  GPIO_InitSet(FIL_RUNOUT_PIN, FIL_RUNOUT_INVERTING ? MGPIO_MODE_IPD : MGPIO_MODE_IPU, 0);
+  GPIO_InitSet(FIL_RUNOUT_PIN, FIL_RUNOUT_INVERTING ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
 }
 
 bool FIL_RunoutPinFilteredLevel(void)

--- a/TFT/src/User/Hal/STM32Fxx_Pins.h
+++ b/TFT/src/User/Hal/STM32Fxx_Pins.h
@@ -201,7 +201,7 @@
 #define PK15  ((_GPIOK_MAP<<8) | 15)
 
 
-#define GPIO_GET_PORT(n) ((n>>8) & 0xFF)
-#define GPIO_GET_PIN(n) (n & 0xFF)
+#define GPIO_GET_PORT(n) (((n)>>8) & 0xFF)
+#define GPIO_GET_PIN(n) ((n) & 0xFF)
 
 #endif

--- a/TFT/src/User/Hal/stm32f2xx/GPIO_Init.h
+++ b/TFT/src/User/Hal/stm32f2xx/GPIO_Init.h
@@ -22,10 +22,10 @@ typedef enum
   MGPIO_MODE_AIN = (0<<5)|(3<<3)|(0<<2)|(3),
 }GPIO_MODE;
 
-#define GPIO_MODE_GET_MODE(n) (n & 0x3)
-#define GPIO_MODE_GET_OTYPE(n) ((n>>2) & 0x1)
-#define GPIO_MODE_GET_OSPEED(n) ((n>>3) & 0x3)
-#define GPIO_MODE_GET_PULL(n) ((n>>5) & 0x3)
+#define GPIO_MODE_GET_MODE(n) ((n) & 0x3)
+#define GPIO_MODE_GET_OTYPE(n) (((n)>>2) & 0x1)
+#define GPIO_MODE_GET_OSPEED(n) (((n)>>3) & 0x3)
+#define GPIO_MODE_GET_PULL(n) (((n)>>5) & 0x3)
 
 #define GPIO_MODE_AF 2
 #define GPIO_AF0 0

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -515,10 +515,8 @@ void show_GlobalInfo(void)
 }
 
 void drawGlobalInfo(void){
-
-
     char tempstr[10];
-
+    GUI_SetBkColor(TITLE_BACKGROUND_COLOR);
     GUI_ClearRect(LCD_WIDTH/3, 0, LCD_WIDTH, BYTE_HEIGHT);
 
     //global nozzle
@@ -530,4 +528,5 @@ void drawGlobalInfo(void){
     lcd_frame_display(ICON_BED_X, 0, 2*BYTE_WIDTH, BYTE_HEIGHT, ICON_ADDR(ICON_GLOBAL_BED));
     my_sprintf(tempstr, "%d/%d", heatGetCurrentTemp(BED), heatGetTargetTemp(BED));
     GUI_DispStringInRect(VALUE_BED_X,0,VALUE_BED_X+8*BYTE_WIDTH,BYTE_HEIGHT, (u8 *)tempstr);
+    GUI_SetBkColor(BACKGROUND_COLOR);
 }

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -303,9 +303,10 @@ void menuPrintFromSource(void)
 
             if (infoFile.source == TFT_SD) {
               //load bmp preview in flash if file exists
-              int gn;
+              int16_t gn;
               char *gnew;
               gn = strlen(infoFile.file[key_num + start - infoFile.F_num]) - 6; // -6 means ".gcode"
+              if(gn < 0) gn = 0; // for extension name ".g", ".gco" file, TODO: improve here in next version 
               gnew = malloc(gn + 10);
               if (gnew != NULL) {
                 strcpy(gnew, getCurFileSource());

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -792,7 +792,7 @@ void getGcodeFromFile(void)
 
   powerFailedCache(infoPrinting.file.fptr);
 
-  if(heatHasWaiting() || infoCmd.count >= 3 || infoPrinting.pause )  return;
+  if(heatHasWaiting() || infoCmd.count || infoPrinting.pause )  return;
 
   if(moveCacheToCmd() == true) return;
 


### PR DESCRIPTION

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
* fix filament runout default level, if not insert sensor,  will pup up "filament runout" immediately when start printing
* fix "M190" & "M109" don't wait temperature reached in printing.

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
