### PR TITLE
fix Repetier-Firmware compatibility

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -114,7 +114,7 @@ void parseACK(void)
 
     if(infoHost.connected == false) //not connected to Marlin
     {
-      if((!ack_seen("T:") && !ack_seen("T0:")) || !ack_seen("ok"))  goto parse_end;  //the first response should be such as "T:25/50 ok\n"
+      if(!ack_seen("T:") && !ack_seen("T0:"))  goto parse_end;  //the first response should be such as "T:25/50\n"
         updateNextHeatCheckTime();
         infoHost.connected = true;
         storeCmd("M115\n");
@@ -167,29 +167,29 @@ void parseACK(void)
       if(ack_seen("ok"))
       {
         infoHost.wait = false;
-    //parse temperature
-        if(ack_seen("T:") || ack_seen("T0:"))
+      }
+      // parse temperature
+      if(ack_seen("T:") || ack_seen("T0:"))
+      {
+        TOOL i = heatGetCurrentToolNozzle();
+        heatSetCurrentTemp(i, ack_value()+0.5);
+        if(!heatGetSendWaiting(i)){
+          heatSyncTargetTemp(i, ack_second_value()+0.5);
+        }
+        for(TOOL i = BED; i < HEATER_NUM; i++)
         {
-          TOOL i = heatGetCurrentToolNozzle();
-          heatSetCurrentTemp(i, ack_value()+0.5);
-          if(!heatGetSendWaiting(i)){
-            heatSyncTargetTemp(i, ack_second_value()+0.5);
-          }
-          for(TOOL i = BED; i < HEATER_NUM; i++)
+          if(ack_seen(toolID[i]))
           {
-            if(ack_seen(toolID[i]))
-            {
-              heatSetCurrentTemp(i, ack_value()+0.5);
-              if(!heatGetSendWaiting(i)) {
-                heatSyncTargetTemp(i, ack_second_value()+0.5);
-              }
+            heatSetCurrentTemp(i, ack_value()+0.5);
+            if(!heatGetSendWaiting(i)) {
+              heatSyncTargetTemp(i, ack_second_value()+0.5);
             }
           }
-          avoid_terminal = infoSettings.terminalACK;
-          updateNextHeatCheckTime();
         }
+        avoid_terminal = infoSettings.terminalACK;
+        updateNextHeatCheckTime();
       }
-      if(ack_seen("X:") && ack_index == 2)
+      else if(ack_seen("X:") && ack_index == 2)
       {
         storegantry(0, ack_value());
         if (ack_seen("Y:"))


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Repetier-Firmware ack of "M105\n" is "ok 0\n T:20/0\n", "ok" and "T:20" are not on the same line， so temperature need separate parse with "ok"
### Benefits

<!-- What does this fix or improve? -->

### Related Issues
#552
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
