### PR TITLE
Adding emulated M601

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -668,6 +668,19 @@ void sendQueueCmd(void)
               speedSetSendWaiting(0, false);
             }
             break;
+
+          #ifdef NOZZLE_PAUSE_M601
+          case 601: //M601 pause print
+            if (isPrinting()) {
+              setPrintPause(true,false);
+              // prevent sending M601 to marlin
+              infoCmd.count--;
+              infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+              return;
+            }
+            break;
+          #endif
+
           case 851: //M851 Z probe offset
             if(cmd_seen('X')) setParameter(P_PROBE_OFFSET, X_AXIS, cmd_float());
             if(cmd_seen('Y')) setParameter(P_PROBE_OFFSET, Y_AXIS, cmd_float());

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -202,6 +202,11 @@
 #define NOZZLE_PAUSE_E_FEEDRATE     6000 // (mm/min) retract & purge feedrate
 #define NOZZLE_PAUSE_XY_FEEDRATE    6000 // (mm/min) X and Y axes feedrate
 #define NOZZLE_PAUSE_Z_FEEDRATE     600  // (mm/min) Z axis feedrate
+/* M601 ; pause print
+ * PrusaSlicer can add this on certain height. Marlin actually does not support this.
+ * Acts here like manual pause
+ */
+//#define NOZZLE_PAUSE_M601
 
 /**
  * Auto Save Load Leveling Data


### PR DESCRIPTION
### Description
This is an improvement / new feature.

Prusa firmware and Prusaslicer support an advanced pause M601.
Prusaslicer can add this to the gcode to pause at certain heights e.g. insert sthg or change filament.

Marlin does not implement M601 at the moment and 
Marlins advanced pause feature (M600) only works with LCD / TFT in Marlin Mode.

### Benefits
* support this advanced pause gcode for prints from sdcard & usb
* enable advanced pause  for serial-only connected displays

### Related Issues

maybe #758

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
