### PR TITLE
Fixed automatic update of fan speed

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -469,24 +469,20 @@ void sendQueueCmd(void)
 
         case 106: //M106
         {
-          if(!fromTFT) {
             u8 i = 0;
             if(cmd_seen('P')) i = cmd_value();
             if(cmd_seen('S'))
             {
               fanSetSpeed(i, cmd_value());
             }
-          }
           break;
         }
 
         case 107: //M107
         {
-          if(!fromTFT) {
             u8 i = 0;
             if(cmd_seen('P')) i = cmd_value();
             fanSetSpeed(i, 0);
-          }
           break;
         }
 


### PR DESCRIPTION
Fixed automatic update of fan speed to status screen when printing if the "Serial_always_on: 0" option is activated

#827 was a bad fix which produced problems with updating values on the status screen
replace it patch #840, #846, #847
 
resolves #843 
