### PR TITLE
Correction for:  two extruders, Sintaxe LCD_Encoder.c, CZ translation

### DIFF
--- a/TFT/src/User/API/LCD_Encoder.c
+++ b/TFT/src/User/API/LCD_Encoder.c
@@ -190,6 +190,7 @@ void loopCheckEncoder()
     skipMode = false; //resume mode change loop
     return 0;
 	}
+	return 0;
 }
 #endif
 

--- a/TFT/src/User/API/LCD_Encoder.c
+++ b/TFT/src/User/API/LCD_Encoder.c
@@ -169,7 +169,7 @@ void loopCheckEncoder()
           sy = ey;
           return 2;
         }
-        return 0;
+        //return 0;
       }
       else
       {
@@ -178,7 +178,7 @@ void loopCheckEncoder()
           sy = ey;
           return 3;
         }
-        return 0;
+        //return 0;
       }
     }
   }
@@ -188,7 +188,7 @@ void loopCheckEncoder()
 		sy = ey =0;
 		MOVE = false;
     skipMode = false; //resume mode change loop
-    return 0;
+    //return 0;
 	}
 	return 0;
 }

--- a/TFT/src/User/API/Language/language_cz.h
+++ b/TFT/src/User/API/Language/language_cz.h
@@ -24,7 +24,7 @@
     #define CZ_POINT_2              "Bod 2"
     #define CZ_POINT_3              "Bod 3"
     #define CZ_POINT_4              "Bod 4"
-    #define CZ_ABL                  "Varovnat"
+    #define CZ_ABL                  "Vyrovnat"
     #define CZ_BLTOUCH              "Bltouch"
     #define CZ_BLTOUCH_TEST         "Test"
     #define CZ_BLTOUCH_DEPLOY       "Vysunout"

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -233,12 +233,26 @@ void parseACK(void)
         if(ack_seen("Z")) setParameter(P_STEPS_PER_MM, Z_STEPPER, ack_value());
         if(ack_seen("E")) setParameter(P_STEPS_PER_MM, E_STEPPER, ack_value());
       }
+      else if(ack_seen("M92 T0 E")){
+        setParameter(P_STEPS_PER_MM, E_STEPPER, ack_value());
+      }
+      else if(ack_seen("M92 T1 E")){
+        setParameter(P_STEPS_PER_MM, E2_STEPPER, ack_value());
+        dualstepper[E_STEPPER] = true;
+      }
     //parse and store Max Feed Rate values
      else if(ack_seen("M203 X")){
                           setParameter(P_MAX_FEED_RATE, X_STEPPER, ack_value());
         if(ack_seen("Y")) setParameter(P_MAX_FEED_RATE, Y_STEPPER, ack_value());
         if(ack_seen("Z")) setParameter(P_MAX_FEED_RATE, Z_STEPPER, ack_value());
         if(ack_seen("E")) setParameter(P_MAX_FEED_RATE, E_STEPPER, ack_value());
+      }
+      else if(ack_seen("M203 T0 E")){
+        setParameter(P_MAX_FEED_RATE, E_STEPPER, ack_value());
+      }
+      else if(ack_seen("M203 T1 E")){
+        setParameter(P_MAX_FEED_RATE, E2_STEPPER, ack_value());
+        dualstepper[E_STEPPER] = true;
       }
     //parse and store Max Acceleration values
       else if(ack_seen("M201 X")){
@@ -247,6 +261,13 @@ void parseACK(void)
         if(ack_seen("Z")) setParameter(P_MAX_ACCELERATION, Z_STEPPER, ack_value());
         if(ack_seen("E")) setParameter(P_MAX_ACCELERATION, E_STEPPER, ack_value());
 
+      }
+      else if(ack_seen("M201 T0 E")){
+        setParameter(P_MAX_ACCELERATION, E_STEPPER, ack_value());
+      }
+      else if(ack_seen("M201 T1 E")){
+        setParameter(P_MAX_ACCELERATION, E2_STEPPER, ack_value());
+        dualstepper[E_STEPPER] = true;
       }
     //parse and store Acceleration values
       else if(ack_seen("M204 P")){


### PR DESCRIPTION
Correction for two extruders
For two axtruders, the values are not displayed:
Steps per mm
Max feed Rate
Max Acceleration
viz.
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/556

Correction of syntax in the file LCD_Encoder.c 
Fixes an issue that arises during compilation in the LCD_Encoder.c file

CZ translation correction
