### PR TITLE
Add better support for Printer SD / TFT SD /TFT USB from ESP3D and other extern prog

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -338,8 +338,6 @@ void sendQueueCmd(void)
             Serial_Puts(SERIAL_PORT_2, "ok\n");
             infoCmd.count--;
             infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
-            infoMenu.cur = 1;
-            menuBeforePrinting();
             return;
           }
           break;
@@ -428,6 +426,22 @@ void sendQueueCmd(void)
             speedSetPercent(1,cmd_value());
           }
           break;
+        #ifdef BUZZER_PIN
+            case 300: //M300
+              if (cmd_seen('S')) {
+                uint16_t hz = cmd_value();
+                if (cmd_seen('P')) {
+                  uint16_t ms = cmd_value();
+                  Buzzer_TurnOn(hz, ms);
+                  if (startsWith("M300 TFT", infoCmd.queue[infoCmd.index_r].gcode)) {
+                    infoCmd.count--;
+                    infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+                    return;
+                  }
+                }
+              }
+              break;
+          #endif
         case 851: //M203 Maximum feedrates (units/s)
           if(cmd_seen('X')) setParameter(P_PROBE_OFFSET, X_AXIS, cmd_float());
           if(cmd_seen('Y')) setParameter(P_PROBE_OFFSET, Y_AXIS, cmd_float());

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -7,6 +7,8 @@ QUEUE infoCacheCmd;  // Only when heatHasWaiting() is false the cmd in this cach
 
 static u8 cmd_index=0;
 
