### PR TITLE
Fixed tool switching for multiple extruders, change the default step …

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:M21\n
+custom_gcode_2:G28\nG29\nG0\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:G28\nG29\nG0\n
+custom_gcode_2:M21\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:M21\n
+custom_gcode_2:G28\nG29\nG0\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:G28\nG29\nG0\n
+custom_gcode_2:M21\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling

--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -11,7 +11,7 @@ MENUITEMS babyStepItems = {
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_INC,                  LABEL_INC},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
-  {ICON_01_MM,                LABEL_01_MM},
+  {ICON_001_MM,                LABEL_001_MM},
   {ICON_RESET_VALUE,          LABEL_RESET},
   {ICON_BACK,                 LABEL_BACK},}
 };

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -249,7 +249,7 @@ for (uint8_t i = 0; i < LISTITEM_PER_PAGE; i++)
 
 void menuParameterSettings(void){
     KEY_VALUES key_num = KEY_IDLE;
-    PARAMETERS now = infoParameters;
+    //PARAMETERS now = infoParameters;
     ps_cur_page = 0;
     loadParameterPage();
     menuDrawListPage(&parameterMainItems);
@@ -282,8 +282,9 @@ void menuParameterSettings(void){
             }
             break;
         case KEY_ICON_7:
-            if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
-			    {
+            //if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
+			if(infoMachineSettings.EEPROM == 1)	
+                {
                     storeCmd("M500\n");
                 }
             infoMenu.cur--;

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -249,7 +249,7 @@ for (uint8_t i = 0; i < LISTITEM_PER_PAGE; i++)
 
 void menuParameterSettings(void){
     KEY_VALUES key_num = KEY_IDLE;
-    //PARAMETERS now = infoParameters;
+    PARAMETERS now = infoParameters;
     ps_cur_page = 0;
     loadParameterPage();
     menuDrawListPage(&parameterMainItems);
@@ -282,9 +282,8 @@ void menuParameterSettings(void){
             }
             break;
         case KEY_ICON_7:
-            //if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
-			if(infoMachineSettings.EEPROM == 1)	
-                {
+            if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
+			    {
                     storeCmd("M500\n");
                 }
             infoMenu.cur--;

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -249,7 +249,7 @@ for (uint8_t i = 0; i < LISTITEM_PER_PAGE; i++)
 
 void menuParameterSettings(void){
     KEY_VALUES key_num = KEY_IDLE;
-    PARAMETERS now = infoParameters;
+    //PARAMETERS now = infoParameters;
     ps_cur_page = 0;
     loadParameterPage();
     menuDrawListPage(&parameterMainItems);
@@ -282,7 +282,8 @@ void menuParameterSettings(void){
             }
             break;
         case KEY_ICON_7:
-            if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
+            //if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
+			if(infoMachineSettings.EEPROM == 1)	
                 {
                     storeCmd("M500\n");
                 }

--- a/TFT/src/User/Menu/Parametersetting.c
+++ b/TFT/src/User/Menu/Parametersetting.c
@@ -249,7 +249,7 @@ for (uint8_t i = 0; i < LISTITEM_PER_PAGE; i++)
 
 void menuParameterSettings(void){
     KEY_VALUES key_num = KEY_IDLE;
-    //PARAMETERS now = infoParameters;
+    PARAMETERS now = infoParameters;
     ps_cur_page = 0;
     loadParameterPage();
     menuDrawListPage(&parameterMainItems);
@@ -282,8 +282,7 @@ void menuParameterSettings(void){
             }
             break;
         case KEY_ICON_7:
-            //if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
-			if(infoMachineSettings.EEPROM == 1)	
+            if(memcmp(&now, &infoParameters, sizeof(PARAMETERS)))
                 {
                     storeCmd("M500\n");
                 }

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -271,7 +271,7 @@ void toggleTool(void)
 {
   if (OS_GetTimeMs() > nextTime)
   {
-    if (EXTRUDER_NUM > 1)
+    if (TOOL_NUM > 1)
     {
       current_Ext = (TOOL)((current_Ext + 1) % HEATER_NUM);
       if (current_Ext == 0)

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:M21\n
+custom_gcode_2:G28\nG29\nG0\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -306,7 +306,7 @@ lcd_idle_delay:4
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
-custom_gcode_2:G28\nG29\nG0\n
+custom_gcode_2:M21\n
 custom_label_3:Release sd card
 custom_gcode_3:M22\n
 custom_label_4:restore leveling


### PR DESCRIPTION
### Description

<!--

-->
Status screen fix.
When using multiple extruders, the tempreture display checks the number of extruders instead of the number of tools. Because of this
the temperature on the screen cycles between non-existing tools.

Baby step
the default value for the change is 0.1mm.
This is value is too big for Baby step.
Changing it to 0.01mm makes more sense.


Correct the value in the config.ini file


### Benefits

<!--

 -->
Correct temperature display with multiple extruders
Starting step 0.01mm Baby step
Correct the value in the config.ini file
