### PR TITLE
restore default REMINDER_FONT_COLOR, fix aoto load leveling config no…

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -49,7 +49,7 @@ background_color:1
 font_color:0
 
 #Reminder font color, such as: "No print attached", "Busy processing", etc.
-reminder_color:5
+reminder_color:2
 
 #Volume status/reminder font color, such as: "Card inserted", "Card removed"
 volume_status_color:5

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -52,7 +52,7 @@ font_color:0
 reminder_color:5
 
 #Volume status/reminder font color, such as: "Card inserted", "Card removed"
-volume_status_color:5
+volume_status_color:2
 
 #Backgroud color for X Y Z position display in Status Screen.
 status_xyz_bg_color:15

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -116,13 +116,18 @@ void parseACK(void)
 
     if(infoHost.connected == false) //not connected to Marlin
     {
+      // Parse error information even though not connected to printer
+      if(ack_seen(errormagic)) {
+        BUZZER_PLAY(sound_error);
+        ackPopupInfo(errormagic);
+      }
       if(!ack_seen("T:") && !ack_seen("T0:"))  goto parse_end;  //the first response should be such as "T:25/50\n"
-        updateNextHeatCheckTime();
-        infoHost.connected = true;
-        storeCmd("M115\n");
-        storeCmd("M503 S0\n");
-        storeCmd("M92\n"); // Steps/mm of extruder is an important parameter for Smart filament runout
-                           // Avoid can't getting this parameter due to disabled M503 in Marlin
+      updateNextHeatCheckTime();
+      infoHost.connected = true;
+      storeCmd("M115\n");
+      storeCmd("M503 S0\n");
+      storeCmd("M92\n"); // Steps/mm of extruder is an important parameter for Smart filament runout
+                         // Avoid can't getting this parameter due to disabled M503 in Marlin
     }
 
     // Gcode command response

--- a/TFT/src/User/Menu/Settings.c
+++ b/TFT/src/User/Menu/Settings.c
@@ -150,7 +150,7 @@ void initMachineSetting(void){
 
 void setupMachine(void){
   #ifdef AUTO_SAVE_LOAD_LEVELING_VALUE
-    if (infoMachineSettings.autoLevel == 1 && infoMachineSettings.EEPROM == 1){
+    if (infoMachineSettings.autoLevel == 1 && infoMachineSettings.EEPROM == 1 && infoSettings.auto_load_leveling == 1){
       storeCmd("M420 S1\n");
     }
   #endif


### PR DESCRIPTION
restore default REMINDER_FONT_COLOR, fix aoto load leveling config no use, parse error information even though not connected printer

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
