### PR TITLE
Restore the ability to change knob colors on TFT35 E3 v3.0, broken in release 26.1

### DIFF
--- a/TFT/src/User/Menu/ledcolor.c
+++ b/TFT/src/User/Menu/ledcolor.c
@@ -59,7 +59,7 @@ void WS2812_Send_DAT(uint32_t ws2812_dat)
   uint16_t led_num;
   int8_t bit;
   uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency / 800000 / 2 - 1;   // WS2812 need 800KHz (1.25us)
-  uint16_t code_0_tim_h_cnt = cycle * (0.4/1.25);  // Code 0, High level hold time, 0.4us / 1.25us
+  uint16_t code_0_tim_h_cnt = cycle * (0.3.5/1.25);  // Code 0, High level hold time, 0.35us / 1.25us; previous 0.4us was to high for some boards
   uint16_t code_1_tim_h_cnt = cycle - code_0_tim_h_cnt;
 
   __disable_irq();  // Disable interrupt, avoid disturbing the timing of WS2812

--- a/TFT/src/User/Menu/ledcolor.c
+++ b/TFT/src/User/Menu/ledcolor.c
@@ -54,12 +54,15 @@ void set_knob_color(int color_index)
   WS2812_Send_DAT(led_color[color_index]);
 }
 
+#define NEOPIXEL_T0H_US 0.35  // Neopixel code 0 high level hold time in us
+#define NEOPIXEL_T1H_US 1.36  // Neopixel code 1 high level hold time in us
+
 void WS2812_Send_DAT(uint32_t ws2812_dat)
 {
   uint16_t led_num;
   int8_t bit;
-  uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency / 800000 / 2 - 1;   // WS2812 need 800KHz (1.25us)
-  uint16_t code_0_tim_h_cnt = cycle * (0.35/1.25);  // Code 0, High level hold time, 0.35us / 1.25us; previous 0.4us was to high for some boards
+  uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency * (0.000001 * (NEOPIXEL_T0H_US + NEOPIXEL_T1H_US)) / 2 - 1;   // Neopixel frequency 
+  uint16_t code_0_tim_h_cnt = cycle * (NEOPIXEL_T0H_US / (NEOPIXEL_T0H_US + NEOPIXEL_T1H_US));  // Code 0, High level hold time,
   uint16_t code_1_tim_h_cnt = cycle - code_0_tim_h_cnt;
 
   __disable_irq();  // Disable interrupt, avoid disturbing the timing of WS2812

--- a/TFT/src/User/Menu/ledcolor.c
+++ b/TFT/src/User/Menu/ledcolor.c
@@ -59,7 +59,7 @@ void WS2812_Send_DAT(uint32_t ws2812_dat)
   uint16_t led_num;
   int8_t bit;
   uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency / 800000 / 2 - 1;   // WS2812 need 800KHz (1.25us)
-  uint16_t code_0_tim_h_cnt = cycle * (0.3.5/1.25);  // Code 0, High level hold time, 0.35us / 1.25us; previous 0.4us was to high for some boards
+  uint16_t code_0_tim_h_cnt = cycle * (0.35/1.25);  // Code 0, High level hold time, 0.35us / 1.25us; previous 0.4us was to high for some boards
   uint16_t code_1_tim_h_cnt = cycle - code_0_tim_h_cnt;
 
   __disable_irq();  // Disable interrupt, avoid disturbing the timing of WS2812


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Changed knob LED timing from 0.4us to 0.35us to correct colors of the knob on the TFT35 E3
According to the WS2812 documentation 0.35us is the right timing to set here.

### Benefits
<!-- What does this fix or improve? -->

On some TFT35 E3 boards release 26.1 broke the knob lighting. This is caused by different tollerance of the "0" timing of different WS2812 LEDs. This PR restores the ability to set colors to the knob leds or to switch them off.
 
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Resolves #696