### PR TITLE
Hide .CUR folder when exploring files and folder in the print menu

### DIFF
--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -48,6 +48,8 @@ bool scanPrintFilesFatFs(void)
     if ((finfo.fattrib&AM_DIR) == AM_DIR)
     {
       if (infoFile.F_num >= FOLDER_NUM)  continue;
+	  
+      if (strstr(finfo.fname, ".CUR") != NULL)  continue; // ignore TFTxx.CUR folder
 
       infoFile.folder[infoFile.F_num] = malloc(len);
       if (infoFile.folder[infoFile.F_num] == NULL)  break;


### PR DESCRIPTION
### Description
When flashing a new firmware the folder TFTxx that contains fonts and pictures is renamed.
eg. \TFT35 renamed \TFT35.CUR
This folder does not contain any gcode, so it doesn't need to be showned when exploring files and folders in the print menu.

### Benefits
Hide TFTxx.CUR folder if present when exploring files and folder in the print menu, for better navigation.
