### PR TITLE
fix some freeze in showLiveInfo

### DIFF
--- a/TFT/src/User/Menu/menu.c
+++ b/TFT/src/User/Menu/menu.c
@@ -355,7 +355,8 @@ void showLiveInfo(uint8_t index, const LIVE_INFO * liveicon, const ITEM * item)
     if (liveicon->enabled[i] == true)
     {
       GUI_SetColor(lcd_colors[liveicon->lines[i].fn_color]);
-      GUI_SetBkColor(lcd_colors[liveicon->lines[i].bk_color]);
+      if (liveicon->lines[i].text_mode != GUI_TEXTMODE_TRANS)
+        GUI_SetBkColor(lcd_colors[liveicon->lines[i].bk_color]);
       GUI_SetTextMode(liveicon->lines[i].text_mode);
 
       GUI_POINT loc;


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
the `bk_color `value is uncertain when `text_mode == GUI_TEXTMODE_TRANS`, so it will freeze if `bk_color ` beyond `LCD_COLOR_COUNT`
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/939#issuecomment-671024642
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
