### PR TITLE
Fix duplicate update of speeds and flow #826

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -469,20 +469,24 @@ void sendQueueCmd(void)
 
         case 106: //M106
         {
-          u8 i = 0;
-          if(cmd_seen('P')) i = cmd_value();
-          if(cmd_seen('S'))
-          {
-            fanSetSpeed(i, cmd_value());
+          if(!fromTFT) {
+            u8 i = 0;
+            if(cmd_seen('P')) i = cmd_value();
+            if(cmd_seen('S'))
+            {
+              fanSetSpeed(i, cmd_value());
+            }
           }
           break;
         }
 
         case 107: //M107
         {
-          u8 i = 0;
-          if(cmd_seen('P')) i = cmd_value();
-          fanSetSpeed(i, 0);
+          if(!fromTFT) {
+            u8 i = 0;
+            if(cmd_seen('P')) i = cmd_value();
+            fanSetSpeed(i, 0);
+          }
           break;
         }
 
@@ -611,11 +615,11 @@ void sendQueueCmd(void)
           if(cmd_seen('W')) setParameter(P_FWRECOVER,3,cmd_float());
           break;
         case 220: //M220
-          if(cmd_seen('S'))
+          if(!fromTFT && cmd_seen('S'))
             speedSetPercent(0,cmd_value());
           break;
         case 221: //M221
-          if(cmd_seen('S'))
+          if(!fromTFT && cmd_seen('S'))
             speedSetPercent(1,cmd_value());
           break;
 


### PR DESCRIPTION
### Requirements

Rotary encoder BTT TFT

### Description

When using the rotary encoder after https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/commit/41a11faf2384957114bb23421895fa861b6458d4 the values for fan speed, speed and flow were getting stuck in a loop as they were updated from both the respective menu and the command queue via g-code parsing.

### Benefits

Fix loop updating values via menu and command queue.

### Related Issues

Fixes https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/826
