### PR TITLE
Babystep fix

### DIFF
--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -10,7 +10,7 @@ MENUITEMS babyStepItems = {
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_INC,                  LABEL_INC},
-  {ICON_EEPROM_SAVE,          LABEL_EEPROM_SAVE},
+  {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_01_MM,                LABEL_01_MM},
   {ICON_NORMAL_SPEED,         LABEL_VALUE_ZERO},
   {ICON_BACK,                 LABEL_BACK},}
@@ -92,20 +92,15 @@ void menuBabyStep(void)
       case KEY_ICON_0:
         if(baby_step_value - elementsUnit.ele[elementsUnit.cur] > BABYSTEP_MIN_VALUE)
         {
-          if(storeCmd("M290 Z-%.2f\n",elementsUnit.ele[elementsUnit.cur]))
+            mustStoreCmd("M290 Z-%.2f\n",elementsUnit.ele[elementsUnit.cur])
             baby_step_value -= elementsUnit.ele[elementsUnit.cur];
         }
         break;
       case KEY_ICON_3:
         if(baby_step_value + elementsUnit.ele[elementsUnit.cur] < BABYSTEP_MAX_VALUE)
         {
-          if(storeCmd("M290 Z%.2f\n",elementsUnit.ele[elementsUnit.cur]))
+            mustStoreCmd("M290 Z%.2f\n",elementsUnit.ele[elementsUnit.cur])
             baby_step_value += elementsUnit.ele[elementsUnit.cur];
-        }
-        break;
-      case KEY_ICON_4:
-        if(infoMachineSettings.EEPROM == 1){
-           storeCmd("M500\n");
         }
         break;
       case KEY_ICON_5:
@@ -114,7 +109,7 @@ void menuBabyStep(void)
         menuDrawItem(&babyStepItems.items[key_num], key_num);
         break;
       case KEY_ICON_6:
-        if(storeCmd("M290 Z%.2f\n",-baby_step_value))
+          mustStoreCmd("M290 Z%.2f\n",-baby_step_value)
           baby_step_value = 0.0f;
         break;
       case KEY_ICON_7:
@@ -124,6 +119,7 @@ void menuBabyStep(void)
         #if LCD_ENCODER_SUPPORT
           if(encoderPosition)
           {
+            mustStoreCmd("M290 Z%.2f\n",elementsUnit.ele[elementsUnit.cur]*encoderPosition);
             baby_step_value += elementsUnit.ele[elementsUnit.cur]*encoderPosition;
             encoderPosition = 0;
           }


### PR DESCRIPTION
Babysteps are not working correct while printing over tft/rs232. Maybe the rs232 buffer is too busy.
Changed command from StoreCmd to mustStoreCmd. The Encoder did not work either. Also the Save Icon is obsolete, there is nothing to save..

This bug was found by nicolas81. Please see <https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/584>
