### PR TITLE
fix & cleanup onboard sd print

### DIFF
--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -1,23 +1,47 @@
 #include "gcode.h"
 #include "includes.h"
 
-REQUEST_COMMAND_INFO requestCommandInfo;
-bool WaitingGcodeResponse=0;
+REQUEST_COMMAND_INFO requestCommandInfo = {0};
 
-static void resetRequestCommandInfo(void)
+static void resetRequestCommandInfo(
+  const char *string_start,  // The magic to identify the start
+  const char *string_stop,   // The magic to identify the stop
+  const char *string_error0, // The first magic to identify the error response
+  const char *string_error1, // The second error magic
+  const char *string_error2  // The third error magic
+)
 {
   requestCommandInfo.cmd_rev_buf = malloc(CMD_MAX_REV);
   while(!requestCommandInfo.cmd_rev_buf); // malloc failed
   memset(requestCommandInfo.cmd_rev_buf,0,CMD_MAX_REV);
+  requestCommandInfo.startMagic = string_start;
+  requestCommandInfo.stopMagic = string_stop;
+  requestCommandInfo.errorMagic[0] = string_error0;
+  requestCommandInfo.errorMagic[1] = string_error1;
+  requestCommandInfo.errorMagic[2] = string_error2;
+  if (string_error0) {
+    requestCommandInfo.error_num = 1;
+  }
+  if (string_error1) {
+    requestCommandInfo.error_num = 2;
+  }
+  if (string_error2) {
+    requestCommandInfo.error_num = 3;
+  }
+
+  while(infoCmd.count || infoHost.wait) {
+    loopProcess(); // Wait for the communication to be clean before requestCommand
+  }
+
   requestCommandInfo.inWaitResponse = true;
   requestCommandInfo.inResponse = false;
   requestCommandInfo.done = false;
   requestCommandInfo.inError = false;
 }
 
-bool RequestCommandInfoIsRunning(void)
+bool requestCommandInfoIsRunning(void)
 {
-   return WaitingGcodeResponse;  //i try to use requestCommandInfo.done but does not work as expected ...
+  return (requestCommandInfo.inWaitResponse || requestCommandInfo.inResponse);
 }
 
 void clearRequestCommandInfo(void)
