### PR TITLE
Change Extrude icon in Tuning menu

### DIFF
--- a/TFT/src/User/Menu/Tuning.c
+++ b/TFT/src/User/Menu/Tuning.c
@@ -9,7 +9,7 @@ void menuTuning(void)
     LABEL_TUNING,
     // icon                         label
     {{ICON_PID,                     LABEL_PID},
-     {ICON_EXTRUDE_100,             LABEL_TUNE_EXTRUDER},
+     {ICON_EXTRUDE,             LABEL_TUNE_EXTRUDER},
      {ICON_BACKGROUND,              LABEL_BACKGROUND},
      {ICON_BACKGROUND,              LABEL_BACKGROUND},
      {ICON_BACKGROUND,              LABEL_BACKGROUND},


### PR DESCRIPTION
I think it's better to use extrude icon (without 100mm inscription) in Tuning menu.

![IMG_1666](https://user-images.githubusercontent.com/12702322/90670298-453cd900-e253-11ea-9892-390465d33dd0.jpg)
