### PR TITLE
Code to handle pause outside of printing

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -10,7 +10,6 @@ const char *const ignoreEcho[] = {
   "busy: processing",
   "Now fresh file:",
   "Probe Z Offset:",
-  "paused for user",
   "Flow:",
   "echo:;",
   "echo:  G",
@@ -352,6 +351,10 @@ void parseACK(void)
       {
         speedSetPercent(1,ack_value());
       }
+      else if(ack_seen("paused for user"))
+      {
+        popupPauseForUser();
+      }
     //Parse error messages & Echo messages
       else if(ack_seen(errormagic))
       {
@@ -366,9 +369,6 @@ void parseACK(void)
           if(strstr(dmaL2Cache, ignoreEcho[i]))
           {
             busyIndicator(STATUS_BUSY);
-            if (i == 3 && isPrinting() == false){
-              popupPauseForUser();
-            }
             goto parse_end;
           }
         }

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -366,6 +366,9 @@ void parseACK(void)
           if(strstr(dmaL2Cache, ignoreEcho[i]))
           {
             busyIndicator(STATUS_BUSY);
+            if (i == 3 && isPrinting() == false){
+              popupPauseForUser();
+            }
             goto parse_end;
           }
         }

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -94,3 +94,34 @@ void popupReminder(u8* info, u8* context) {
   }
 }
 
+void menuPopupPauseForUser(void)
+{
+  u16 key_num = IDLE_TOUCH;
+
+  while(infoMenu.menu[infoMenu.cur] == menuPopupPauseForUser)
+  {
+    key_num = KEY_GetValue(BUTTON_NUM, &popupMenuRect);
+    switch(key_num)
+    {
+      case KEY_POPUP_CONFIRM:
+        infoMenu.cur--;
+        Serial_Puts(SERIAL_PORT, "M108\n");
+        break;
+
+      default:
+        break;
+    }
+    loopProcess();
+  }
+}
+
+void popupPauseForUser() {
+  #ifdef CLEAN_MODE_SWITCHING_SUPPORT
+    if (infoSettings.mode == LCD12864) return;
+  #endif
+  popupDrawPage(&bottomSingleBtn , (u8*)"Printer Paused", (u8*)"OK to continue", textSelect(LABEL_CONFIRM), NULL);
+  if(infoMenu.menu[infoMenu.cur] != menuPopupPauseForUser)
+  {
+    infoMenu.menu[++infoMenu.cur] = menuPopupPauseForUser;
+  }
+}

--- a/TFT/src/User/Menu/Popup.h
+++ b/TFT/src/User/Menu/Popup.h
@@ -19,5 +19,6 @@ void windowSetButton(const BUTTON *btn);
 void windowReDrawButton(uint8_t positon, uint8_t is_press);
 void popupDrawPage(BUTTON *btn, const uint8_t *title, const uint8_t *context, const uint8_t *yes, const uint8_t *no);
 void popupReminder(u8* info, u8* context);
+void popupPauseForUser();
 
 #endif


### PR DESCRIPTION
This is useful for setups that need to pause for a leveling probe to be attached on ABL. My uses PAUSE_BEFORE_DEPLOY_STOW and if it doesn't send M108 the printer is hard frozen.

### Description

There is not too much to this change. Now when "paused for user" comes in and the machine is not printing a pop up comes up to let the user hit OK to continue. 

### Benefits

This makes the screen more usable. This way people don't get into a situation where the machine is waiting for a button press without a way to get one.


### Related Issues

None that I am aware of. Why does M108 need to be sent using 

`Serial_Puts(SERIAL_PORT, "M108\n");`

The same code is found in Printing.c line 317. Must store did not result in the command ever being sent. 

Notably sending M0 then M108 through the screen's little console doesn't register as an OK. That likely has to do with whatever is going on with the requirement for Serial_Puts