@@ -36,21 +60,20 @@ void clearRequestCommandInfo(void)
 */
 bool request_M21(void)
 {
-  strcpy(requestCommandInfo.command,"M21\n");
-  strcpy(requestCommandInfo.startMagic,"SD");
-  strcpy(requestCommandInfo.stopMagic,"card ok");
-  strcpy(requestCommandInfo.nosdMagic,"No SD card");
-  strcpy(requestCommandInfo.errorMagic,"volume.init failed");
+  resetRequestCommandInfo(
+  "SD card ",          // The magic to identify the start
+  "ok",                // The magic to identify the stop
+  "No SD card",        // The first magic to identify the error response
+  "SD card failed",    // The second error magic
+  "volume.init failed" // The third error magic
+  );
+  mustStoreCmd("M21\n");
 
-  resetRequestCommandInfo();
-  mustStoreCmd(requestCommandInfo.command);
   // Wait for response
-  WaitingGcodeResponse = 1;
   while (!requestCommandInfo.done)
   {
     loopProcess();
   }
-  WaitingGcodeResponse = 0;
   clearRequestCommandInfo();
   // Check reponse
   return !requestCommandInfo.inError;
@@ -72,19 +95,20 @@ End file list
 */
 char *request_M20(void)
 {
-  strcpy(requestCommandInfo.command,"M20\n");
-  strcpy(requestCommandInfo.startMagic,"Begin file list");
-  strcpy(requestCommandInfo.stopMagic,"End file list");
-  strcpy(requestCommandInfo.errorMagic,"Error");
-  resetRequestCommandInfo();
-  mustStoreCmd(requestCommandInfo.command);
+  resetRequestCommandInfo(
+  "Begin file list", // The magic to identify the start
+  "End file list",   // The magic to identify the stop
+  "Error",           // The first magic to identify the error response
+  NULL,              // The second error magic
+  NULL               // The third error magic
+  );
+  mustStoreCmd("M20\n");
+
   // Wait for response
-  WaitingGcodeResponse = 1;
   while (!requestCommandInfo.done)
   {
     loopProcess();
   }
-  WaitingGcodeResponse = 0;
   //clearRequestCommandInfo(); //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
 }
@@ -98,19 +122,20 @@ char *request_M20(void)
 */
 char * request_M33(char *filename)
 {
-  sprintf(requestCommandInfo.command, "M33 %s\n",filename);
-  strcpy(requestCommandInfo.startMagic,"/"); //a character that is in the line to be treated
-  strcpy(requestCommandInfo.stopMagic,"ok");
-  strcpy(requestCommandInfo.errorMagic,"Cannot open subdir");
-  resetRequestCommandInfo();
-  mustStoreCmd(requestCommandInfo.command);
+  resetRequestCommandInfo(
+  "/",                  // The magic to identify the start
+  "ok",                 // The magic to identify the stop
+  "Cannot open subdir", // The first magic to identify the error response
+  NULL,                 // The second error magic
+  NULL                  // The third error magic
+  );
+  mustStoreCmd("M33 %s\n", filename);
+
   // Wait for response
-  WaitingGcodeResponse = 1;
   while (!requestCommandInfo.done)
   {
     loopProcess();
   }
-  WaitingGcodeResponse = 0;
   //clearRequestCommandInfo(); //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
 }
@@ -127,19 +152,21 @@ char * request_M33(char *filename)
  **/
 long request_M23(char *filename)
 {
-  sprintf(requestCommandInfo.command, "M23 %s\n",filename);
-  strcpy(requestCommandInfo.startMagic, "File opened");
-  strcpy(requestCommandInfo.stopMagic,"File selected");
-  strcpy(requestCommandInfo.errorMagic,"open failed");
-  resetRequestCommandInfo();
-  mustStoreCmd(requestCommandInfo.command);
+  resetRequestCommandInfo(
+  "File opened",   // The magic to identify the start
+  "File selected", // The magic to identify the stop
+  "open failed",   // The first magic to identify the error response
+  NULL,            // The second error magic
+  NULL             // The third error magic
+  );
+  mustStoreCmd("M23 %s\n", filename);
+
   // Wait for response
-  WaitingGcodeResponse = 1;
   while (!requestCommandInfo.done)
   {
     loopProcess();
   }
-  WaitingGcodeResponse = 0;
+  if (requestCommandInfo.inError) return 0;
   // Find file size and report its.
   char *ptr;
   long size = strtol(strstr(requestCommandInfo.cmd_rev_buf,"Size:")+5, &ptr, 10);
@@ -153,11 +180,9 @@ long request_M23(char *filename)
 bool request_M24(int pos)
 {
   if(pos == 0){
-      mustStoreCmd("M24\n");
+    mustStoreCmd("M24\n");
   } else {
-      char command[100];
-      sprintf(command, "M24 S%d\n",pos);
-      mustStoreCmd(command);
+    mustStoreCmd("M24 S%d\n", pos);
   }
   return true;
 }
@@ -186,8 +211,6 @@ bool request_M25(void)
  **/
 bool request_M27(int seconds)
 {
-  char command[10];
-  sprintf(command, "M27 S%d\n",seconds);
-  mustStoreCmd(command);
+  mustStoreCmd("M27 S%d\n", seconds);
   return true;
 }

--- a/TFT/src/User/API/Gcode/gcode.h
+++ b/TFT/src/User/API/Gcode/gcode.h
@@ -5,23 +5,25 @@
 
 #define CMD_MAX_REV     5000
 
+#define MAX_ERROR_NUM   3
 typedef struct {
-    char command[CMD_MAX_CHAR];     // The command sent to printer
-    char startMagic[CMD_MAX_CHAR];  // The magic to identify the start
-    char stopMagic[CMD_MAX_CHAR];   // The magic to identify the stop
-    char nosdMagic[CMD_MAX_CHAR];  // The magic to identify the no sd card response
-    char errorMagic[CMD_MAX_CHAR];  // The magic to identify the error response
-    bool inResponse;                // true if between start and stop magic
-    bool inWaitResponse;            // true if waiting for start magic
-    bool done;                      // true if command is executed and response is received
-    bool inError;                   // true if error response
-    char *cmd_rev_buf;              // buffer where store the command response
+  char *cmd_rev_buf;     // buffer where store the command response
+  const char *startMagic; // The magic to identify the start
+  const char *stopMagic;  // The magic to identify the stop
+  const char *errorMagic[MAX_ERROR_NUM];
+                         // The magic to identify the error response
+                         // Some Gcode respond to multiple errors, such as:M21 -- "SD card failed", "No SD card", "volume.init failed"
+  uint8_t error_num;     // Number of error magic corresponding to current Gcode
+  bool inResponse;       // true if between start and stop magic
+  bool inWaitResponse;   // true if waiting for start magic
+  bool done;             // true if command is executed and response is received
+  bool inError;          // true if error response
 } REQUEST_COMMAND_INFO;
 
 extern REQUEST_COMMAND_INFO requestCommandInfo;
 
 void clearRequestCommandInfo(void);
-bool RequestCommandInfoIsRunning(void);
+bool requestCommandInfoIsRunning(void);
 bool request_M21(void);
 char * request_M20(void);
 char * request_M33(char *filename);

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -147,7 +147,7 @@ void loopCheckHeater(void)
   {  // Send M105 query temperature continuously
     if(heat_update_waiting == true) {updateNextHeatCheckTime();break;}
     if(OS_GetTimeMs() < nextHeatCheckTime)     break;
-    if(RequestCommandInfoIsRunning())          break; //to avoid colision in Gcode response processing
+    if(requestCommandInfoIsRunning())          break; //to avoid colision in Gcode response processing
     if(storeCmd("M105\n") == false)            break;
     updateNextHeatCheckTime();
     heat_update_waiting = true;

--- a/TFT/src/User/API/extend.c
+++ b/TFT/src/User/API/extend.c
@@ -86,7 +86,7 @@ bool FIL_SmartRunoutDetect(void)
   {  /* Send M114 E query extrude position continuously	*/
     if(update_waiting == true)        {nextTime=OS_GetTimeMs()+update_time;break;}
     if(OS_GetTimeMs()<nextTime)       break;
-    if(RequestCommandInfoIsRunning()) break; //to avoid colision in Gcode response processing
+    if(requestCommandInfoIsRunning()) break; //to avoid colision in Gcode response processing
     if(storeCmd("M114 E\n")==false)   break;
 
     nextTime=OS_GetTimeMs()+update_time;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -218,7 +218,9 @@ void parseACK(void)
         requestCommandInfo.inResponse = true;
         requestCommandInfo.inWaitResponse = false;
       }
-      else if (ack_seen(requestCommandInfo.nosdMagic) || ack_seen(requestCommandInfo.errorMagic))
+      else if ((requestCommandInfo.error_num > 0 && ack_seen(requestCommandInfo.errorMagic[0]))
+            || (requestCommandInfo.error_num > 1 && ack_seen(requestCommandInfo.errorMagic[1]))
+            || (requestCommandInfo.error_num > 2 && ack_seen(requestCommandInfo.errorMagic[2])))
       { //parse onboard sd error
         requestCommandInfo.done = true;
         requestCommandInfo.inResponse = false;
@@ -300,7 +302,7 @@ void parseACK(void)
         coordinateSetAxisActualSteps(E_AXIS, ack_value());
       }
 
-      else if(ack_seen(bsdnoprintingmagic) && infoMenu.menu[infoMenu.cur] == menuPrinting && infoMachineSettings.onboard_sd_support == ENABLED)
+      else if(ack_seen(bsdnoprintingmagic) && infoMachineSettings.onboard_sd_support == ENABLED)
       {
         infoHost.printing = false;
         completePrinting();
@@ -309,7 +311,7 @@ void parseACK(void)
       {
         if(infoMenu.menu[infoMenu.cur] != menuPrinting && !infoHost.printing) {
           infoMenu.menu[++infoMenu.cur] = menuPrinting;
-          infoHost.printing=true;
+          infoHost.printing = true;
         }
         // Parsing printing data
         // Example: SD printing byte 123/12345

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -301,13 +301,12 @@ void parseACK(void)
       {
         coordinateSetAxisActualSteps(E_AXIS, ack_value());
       }
-
-      else if(ack_seen(bsdnoprintingmagic) && infoMachineSettings.onboard_sd_support == ENABLED)
+      else if(infoMachineSettings.onboard_sd_support == ENABLED && ack_seen(bsdnoprintingmagic))
       {
         infoHost.printing = false;
         completePrinting();
       }
-      else if(ack_seen(bsdprintingmagic) && infoMachineSettings.onboard_sd_support == ENABLED)
+      else if(infoMachineSettings.onboard_sd_support == ENABLED && ack_seen(bsdprintingmagic))
       {
         if(infoMenu.menu[infoMenu.cur] != menuPrinting && !infoHost.printing) {
           infoMenu.menu[++infoMenu.cur] = menuPrinting;
@@ -319,6 +318,11 @@ void parseACK(void)
         u32 position = strtol(strstr(dmaL2Cache, "byte ") + 5, &ptr, 10);
         setPrintCur(position);
   //      powerFailedCache(position);
+      }
+      else if(infoMachineSettings.onboard_sd_support == ENABLED && ack_seen("Done printing file"))
+      {
+        infoPrinting.printing = false;
+        infoPrinting.cur = infoPrinting.size; // for onboard sd printing
       }
 
     //parse and store stepper steps/mm values

--- a/TFT/src/User/Menu/More.c
+++ b/TFT/src/User/Menu/More.c
@@ -39,7 +39,7 @@ void menuMore(void)
      {ICON_PERCENTAGE,              LABEL_PERCENTAGE},
      {ICON_FEATURE_SETTINGS,        LABEL_FEATURE_SETTINGS},
      {ICON_MACHINE_SETTINGS,        LABEL_MACHINE_SETTINGS},
-     {ICON_BABYSTEP,                LABEL_BABYSTEP},
+     {ICON_GCODE,                   LABEL_TERMINAL},
      {ICON_BACK,                    LABEL_BACK},}
   };
 
@@ -80,7 +80,7 @@ void menuMore(void)
         break;
 
       case KEY_ICON_6:
-        infoMenu.menu[++infoMenu.cur] = menuBabyStep;
+        infoMenu.menu[++infoMenu.cur] = menuSendGcode;
         break;
         
       case KEY_ICON_7:

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -72,6 +72,8 @@ const ITEM itemIsPause[2] = {
 
 void completePrinting(void)
 {
+  infoPrinting.printing = false;
+  infoPrinting.cur = infoPrinting.size; // for onboard sd printing
   printingItems.items[KEY_ICON_7].icon = ICON_BACK;
   printingItems.items[KEY_ICON_7].label.index = LABEL_BACK;
   if (infoMenu.menu[infoMenu.cur] == menuPrinting)
@@ -118,7 +120,7 @@ void menuBeforePrinting(void)
         request_M27(0);
       }
 
-      infoHost.printing=true; // Global lock info on printer is busy in printing.
+      infoHost.printing = true; // Global lock info on printer is busy in printing.
 
       break;
 

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -72,8 +72,6 @@ const ITEM itemIsPause[2] = {
 
 void completePrinting(void)
 {
-  infoPrinting.printing = false;
-  infoPrinting.cur = infoPrinting.size; // for onboard sd printing
   printingItems.items[KEY_ICON_7].icon = ICON_BACK;
   printingItems.items[KEY_ICON_7].label.index = LABEL_BACK;
   if (infoMenu.menu[infoMenu.cur] == menuPrinting)

--- a/TFT/src/User/Menu/menu.c
+++ b/TFT/src/User/Menu/menu.c
@@ -634,7 +634,7 @@ void loopBackEnd(void)
   loopBuzzer();
 #endif
 
-if(infoMachineSettings.onboard_sd_support == ENABLED && infoMachineSettings.autoReportSDStatus == DISABLED)
+  if(infoMachineSettings.onboard_sd_support == ENABLED && infoMachineSettings.autoReportSDStatus == DISABLED)
   {
     loopCheckPrinting(); //Check if there is a SD or USB print running.
   }


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
* cleanup `requestCommand` code, Flash use reduced 100 bytes, Global RAM use reduced 470 + bytes
* M21 start Magic “SD” modify to "SD Card ", because error Magic "No SD Card" will be parsed to start Magic 
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
