### PR TITLE
Numpad repair

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -114,7 +114,7 @@ void infoSettingsReset(void)
 
 
   infoSettings.pause_pos[X_AXIS]      = NOZZLE_PAUSE_X_POSITION;  // X
-  infoSettings.pause_pos[Y_AXIS]      = NOZZLE_PAUSE_X_POSITION;  // Y
+  infoSettings.pause_pos[Y_AXIS]      = NOZZLE_PAUSE_Y_POSITION;  // Y
   infoSettings.pause_z_raise          = NOZZLE_PAUSE_Z_RAISE;
 
   for(int i = 0; i < TOTAL_AXIS ;i++)

--- a/TFT/src/User/API/UI/Numpad.c
+++ b/TFT/src/User/API/UI/Numpad.c
@@ -96,14 +96,14 @@ float numPadFloat(u8* title, float old_val, bool negative)
     touchSound = false;
     setLargeFont(true);
     u8 nowIndex = 0,lastIndex = 0;
-    char ParameterBuf[BUFLONG + 1] = {0};
+    char ParameterBuf[FLOAT_BUFLONG + 1] = {0};
     u8 prec = (old_val == 0) ? 0 : 2;
     sprintf(ParameterBuf,"%.*f", prec, old_val);
     nowIndex = strlen(ParameterBuf);
 
     if (title == NULL)
     {
-      char tempstr[BUFLONG];
+      char tempstr[FLOAT_BUFLONG + 1];
       sprintf(tempstr, "%.*f", prec, old_val);
       title = (u8 *)tempstr;
     }
@@ -142,7 +142,7 @@ float numPadFloat(u8* title, float old_val, bool negative)
       case NUM_KEY_8:
       case NUM_KEY_9:
       case NUM_KEY_0:
-        if (nowIndex < BUFLONG - 1)
+        if (nowIndex < FLOAT_BUFLONG - 1)
         {
           if(ParameterBuf[0] == '0' && nowIndex == 1)
             nowIndex = lastIndex = 0;
@@ -156,7 +156,7 @@ float numPadFloat(u8* title, float old_val, bool negative)
         }
         break;
       case NUM_KEY_DEC:
-        if (!strchr((const char *)ParameterBuf, numPadKeyChar[key_num][0]) && nowIndex < (BUFLONG - 1))
+        if (!strchr((const char *)ParameterBuf, numPadKeyChar[key_num][0]) && nowIndex < (FLOAT_BUFLONG - 1))
         {
           if (nowIndex == 0 || (nowIndex == 1 && strchr((const char *)ParameterBuf, '-'))) // check if no number exits or only minus exists
             ParameterBuf[nowIndex++] = '0';                                                //add zero before decimal sign if it is the first character
@@ -222,7 +222,7 @@ int32_t numPadInt(u8* title, int32_t old_val, bool negative)
 
     int32_t val = old_val, lastval = 0;
     uint8_t len = 0;
-    char ParameterBuf[7];
+    char ParameterBuf[INT_BUFLONG + 1];
     int8_t neg = 1, lastneg = 1;
 
     if (old_val < 0)
@@ -230,7 +230,7 @@ int32_t numPadInt(u8* title, int32_t old_val, bool negative)
     val = old_val * neg;
     if (title == NULL)
     {
-      char tempstr[BUFLONG];
+      char tempstr[INT_BUFLONG + 1];
       sprintf(tempstr, "%i", old_val);
       title = (u8 *)tempstr;
     }
@@ -283,7 +283,7 @@ int32_t numPadInt(u8* title, int32_t old_val, bool negative)
       case NUM_KEY_9:
       case NUM_KEY_0:
         len = strlen(ParameterBuf);
-        if (len < BUFLONG && !(val == 0 && key_num == NUM_KEY_0))
+        if (len < INT_BUFLONG && !(val == 0 && key_num == NUM_KEY_0))
           {
             int num = (numPadKeyChar[key_num][0] - '0');
             if (val < 0)

--- a/TFT/src/User/API/UI/Numpad.h
+++ b/TFT/src/User/API/UI/Numpad.h
@@ -8,7 +8,8 @@
 #define SKEYWIDTH       LCD_WIDTH/4
 
 #define KEY_NUM 16
-#define BUFLONG 6
+#define FLOAT_BUFLONG 7
+#define INT_BUFLONG 6
 
 typedef enum
 {

--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -102,7 +102,7 @@ void menuBabyStep(void)
     {ICON_BACKGROUND,           LABEL_BACKGROUND},
     {ICON_BACKGROUND,           LABEL_BACKGROUND},
     {ICON_INC,                  LABEL_INC},
-    {ICON_BACKGROUND,           LABEL_BACKGROUND},
+    {ICON_EEPROM_SAVE,          LABEL_EEPROM_SAVE},
     {ICON_01_MM,                LABEL_01_MM},
     {ICON_RESET_VALUE,          LABEL_RESET},
     {ICON_BACK,                 LABEL_BACK},}
@@ -149,6 +149,13 @@ void menuBabyStep(void)
 
           mustStoreCmd("M290 Z%.2f\n", max_unit);
           baby_step_value += max_unit;
+        }
+        break;
+         case KEY_ICON_4:
+        if (infoMachineSettings.EEPROM == 1)
+        {
+          mustStoreCmd("M851 Z%.2f\n", (orig_z_offset + baby_step_value));
+          mustStoreCmd("M500\n");
         }
         break;
 

--- a/TFT/src/User/Menu/BabyStep.c
+++ b/TFT/src/User/Menu/BabyStep.c
@@ -151,10 +151,11 @@ void menuBabyStep(void)
           baby_step_value += max_unit;
         }
         break;
-         case KEY_ICON_4:
+      //save change value  
+      case KEY_ICON_4:
+        mustStoreCmd("M851 Z%.2f\n", (orig_z_offset + baby_step_value)); 
         if (infoMachineSettings.EEPROM == 1)
         {
-          mustStoreCmd("M851 Z%.2f\n", (orig_z_offset + baby_step_value));
           mustStoreCmd("M500\n");
         }
         break;


### PR DESCRIPTION
Fixed entering values via numpad if the value contains 5 digits - resolves #867
typo correction  - mentioned #866
Add a Save button to the BabyStep menu  - mentioned #869