### PR TITLE
Fix UBL enable by default

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -245,7 +245,7 @@
  * Options:  0: Disabled    1: Enabled    2: Auto-detect [default]
  *
  */
-#define ENABLE_UBL_VALUE 1
+#define ENABLE_UBL_VALUE 2
 
 /**
  * Enable friendly probe offset language.


### PR DESCRIPTION
UBL (AUTO_BED_LEVELING_UBL) is enable by default and for people use AUTO_BED_LEVELING_BILINEAR or other it's not good for leveling settings.
With this parameters set to auto-detect, all is working fine.

See issue https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/985