### PR TITLE
Update parseACK.c

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -285,6 +285,10 @@ void parseACK(void)
         dualstepper[E_STEPPER] = true;
       }
     // Parse M115 capability report
+      else if(ack_seen("Cap:EEPROM:"))
+      {
+        infoMachineSettings.EEPROM = ack_value();
+      }
       else if(ack_seen("Cap:AUTOREPORT_TEMP:"))
       {
         infoMachineSettings.autoReportTemp = ack_value();


### PR DESCRIPTION
add EEPROM status Parser

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
add EEPROM status Parser

## Benefits

<!-- What does this fix or improve? -->
EEPROM status can be parse from M115 then used by Save button that need EEPROM==1 status
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
