### PR TITLE
Fix freeze issues with TFT24 displays

### DIFF
--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -370,8 +370,6 @@ void showLiveInfo(uint8_t index, const LIVE_INFO * liveicon, const ITEM * item)
     if (liveicon->enabled[i] == true)
     {
       GUI_SetColor(lcd_colors[liveicon->lines[i].fn_color]);
-      if (liveicon->lines[i].text_mode != GUI_TEXTMODE_TRANS)
-        GUI_SetBkColor(lcd_colors[liveicon->lines[i].bk_color]);
       GUI_SetTextMode(liveicon->lines[i].text_mode);
 
       GUI_POINT loc;

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -111,7 +111,6 @@ typedef struct
   uint8_t         h_align; //left, right or center of pos point
   uint8_t         v_align; //left, right or center of pos point
   uint16_t        fn_color;
-  uint16_t        bk_color;
   GUI_TEXT_MODE   text_mode;
 }LIVE_DATA;
 


### PR DESCRIPTION
# Description

This change prevents freezing issues seen on TFT24 displays. The issue may be with the bk_color going out of the array bounds of lcd_colors and causing a freeze as result. Since bk_color is not used for anything in the code today. I think it should be removed and implemented back in if or when needed. 

### Benefits
Corrects issues seen with TFT24 displays freezing or locking up on the status screen.


### Related Issues

#999 