### PR TITLE
Addition of the BabyStep button

### DIFF
--- a/TFT/src/User/Menu/More.c
+++ b/TFT/src/User/Menu/More.c
@@ -39,7 +39,7 @@ void menuMore(void)
      {ICON_PERCENTAGE,              LABEL_PERCENTAGE},
      {ICON_FEATURE_SETTINGS,        LABEL_FEATURE_SETTINGS},
      {ICON_MACHINE_SETTINGS,        LABEL_MACHINE_SETTINGS},
-     {ICON_BACKGROUND,              LABEL_BACKGROUND},
+     {ICON_BABYSTEP,                LABEL_BABYSTEP},
      {ICON_BACK,                    LABEL_BACK},}
   };
 
@@ -79,6 +79,10 @@ void menuMore(void)
         infoMenu.menu[++infoMenu.cur] = menuMachineSettings;
         break;
 
+      case KEY_ICON_6:
+        infoMenu.menu[++infoMenu.cur] = menuBabyStep;
+        break;
+        
       case KEY_ICON_7:
         infoMenu.cur--;
         break;

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -56,8 +56,8 @@ LABEL_BACKGROUND,
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
   {ICON_BACKGROUND,           LABEL_BACKGROUND},
-  {ICON_PAUSE,                LABEL_PAUSE},
   {ICON_BABYSTEP,             LABEL_BABYSTEP},
+  {ICON_PAUSE,                LABEL_PAUSE},
   {ICON_MORE,                 LABEL_MORE},
   {ICON_STOP,                 LABEL_STOP},}
 };
@@ -310,15 +310,14 @@ void toggleinfo(void)
 void printingDrawPage(void)
 {
   //  Scroll_CreatePara(&titleScroll, infoFile.title,&titleRect);  //
+  key_pause = 5;
   if(infoPrinting.model_icon){
-    key_pause = 5;
-    //printingItems.items[key_pause - 1] = itemBlank;
     printingItems.items[key_pause - 1].icon = ICON_PREVIEW;
-    printingItems.items[key_pause - 1].label.index = LABEL_BACKGROUND;
+    printingItems.items[key_pause - 1].label.index = LABEL_BABYSTEP;
   }
   else{
-    key_pause = 4;
-    printingItems.items[key_pause+1] = itemBabyStep;
+    printingItems.items[key_pause - 1].icon = ICON_BABYSTEP;
+    printingItems.items[key_pause - 1].label.index = LABEL_BABYSTEP;
   }
 
     printingItems.items[key_pause] = itemIsPause[isPause()];
@@ -419,20 +418,12 @@ void menuPrinting(void)
     switch(key_num)
     {
       case KEY_ICON_4:
-        if (!infoPrinting.model_icon){
-          setPrintPause(!isPause(), false);
-          resumeToPause(isPause());
-        }
+        infoMenu.menu[++infoMenu.cur] = menuBabyStep;
         break;
 
       case KEY_ICON_5:
-        if (infoPrinting.model_icon){
           setPrintPause(!isPause(), false);
           resumeToPause(isPause());
-        }
-        else{
-          infoMenu.menu[++infoMenu.cur] = menuBabyStep;
-        }
         break;
 
       case KEY_ICON_6:


### PR DESCRIPTION
Addition of the BabyStep button to the More menu.
If a file generated with Cura plagin is printed to create an icon, the Baby Step button is missing in the PrintingMenu.
resolves #943 

Added BabyStep button to More menu.

Added BabyStep button to PrintingMenu, even when a model preview is displayed. Click on the model to display BabyStep


![image](https://user-images.githubusercontent.com/46979052/89739651-bc6bb380-da82-11ea-9e51-24ec859c5d01.png)

![image](https://user-images.githubusercontent.com/46979052/89739658-d4433780-da82-11ea-9a7d-68c8d09a4000.png)

![image](https://user-images.githubusercontent.com/46979052/89739664-e6bd7100-da82-11ea-93ca-b5760a20f4ed.png)
