### PR TITLE
Fix "Updating Icons" typo

### DIFF
--- a/TFT/src/User/API/boot.c
+++ b/TFT/src/User/API/boot.c
@@ -146,7 +146,7 @@ void updateIcon(void)
   }
 
   GUI_Clear(BACKGROUND_COLOR);
-  GUI_DispString(5, PADDING, (u8 *)"Updating Logo");
+  GUI_DispString(5, PADDING, (u8 *)"Updating Icons");
 
   for (int i = 0; i < COUNT(iconBmpName); i++)
   {


### PR DESCRIPTION
### Description

Replace second "Updating Logo" text with "Updating Icons".

### Benefits

Correct text is displayed while updating TFT firmware.

### Related Issues

https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/464#issuecomment-619616901
