### PR TITLE
Fix the marlin_fullscreen parameter in config.ini doesn't work.

### DIFF
--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -495,7 +495,11 @@ void parseConfigKey(u16 index)
         strcpy(configStringsStore->marlin_title, pchr);
     }
     break;
-
+      
+  case C_INDEX_MARLIN_FULLSCREEN:
+      infoSettings.marlin_mode_fullscreen = getOnOff();
+    break;
+      
 #endif //ST7920_SPI
 
   //---------------------------------------------------------Printer / Machine Settings

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -484,7 +484,11 @@ void parseConfigKey(u16 index)
   case C_INDEX_MARLIN_SHOW_TITLE:
       infoSettings.marlin_mode_showtitle = getOnOff();
     break;
-
+      
+  case C_INDEX_MARLIN_FULLSCREEN:
+      infoSettings.marlin_mode_fullscreen = getOnOff();
+    break;
+      
   case C_INDEX_MARLIN_TITLE:
     {
       char * pchr;
@@ -494,10 +498,6 @@ void parseConfigKey(u16 index)
       if (inLimit(utf8len,NAME_MIN_LENGTH,MAX_STRING_LENGTH) && inLimit(bytelen,NAME_MIN_LENGTH,MAX_GCODE_LENGTH))
         strcpy(configStringsStore->marlin_title, pchr);
     }
-    break;
-      
-  case C_INDEX_MARLIN_FULLSCREEN:
-      infoSettings.marlin_mode_fullscreen = getOnOff();
     break;
       
 #endif //ST7920_SPI


### PR DESCRIPTION
### Requirements

All supported screens.

### Description
In the config.c file the code reading the marlin_fullscreen parameter from the config.ini file is missing.
### Benefits

Defining the marlin_fullscreen parameter via the config.ini file

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
