### PR TITLE
Improve heat menu logic

### DIFF
--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -124,6 +124,9 @@ void heatSetCurrentTool(TOOL tool)
 {
   if(tool >= (infoSettings.tool_count + 1)) return;
   heater.tool = tool;
+  // This is a rough hack with a hardcode to menu item.
+  // I couldn't figure out, how to make it correctly.
+  heatItems.items[KEY_ICON_4] = itemTool[tool];
 }
 /* Get current tool, nozzle or hot bed */
 TOOL heatGetCurrentTool(void)

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -329,10 +329,12 @@ void menuStatus(void)
     switch (key_num)
     {
       case KEY_ICON_0:
-        infoMenu.menu[++infoMenu.cur] = menuUnifiedHeat;
+        heatSetCurrentTool(NOZZLE0);
+        infoMenu.menu[++infoMenu.cur] = menuHeat;
         break;
       case KEY_ICON_1:
-        infoMenu.menu[++infoMenu.cur] = menuUnifiedHeat;
+        heatSetCurrentTool(BED);
+        infoMenu.menu[++infoMenu.cur] = menuHeat;
         break;
       case KEY_ICON_2:
         infoMenu.menu[++infoMenu.cur] = menuFan;


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Improvements for Unified Menu logic:

1. From the Status Screen we can go to nozzle or bed management. How it works now: we get another menu - Unified Heat Menu. And we must to go more deeper before reach the desired tool (nozzle or bed). But I believe that user want to get a corresponding tool immediately. So I made a direct way to it. You can compare this logic with the fan menu. It can be reached directly from the Status Screen. Now the same behavior (direct way) for the nozzle and the bed.

2. Again about nozzle/bed menus. When the user comes to the desired menu he got a Heat Menu with unpredictable target. It can be a nozzle or a bed, in depending of what was the last changed. But! If the user came here from the Status Screen it is obvious that he want to setup the tool from the previous screen. So I made it too, but with a crutch. I don't understand clearly the menus code.

### Benefits

Direct access to the nozzle/bed tools from the Status Screen.

### Related Issues

I didn't raise the issue, just made the changes. I'm not sure is there any related issue.
