### PR TITLE
Use LF line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ charset = utf-8
 [{*.c,*.cpp,*.h,Makefile}]
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = crlf
+end_of_line = lf
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
### Description

Use LF line endings as most files are already saved with this formatting.

### Benefits

Current line endings aren't re-written with CRLF line endings on every save.

Tested (again) on a fresh Windows 10 & macOS installs with the latest VSCode (1.47.3 as of this PR) + [EditorConfig plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).

### Related Issues

None.