### PR TITLE
Neopixel sequential in accurate 800Khz

### DIFF
--- a/TFT/src/User/Menu/ledcolor.c
+++ b/TFT/src/User/Menu/ledcolor.c
@@ -54,15 +54,15 @@ void set_knob_color(int color_index)
   WS2812_Send_DAT(led_color[color_index]);
 }
 
-// total 2.5us, run in 400Khz
-#define NEOPIXEL_T0H_US 0.35  // Neopixel code 0 high level hold time in us
-#define NEOPIXEL_T1H_US 2.15  // Neopixel code 1 high level hold time in us
+// The signal captured by the logic analyzer shows that this configuration cycle is about 1.35us, run in ~800Khz
+#define NEOPIXEL_T0H_US 0.25  // Neopixel code 0 high level hold time in us
+#define NEOPIXEL_T1H_US 0.75  // Neopixel code 1 high level hold time in us
 
 void WS2812_Send_DAT(uint32_t ws2812_dat)
 {
   uint16_t led_num;
   int8_t bit;
-  uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency * (0.000001 * (NEOPIXEL_T0H_US + NEOPIXEL_T1H_US)) / 2 - 1;   // Neopixel frequency
+  uint16_t cycle = mcuClocks.PCLK1_Timer_Frequency * (0.000001 * (NEOPIXEL_T0H_US + NEOPIXEL_T1H_US)) - 1;   // Neopixel frequency
   uint16_t code_0_tim_h_cnt = cycle * (NEOPIXEL_T0H_US / (NEOPIXEL_T0H_US + NEOPIXEL_T1H_US));  // Code 0, High level hold time,
   uint16_t code_1_tim_h_cnt = cycle - code_0_tim_h_cnt;
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
1. The signal captured by the logic analyzer shows that this configuration cycle is about 1.35us, run in ~800Khz
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