+static bool ispolling = true;
+
 // Is there a code character in the current gcode command.
 static bool cmd_seen(char code)
 {
@@ -462,6 +464,11 @@ void sendQueueCmd(void)
   }
   else
   {
+      if (!ispolling) { //ignore any query from TFT 
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+      }
     // this command originated with the TFT
     switch(infoCmd.queue[infoCmd.index_r].gcode[0])
     {

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -33,6 +33,12 @@ static float cmd_float(void)
   return (strtod(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL));
 }
 
+//check if 'string' start with 'search'
+bool static  startsWith(TCHAR* search, TCHAR* string) 
+{
+    return (strncmp(search, string, strlen(search)) == 0)?true: false;
+}
+
 // Store gcode cmd to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
 // If the infoCmd queue is full, reminde in title bar.
 bool storeCmd(const char * format,...)
@@ -161,6 +167,191 @@ void sendQueueCmd(void)
       cmd = cmd_value();
       switch(cmd)
       {
+#ifdef SERIAL_PORT_2
+        case 20: //M20
+          if (startsWith("M20 SD:", infoCmd.queue[infoCmd.index_r].gcode) ||startsWith("M20 U:", infoCmd.queue[infoCmd.index_r].gcode))   {
+            if(startsWith("M20 SD:", infoCmd.queue[infoCmd.index_r].gcode)) infoFile.source = TFT_SD;
+            else infoFile.source = TFT_UDISK;
+            strncpy(infoFile.title, &infoCmd.queue[infoCmd.index_r].gcode[4], MAX_PATH_LEN);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < MAX_PATH_LEN && infoFile.title[i] !=0 ; i++)
+              {
+                if ((infoFile.title[i] == '*') || (infoFile.title[i] == '\n') ||(infoFile.title[i] == '\r'))
+                {
+                  infoFile.title[i] = 0;
+                  break;
+                }
+              }
+            Serial_Puts(SERIAL_PORT_2, "Begin file list\n");
+            if (mountFS() == true && scanPrintFiles() == true){
+              for (uint i = 0; i < infoFile.f_num; i++) {
+                Serial_Puts(SERIAL_PORT_2,infoFile.file[i]);
+                Serial_Puts(SERIAL_PORT_2,"\n");
+                } 
+              for (uint i = 0; i < infoFile.F_num; i++) {
+                Serial_Puts(SERIAL_PORT_2,"/");
+                Serial_Puts(SERIAL_PORT_2,infoFile.folder[i]);
+                Serial_Puts(SERIAL_PORT_2,"/\n");
+                } 
+            }
+            Serial_Puts(SERIAL_PORT_2, "End file list\nok\n");
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+            }
+          break;
+
+        case 23: //M23
+          if (startsWith("M23 SD:", infoCmd.queue[infoCmd.index_r].gcode) || startsWith("M23 U:", infoCmd.queue[infoCmd.index_r].gcode))   {
+            if(startsWith("M23 SD:", infoCmd.queue[infoCmd.index_r].gcode)) infoFile.source = TFT_SD;
+            else infoFile.source = TFT_UDISK;
+            resetInfoFile();
+            strncpy(infoFile.title, &infoCmd.queue[infoCmd.index_r].gcode[4], MAX_PATH_LEN);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < MAX_PATH_LEN && infoFile.title[i] !=0 ; i++)
+              {
+                if ((infoFile.title[i] == '*') || (infoFile.title[i] == '\n') ||(infoFile.title[i] == '\r'))
+                {
+                  infoFile.title[i] = 0;
+                  break;
+                }
+              }
+            Serial_Puts(SERIAL_PORT_2, "echo:Now fresh file: ");
+            Serial_Puts(SERIAL_PORT_2, infoFile.title);
+            Serial_Puts(SERIAL_PORT_2, "\n");
+            FIL tmp;
+            if (mountFS() && (f_open(&tmp, infoFile.title, FA_OPEN_EXISTING | FA_READ) == FR_OK) ){
+                char buf[10];
+                my_sprintf(buf, "%d", f_size(&tmp));
+                Serial_Puts(SERIAL_PORT_2, "File opened: ");
+                Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                Serial_Puts(SERIAL_PORT_2, " Size: ");
+                Serial_Puts(SERIAL_PORT_2, buf);
+                Serial_Puts(SERIAL_PORT_2, "\nFile selected\n");
+                f_close(&tmp);
+            }else{
+                Serial_Puts(SERIAL_PORT_2, "open failed, File: ");
+                Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                Serial_Puts(SERIAL_PORT_2, "\n");
+            }
+            Serial_Puts(SERIAL_PORT_2, "ok\n");
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+          }
+          break;
+
+        case 24: //M24
+          if ((infoFile.source == TFT_UDISK) || (infoFile.source == TFT_SD)){
+             if (isPause()) {
+              setPrintPause(false, false);
+            } else {
+                Serial_Puts(SERIAL_PORT_2, "ok\n");
+                infoCmd.count--;
+                infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+                infoMenu.cur = 1;
+                menuBeforePrinting();
+            }
+            return;
+          }
+          break;
+
+        case 25: //M25
+          if (isPrinting() && !infoHost.printing){
+            setPrintPause(true, false);
+            Serial_Puts(SERIAL_PORT_2, "ok\n");
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+            }
+          break;
+
+        case 27: //M27
+            if (isPrinting() && !infoHost.printing){
+                if (cmd_seen('C')){
+                     Serial_Puts(SERIAL_PORT_2, "Current file: ");
+                     Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                      Serial_Puts(SERIAL_PORT_2, ".\n");
+                    }
+                 char buf[55];
+                 my_sprintf(buf, "%s printing byte %d/%d\n",(infoFile.source==TFT_SD)?"TFT SD":"TFT USB", getPrintCur(),getPrintSize());
+                 Serial_Puts(SERIAL_PORT_2, buf);
+                 Serial_Puts(SERIAL_PORT_2, "ok\n");
+                 infoCmd.count--;
+                 infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+                 return;
+            } 
+          break;
+
+        case 28: //M28
+            ispolling = false;
+            break;
+
+        case 29: //M29
+            storeCmd("M105\nM114\nM220\nM221\n");
+            ispolling = true;
+            break;
+
+        case 30: //M30
+          if (startsWith("M30 SD:", infoCmd.queue[infoCmd.index_r].gcode) || startsWith("M30 U:", infoCmd.queue[infoCmd.index_r].gcode))   {
+            if(startsWith("M30 SD:", infoCmd.queue[infoCmd.index_r].gcode)) infoFile.source = TFT_SD;
+            else infoFile.source = TFT_UDISK;
+            TCHAR filepath[MAX_PATH_LEN];
+            strncpy(filepath, &infoCmd.queue[infoCmd.index_r].gcode[4], MAX_PATH_LEN);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < MAX_PATH_LEN && filepath[i] !=0 ; i++)
+              {
+                if ((filepath[i] == '*') || (filepath[i] == '\n') ||(filepath[i] == '\r'))
+                {
+                  filepath[i] = 0;
+                  break;
+                }
+              }
+            if ((mountFS() == true) && (f_unlink (filepath)== FR_OK)) {
+                Serial_Puts(SERIAL_PORT_2, "File deleted: ");
+                Serial_Puts(SERIAL_PORT_2, filepath);
+                Serial_Puts(SERIAL_PORT_2, ".\nok\n");
+            } else {
+                Serial_Puts(SERIAL_PORT_2, "Deletion failed, File: ");
+                Serial_Puts(SERIAL_PORT_2, filepath);
+                Serial_Puts(SERIAL_PORT_2, ".\nok\n");
+            }
+
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+          }
+          break;
+
+        case 115: //M115 TFT
+          if (startsWith("M115 TFT", infoCmd.queue[infoCmd.index_r].gcode)) {
+            char buf[50];
+            Serial_Puts(SERIAL_PORT_2, "FIRMWARE_NAME: " FIRMWARE_NAME " SOURCE_CODE_URL:https://github.com/luc-github/BIGTREETECH-TouchScreenFirmware/tree/esp3d-support\n");
+            my_sprintf(buf, "Cap:TOOL_NUM:%d\n", TOOL_NUM);
+            Serial_Puts(SERIAL_PORT_2, buf);
+            my_sprintf(buf, "Cap:EXTRUDER_NUM:%d\n", EXTRUDER_NUM);
+            Serial_Puts(SERIAL_PORT_2, buf);
+            my_sprintf(buf, "Cap:FAN_NUM:%d\n", FAN_NUM);
+            Serial_Puts(SERIAL_PORT_2, buf);
+            Serial_Puts(SERIAL_PORT_2, "ok\n");
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            infoMenu.cur = 1;
+            menuBeforePrinting();
+            return;
+          }
+          break;
+
+        case 524: //M524 
+          if (isPrinting() && !infoHost.printing){
+            abortPrinting();
+            Serial_Puts(SERIAL_PORT_2, "ok\n");
+            infoCmd.count--;
+            infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+            return;
+            }
+          break;
+#endif
 
         case 92: //M92 Steps per unit
           if(cmd_seen('X')) setParameter(P_STEPS_PER_MM, X_AXIS, cmd_float());

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -328,7 +328,7 @@ void sendQueueCmd(void)
         case 115: //M115 TFT
           if (startsWith("M115 TFT", infoCmd.queue[infoCmd.index_r].gcode)) {
             char buf[50];
-            Serial_Puts(SERIAL_PORT_2, "FIRMWARE_NAME: " FIRMWARE_NAME " SOURCE_CODE_URL:https://github.com/luc-github/BIGTREETECH-TouchScreenFirmware/tree/esp3d-support\n");
+            Serial_Puts(SERIAL_PORT_2, "FIRMWARE_NAME: " FIRMWARE_NAME " SOURCE_CODE_URL:https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware\n");
             my_sprintf(buf, "Cap:TOOL_NUM:%d\n", TOOL_NUM);
             Serial_Puts(SERIAL_PORT_2, buf);
             my_sprintf(buf, "Cap:EXTRUDER_NUM:%d\n", EXTRUDER_NUM);

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -410,7 +410,7 @@ void parseACK(void)
     {
       Serial_Puts(ack_cur_src, dmaL2Cache);
     }
-    else if (!ack_seen("ok"))
+    else if (!ack_seen("ok") || ack_seen("T:") || ack_seen("T0:"))
     {
       // make sure we pass on spontaneous messages to all connected ports (since these can come unrequested)
       for (int port = 0; port < _UART_CNT; port++)

--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -115,9 +115,21 @@ void setPrintingTime(u32 RTtime)
 }
 
 //
+u32 getPrintSize(void)
+{
+  return infoPrinting.size;
+}
+
+//
 void setPrintSize(u32 size)
 {
   infoPrinting.size = size;
+}
+
+//
+u32 getPrintCur(void)
+{
+  return infoPrinting.cur;
 }
 
 //

--- a/TFT/src/User/Menu/Printing.h
+++ b/TFT/src/User/Menu/Printing.h
@@ -32,6 +32,8 @@ void setPrintingTime(u32 RTtime);
 
 void setPrintSize(u32 size);
 void setPrintCur(u32 cur);
+u32 getPrintSize(void);
+u32 getPrintCur(void);
 
 u8   getPrintProgress(void);
 u32  getPrintTime(void);


### PR DESCRIPTION
### Description

Add better support for listing files / start print / delete file of TFT SD and TFT USB, uploading file to printer SD and TFT capabilities

### Benefits
More features allowing listing files / start print / delete file of TFT SD and TFT USB
by adding a hook when SD: or U: is added in front of file path
e.g.:
`M20 SD:` List TFT SD files
`M20 U::` List TFT USB files
```
M20 SD:
Begin file list
/MKS.CUR/
End file list
ok
M20 U:
Begin file list
/eclipse/
/Arduino - 1.6.9 -Due 1.6.8/
/GitHub/
/ld5110/
End file list
ok
```
this apply to: 
* M23 and M24 to print file from TFT SD and TFT USB, 
* M25 to pause print file from TFT SD and TFT USB 
* M27 to get print status from print file from TFT SD and TFT USB
* M30 to delete file from  TFT SD and TFT USB 
* M524 to abort printing  from TFT SD and TFT USB

#### Additional features
* M115 TFT give TFT capabilities that could be usefull for ESP3D or any other external program connected to Serial2, and informations can be added of course - this is POC
```
M115 TFT
FIRMWARE_NAME: .26.1 SOURCE_CODE_URL:https://github.com/luc-github/BIGTREETECH-TouchScreenFirmware/tree/esp3d-support
Cap:TOOL_NUM:1
Cap:EXTRUDER_NUM:1
Cap:FAN_NUM:1
ok
```

* M28 / M29 now disable/enable TFT polling and so allow to upload files to printer SD card using this protocol

* M300 TFT to send M300 gcode to TFT only if printer does not support it    

Note: I did not added the upload to TFT SD neither TFT USB but it can be added later

### Related Issues

https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/261