### PR TITLE
fix mega2560 "no printer attached!"

### DIFF
--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -47,6 +47,7 @@ void infoMenuSelect(void)
           u32 startUpTime = OS_GetTimeMs();
           heatSetUpdateTime(TEMPERATURE_QUERY_FAST_DURATION);
           LOGO_ReadDisplay();
+          updateNextHeatCheckTime(); // send "M105" 1s later not now, because of mega2560 will be hanged when received data at startup
           while (OS_GetTimeMs() - startUpTime < 3000) //Display 3s logo
           {
             loopProcess();


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
send "M105" 1s later not startup, because of mega2560 will be hanged when received data at startup.
### Benefits
#552 
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
