### PR TITLE
Add auto-detect On-board SD Card via M115 and change PRINT_CANCEL_GCODE behaviour to be sent only when printing from TFT's SD card

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -205,13 +205,12 @@ void parseACK(void)
         coordinateSetAxisActualSteps(E_AXIS, ack_value());
       }
 
-  #ifdef ONBOARD_SD_SUPPORT
-      else if(ack_seen(bsdnoprintingmagic) && infoMenu.menu[infoMenu.cur] == menuPrinting)
+      else if(ack_seen(bsdnoprintingmagic) && infoMenu.menu[infoMenu.cur] == menuPrinting && infoMachineSettings.onboard_sd_support == 1)
       {
         infoHost.printing = false;
         completePrinting();
       }
-      else if(ack_seen(bsdprintingmagic))
+      else if(ack_seen(bsdprintingmagic) && infoMachineSettings.onboard_sd_support == 1)
       {
         if(infoMenu.menu[infoMenu.cur] != menuPrinting && !infoHost.printing) {
           infoMenu.menu[++infoMenu.cur] = menuPrinting;
@@ -224,7 +223,7 @@ void parseACK(void)
         setPrintCur(position);
   //      powerFailedCache(position);
       }
-  #endif
+
     //parse and store stepper steps/mm values
       else if(ack_seen("M92 X"))
       {
@@ -320,6 +319,10 @@ void parseACK(void)
       else if(ack_seen("Cap:EMERGENCY_PARSER:"))
       {
         infoMachineSettings.emergencyParser = ack_value();
+      }
+      else if(ack_seen("Cap:SDCARD:"))
+      {
+        infoMachineSettings.onboard_sd_support = ack_value();
       }
       else if(ack_seen("Cap:AUTOREPORT_SD_STATUS:"))
       {

--- a/TFT/src/User/API/parseACK.h
+++ b/TFT/src/User/API/parseACK.h
@@ -7,10 +7,8 @@
 static const char errormagic[]        = "Error:";
 static const char echomagic[]         = "echo:";
 static const char unknowmagic[]       = "Unknown command:";
-#ifdef ONBOARD_SD_SUPPORT
 static const char bsdprintingmagic[]   = "SD printing byte";
 static const char bsdnoprintingmagic[] = "Not SD printing";
-#endif
 
 
 #define ACK_MAX_SIZE 2048

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -237,7 +237,7 @@
 
 /**
  * SD support
- * Starting from Marlin Bufix 2.0.x Distribution Date: 2020-04-27 & above, The TFT will auto detect
+ * Starting from Marlin Bugfix 2.0.x Distribution Date: 2020-04-27 & above, The TFT will auto detect
  * On-Board SD Card and auto-configure M27 AutoReport with M115 command
  * Set the time interval to poll SD Printing status if Marlin reports M27 AutoReport as disabled.
  */

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -237,14 +237,12 @@
 
 /**
  * SD support
- * The TFT will auto configure M27 AutoReport with M115 command
- * Set the time interval to poll SD Printing status if Marlin reports M27 disabled.
+ * Starting from Marlin Bufix 2.0.x Distribution Date: 2020-04-27 & above, The TFT will auto detect
+ * On-Board SD Card and auto-configure M27 AutoReport with M115 command
+ * Set the time interval to poll SD Printing status if Marlin reports M27 AutoReport as disabled.
  */
-#define ONBOARD_SD_SUPPORT
-#ifdef ONBOARD_SD_SUPPORT
-  #define M27_REFRESH                3        // Time in sec for M27 command
-  #define M27_WATCH_OTHER_SOURCES    true     // if true the polling on M27 report is always active. Case: SD print started not from TFT35
-#endif
+#define M27_REFRESH                3        // Time in sec for M27 command
+#define M27_WATCH_OTHER_SOURCES    true     // if true the polling on M27 report is always active. Case: SD print started not from TFT35
 
 /**
  * Power Loss Recovery

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -306,7 +306,7 @@ void menuPrintFromSource(void)
               int16_t gn;
               char *gnew;
               gn = strlen(infoFile.file[key_num + start - infoFile.F_num]) - 6; // -6 means ".gcode"
-              if(gn < 0) gn = 0; // for extension name ".g", ".gco" file, TODO: improve here in next version 
+              if(gn < 0) gn = 0; // for extension name ".g", ".gco" file, TODO: improve here in next version
               gnew = malloc(gn + 10);
               if (gnew != NULL) {
                 strcpy(gnew, getCurFileSource());
@@ -367,28 +367,33 @@ MENUITEMS sourceSelItems = {
 LABEL_PRINT,
 // icon                       label
  {{ICON_ONTFT_SD,            LABEL_TFTSD},
- #ifdef ONBOARD_SD_SUPPORT
-  {ICON_ONBOARD_SD,           LABEL_ONBOARDSD},
- #endif
- #ifdef U_DISK_SUPPROT
+ #ifdef U_DISK_SUPPORT
   {ICON_U_DISK,               LABEL_U_DISK},
+  {ICON_ONBOARD_SD,           LABEL_ONBOARDSD},
  #else
+  {ICON_ONBOARD_SD,           LABEL_ONBOARDSD},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
  #endif
- #ifndef ONBOARD_SD_SUPPORT
-  {ICON_BACKGROUND,           LABEL_BACKGROUND},
- #endif
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
-  {ICON_BACK,                 LABEL_BACK},}
+  {ICON_BACK,                 LABEL_BACK}}
 };
 
 void menuPrint(void)
 {
   KEY_VALUES  key_num = KEY_IDLE;
+  if(infoMachineSettings.onboard_sd_support != 1){
+    #ifdef U_DISK_SUPPORT
+    sourceSelItems.items[2].icon = ICON_BACKGROUND;
+    sourceSelItems.items[2].label.index = LABEL_BACKGROUND;
+    #else
+    sourceSelItems.items[1].icon = ICON_BACKGROUND;
+    sourceSelItems.items[1].label.index = LABEL_BACKGROUND;
+    #endif
 
+  }
   menuDrawPage(&sourceSelItems);
   while(infoMenu.menu[infoMenu.cur] == menuPrint)
   {
@@ -402,26 +407,24 @@ void menuPrint(void)
         infoMenu.menu[++infoMenu.cur] = menuPowerOff;
         goto selectEnd;
 
-      #ifdef ONBOARD_SD_SUPPORT
-      case KEY_ICON_1:
-        list_mode = true; //force list mode in Onboard sd casd
-        infoFile.source = BOARD_SD;
-        infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;   //TODO: fix here,  onboard sd card PLR feature
-        goto selectEnd;
-      #endif
-
-      #ifdef U_DISK_SUPPROT
-        #ifdef ONBOARD_SD_SUPPORT
-          case KEY_ICON_2:
-        #else
+      #ifdef U_DISK_SUPPORT
           case KEY_ICON_1:
-        #endif
-        list_mode = infoSettings.file_listmode; //follow list mode setting in usb disk
-        infoFile.source = TFT_UDISK;
-        infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;
-        infoMenu.menu[++infoMenu.cur] = menuPowerOff;
-        goto selectEnd;
+            list_mode = infoSettings.file_listmode; //follow list mode setting in usb disk
+            infoFile.source = TFT_UDISK;
+            infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;
+            infoMenu.menu[++infoMenu.cur] = menuPowerOff;
+            goto selectEnd;
+          case KEY_ICON_2:
+      #else
+          case KEY_ICON_1:
       #endif
+          if(infoMachineSettings.onboard_sd_support == 1)
+          {
+            list_mode = true; //force list mode in Onboard sd casd
+            infoFile.source = BOARD_SD;
+            infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;   //TODO: fix here,  onboard sd card PLR feature
+            goto selectEnd;
+          }
 
       case KEY_ICON_7:
         infoMenu.cur--;

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -83,11 +83,7 @@ const ITEM itemIsPause[2] = {
 static PRINTING infoPrinting;
 static u32     update_time = M27_REFRESH * 1000;
 
-#ifdef ONBOARD_SD_SUPPORT
-static bool    update_waiting = M27_WATCH_OTHER_SOURCES;
-#else
 static bool    update_waiting = false;
-#endif
 
 //
 bool isPrinting(void)

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -693,15 +693,14 @@ void abortPrinting(void)
 
     case TFT_UDISK:
     case TFT_SD:
+      if (infoSettings.send_cancel_gcode == 1)
+        mustStoreCmd(PRINT_CANCEL_GCODE);
+
       clearCmdQueue();
       break;
   }
 
   heatClearIsWaiting();
-
-  if(infoSettings.send_cancel_gcode == 1){
-    mustStoreCmd(PRINT_CANCEL_GCODE);
-  }
 
   endPrinting();
   exitPrinting();

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -24,7 +24,7 @@ void infoSettingsReset(void)
   infoSettings.knob_led_color       = (STARTUP_KNOB_LED_COLOR - 1);
   infoSettings.send_start_gcode     = 0;
   infoSettings.send_end_gcode       = 0;
-  infoSettings.send_cancel_gcode    = 0;
+  infoSettings.send_cancel_gcode    = 1;
   infoSettings.persistent_info      = 1;
   infoSettings.file_listmode        = 1;
   #ifdef LCD_LED_PWM_CHANNEL

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -36,17 +36,18 @@ void infoSettingsReset(void)
 }
 
 void initMachineSetting(void){
-
-  infoMachineSettings.EEPROM                  = 0;
+  // some settings are assumes as active unless reported disabled by marlin
+  infoMachineSettings.EEPROM                  = 1;
   infoMachineSettings.autoReportTemp          = 0;
-  infoMachineSettings.autoLevel               = 0;
-  infoMachineSettings.zProbe                  = 0;
-  infoMachineSettings.levelingData            = 0;
+  infoMachineSettings.autoLevel               = 1;
+  infoMachineSettings.zProbe                  = 1;
+  infoMachineSettings.levelingData            = 1;
   infoMachineSettings.softwarePower           = 0;
   infoMachineSettings.toggleLights            = 0;
   infoMachineSettings.caseLightsBrightness    = 0;
   infoMachineSettings.emergencyParser         = 0;
   infoMachineSettings.promptSupport           = 0;
+  infoMachineSettings.onboard_sd_support      = 1;
   infoMachineSettings.autoReportSDStatus      = 0;
 }
 
@@ -59,6 +60,7 @@ void setupMachine(void){
   if (infoMachineSettings.emergencyParser != 1 && wasRestored == true){
     popupReminder(textSelect(LABEL_WARNING), textSelect(LABEL_EMERGENCYPARSER));
   }
+  printSetUpdateWaiting(M27_WATCH_OTHER_SOURCES);
 }
 
 // Version infomation

--- a/TFT/src/User/Menu/Settings.h
+++ b/TFT/src/User/Menu/Settings.h
@@ -41,17 +41,19 @@ typedef struct
 
 typedef struct
 {
-  int EEPROM;
-  int autoReportTemp;
-  int autoLevel;
-  int zProbe;
-  int levelingData;
-  int softwarePower;
-  int toggleLights;
-  int caseLightsBrightness;
-  int emergencyParser;
-  int promptSupport;
-  int autoReportSDStatus;
+  uint8_t EEPROM;
+  uint8_t autoReportTemp;
+  uint8_t autoLevel;
+  uint8_t zProbe;
+  uint8_t levelingData;
+  uint8_t softwarePower;
+  uint8_t toggleLights;
+  uint8_t caseLightsBrightness;
+  uint8_t emergencyParser;
+  uint8_t promptSupport;
+  uint8_t onboard_sd_support;
+  uint8_t autoReportSDStatus;
+  uint8_t babyStepping;
 }MACHINESETTINGS;
 
 

--- a/TFT/src/User/Menu/menu.c
+++ b/TFT/src/User/Menu/menu.c
@@ -400,11 +400,10 @@ void loopBackEnd(void)
   loopBuzzer();
 #endif
 
-#if defined ONBOARD_SD_SUPPORT
-  if (infoMachineSettings.autoReportSDStatus !=1){
-    loopCheckPrinting();                //Check if there is a SD or USB print running.
+if(infoMachineSettings.onboard_sd_support == 1 && infoMachineSettings.autoReportSDStatus != 1)
+  {
+    loopCheckPrinting(); //Check if there is a SD or USB print running.
   }
-#endif
 
 #ifdef U_DISK_SUPPROT
   USBH_Process(&USB_OTG_Core, &USB_Host);


### PR DESCRIPTION
- With this update, the TFT firmware will be able to auto-detect Onboard SD Card with M115 starting from Marlin Bugfix 2.0.x date: 2020-04-27.
- Enable PRINT_CANCEL_GCODE by default and change PRINT_CANCEL_GCODE behaviour to be sent only when printing from TFT's SD card and USB flash disk to avoid duplicate Cancel G-codes when printing from Onboard SD card.