### PR TITLE
Fix several formatting errors in config.ini and removed duplicate entries.

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -192,8 +192,8 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.2
-level_z_raise:10
+level_z_pos:0.2f
+level_z_raise:10f
 level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -192,8 +192,8 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.2f
-level_z_raise:10f
+level_z_pos:0.2
+level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -198,7 +198,7 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.1
+level_z_pos:0.2
 level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -193,14 +193,14 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 
 ### Manual Level Points Edge distance (mm)
 # distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [pause_pos: X<distance in mm> Y<distance in mm>]
+# Leveling Edge distance format  [level_edge_distance: <distance from edge in mm>]
 # Leveling Z Position format     [level_z_pos: Z<position in mm>]
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
-level_edge_distance: X20 Y20
-level_z_pos:0.2
+level_edge_distance:20
+level_z_pos:0.1
 level_z_raise:10
-level_feedrate: X6000 Y6000 Z6000
+level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature
 # Maximum Filament name length 7 characters

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -54,14 +54,8 @@ list_border_color:15
 #List View button background color
 list_button_bg_color:15
 
-#Backgroud color for X Y Z position display in Status Screen.
-status_xyz_bg_color:15
-
 #List View Border Color
 list_border_color:15
-
-#List View button background color
-list_button_bg_color:15
 
 #### Rotate UI 180 degrees
 # Options: [enable: 1, disable: 0]

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -192,8 +192,8 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.2
-level_z_raise:10
+level_z_pos:0.2f
+level_z_raise:10f
 level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -198,7 +198,7 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.1
+level_z_pos:0.2
 level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -193,14 +193,14 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 
 ### Manual Level Points Edge distance (mm)
 # distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [pause_pos: X<distance in mm> Y<distance in mm>]
+# Leveling Edge distance format  [level_edge_distance: <distance from edge in mm>]
 # Leveling Z Position format     [level_z_pos: Z<position in mm>]
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
-level_edge_distance: X20 Y20
-level_z_pos:0.2
+level_edge_distance:20
+level_z_pos:0.1
 level_z_raise:10
-level_feedrate: X6000 Y6000 Z6000
+level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature
 # Maximum Filament name length 7 characters

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -54,14 +54,8 @@ list_border_color:15
 #List View button background color
 list_button_bg_color:15
 
-#Backgroud color for X Y Z position display in Status Screen.
-status_xyz_bg_color:15
-
 #List View Border Color
 list_border_color:15
-
-#List View button background color
-list_button_bg_color:15
 
 #### Rotate UI 180 degrees
 # Options: [enable: 1, disable: 0]

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -192,8 +192,8 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.2
-level_z_raise:10
+level_z_pos:0.2f
+level_z_raise:10f
 level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -198,7 +198,7 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
 level_edge_distance:20
-level_z_pos:0.1
+level_z_pos:0.2
 level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -193,14 +193,14 @@ pause_feedrate: X6000 Y6000 Z6000 E600
 
 ### Manual Level Points Edge distance (mm)
 # distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [pause_pos: X<distance in mm> Y<distance in mm>]
+# Leveling Edge distance format  [level_edge_distance: <distance from edge in mm>]
 # Leveling Z Position format     [level_z_pos: Z<position in mm>]
 # Leveling Z raise format        [level_z_raise: Z<distance in mm>]
 # Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
-level_edge_distance: X20 Y20
-level_z_pos:0.2
+level_edge_distance:20
+level_z_pos:0.1
 level_z_raise:10
-level_feedrate: X6000 Y6000 Z6000
+level_feedrate:X6000 Y6000 Z6000
 
 #### Preheat Temperature
 # Maximum Filament name length 7 characters

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -54,14 +54,8 @@ list_border_color:15
 #List View button background color
 list_button_bg_color:15
 
-#Backgroud color for X Y Z position display in Status Screen.
-status_xyz_bg_color:15
-
 #List View Border Color
 list_border_color:15
-
-#List View button background color
-list_button_bg_color:15
 
 #### Rotate UI 180 degrees
 # Options: [enable: 1, disable: 0]


### PR DESCRIPTION
In config.ini the current `level_edge_distance: X20 Y20` is not correct and will cause the printer to go to X0 Y0 when you execute a lower left bed manual bed leveling command.

It seems that under the current implementation, it's actually expecting something like `level_edge_distance:20`

With this change, the nozzle moves to X20 Y20 as expected when leveling routine is run for lower left manual level. I have fixed this, as well as changed the commenting to reflect the change in formatting. 

I also removed some duplicate settings as well.