### PR TITLE
Fix warning: 'cur_item' may be used uninitialized in this function

### DIFF
--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -121,7 +121,7 @@ void menuSimulatorBackGroundColor(void)
   LISTITEM totalItems[LCD_COLOR_COUNT];
   KEY_VALUES key_num = KEY_IDLE;
   SETTINGS now = infoSettings;
-  uint8_t cur_item;
+  uint8_t cur_item = 0;
 
   // fill items
   for(uint8_t i = 0; i < COUNT(totalItems); i++) {
@@ -185,7 +185,7 @@ void menuSimulatorFontColor(void)
   LISTITEM totalItems[LCD_COLOR_COUNT];
   KEY_VALUES key_num = KEY_IDLE;
   SETTINGS now = infoSettings;
-  uint8_t cur_item;
+  uint8_t cur_item = 0;
 
   // fill items
   for(uint8_t i = 0; i < COUNT(totalItems); i++) {


### PR DESCRIPTION
### Description

The uint8_t cur_item is declared but not initialized in two functions, which may lead to undefined behavior. As per the ISO C18 standard: "If an object that has automatic storage duration is not initialized explicitly, its value is indeterminate (section 6.7.9)."

### Benefits

Remove warning when compiling.

### Related Issues

Not applicable.
