### PR TITLE
enable PLR for u disk

### DIFF
--- a/TFT/src/User/Menu/PowerFailed.c
+++ b/TFT/src/User/Menu/PowerFailed.c
@@ -24,7 +24,7 @@ bool powerFailedCreate(char *path)
 
   create_ok = false;
 
-  if(infoFile.source != TFT_SD)  return false;//support SD Card only now
+  if(infoFile.source == BOARD_SD)  return false; // on board SD not support now
 
   if(f_open(&fpPowerFailed, powerFailedFileName, FA_OPEN_ALWAYS | FA_WRITE) != FR_OK)  return false;
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
u disk write is ok after #746, so enable `resume printing after power failed ` function for u disk
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
