### PR TITLE
fix u disk preview model function

### DIFF
--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -9,7 +9,7 @@ FATFS fatfs[FF_VOLUMES]; /* FATFS work area*/
  true: mount ok
  false: mount failed
 */
- bool mountSDCard(void)
+bool mountSDCard(void)
 {
   return (f_mount(&fatfs[VOLUMES_SD_CARD], "SD:", 1) == FR_OK);
 }
@@ -17,7 +17,7 @@ FATFS fatfs[FF_VOLUMES]; /* FATFS work area*/
 /*
  mount U disk from Fatfs
 */
- bool mountUDisk(void)
+bool mountUDisk(void)
 {
   return (f_mount(&fatfs[VOLUMES_U_DISK], "U:", 1)== FR_OK);
 }

--- a/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usbh_usr.c
+++ b/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usbh_usr.c
@@ -379,6 +379,12 @@ uint8_t USBH_UDISK_Read(uint8_t* buf, uint32_t sector, uint32_t cnt)
 
   if (HCD_IsDeviceConnected(&USB_OTG_Core))
   {
+    while(USBH_MSC_BOTXferParam.MSCState != USBH_MSC_DEFAULT_APPLI_STATE)
+    {
+      // Precess the unfinished USB event before being called by FatFs
+      USBH_Process(&USB_OTG_Core, &USB_Host);
+    }
+
     do
     {
       status = USBH_MSC_Read10(&USB_OTG_Core, buf, sector,512 * cnt);
@@ -404,6 +410,12 @@ uint8_t USBH_UDISK_Write(uint8_t* buf, uint32_t sector, uint32_t cnt)
 
   if (HCD_IsDeviceConnected(&USB_OTG_Core))
   {
+    while(USBH_MSC_BOTXferParam.MSCState != USBH_MSC_DEFAULT_APPLI_STATE)
+    {
+      // Precess the unfinished USB event before being called by FatFs
+      USBH_Process(&USB_OTG_Core, &USB_Host);
+    }
+
     do
     {
       status = USBH_MSC_Write10(&USB_OTG_Core, buf, sector, 512 * cnt);

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -323,7 +323,7 @@ void menuPrintFromSource(void)
             if(infoHost.connected !=true) break;
             if(EnterDir(infoFile.file[key_num + start - infoFile.F_num]) == false) break;
 
-            if (infoFile.source == TFT_SD) {
+            if (infoFile.source != BOARD_SD) {
               //load bmp preview in flash if file exists
               int16_t gn;
               char *gnew;


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
fixed u disk can't preview model function after #544
This is because before `f_open` gcode file, the BMP file of the preview icon will be read first, which makes a lot of `f_ read(USBH_ MSC_ Read10)` but did not call `USBH_Process`, which causes USB to pile up a large number of USB tasks.
This PR adds the judgment on the current state of USB  in `f_ read(USBH_ UDISK_ Read)`. If USB is not in idle state, calling `USBH_Process ` first,  and read/write until idle.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
