### PR TITLE
Fix send_cancel_gcode in abortPrinting

### DIFF
--- a/TFT/src/User/Menu/Printing.c
+++ b/TFT/src/User/Menu/Printing.c
@@ -718,13 +718,13 @@ void abortPrinting(void)
 
     case TFT_UDISK:
     case TFT_SD:
-      if (infoSettings.send_cancel_gcode == 1)
-        mustStoreCmd(PRINT_CANCEL_GCODE);
-
-      clearCmdQueue();
+      
       break;
   }
+if (infoSettings.send_cancel_gcode == 1)
+        mustStoreCmd(PRINT_CANCEL_GCODE);
 
+  clearCmdQueue();
   heatClearIsWaiting();
 
   endPrinting();


### PR DESCRIPTION
### Description
Fix misplaced send_cancel_gcode in abortPrinting

### Benefits

Enabled Cancel Gcode works now as expected, before it was not executed 

### Related Issues

Cancel Gcode doesn´t work on TFT-SD and U_DISK
