### PR TITLE
Sanity check update - ST7920_SPI, STARTUP_KNOB_LED_COLOR and multi bu…

### DIFF
--- a/TFT/src/User/API/LCD_Encoder.h
+++ b/TFT/src/User/API/LCD_Encoder.h
@@ -21,7 +21,9 @@ extern "C" {
 extern int16_t encoderPosition;
 
 void HW_EncoderInit(void);
-bool encoder_ReadBtn(uint16_t intervals);
+#if LCD_ENCODER_SUPPORT
+  bool encoder_ReadBtn(uint16_t intervals);
+#endif
 bool LCD_ReadPen(uint16_t intervals);
 bool LCD_BtnTouch(uint16_t intervals);
 uint8_t LCD_ReadTouch(void);

--- a/TFT/src/User/Menu/Selectmode.c
+++ b/TFT/src/User/Menu/Selectmode.c
@@ -85,7 +85,12 @@ void loopCheckMode(void)
     return;
 
 //  #endif
-  if(LCD_ReadPen(LCD_CHANGE_MODE_INTERVALS) || encoder_ReadBtn(LCD_CHANGE_MODE_INTERVALS))
+  if(LCD_ReadPen(LCD_CHANGE_MODE_INTERVALS) 
+#if LCD_ENCODER_SUPPORT 
+      || encoder_ReadBtn(LCD_CHANGE_MODE_INTERVALS)
+#endif
+    )
+
   {
     infoMenu.menu[++infoMenu.cur] = menuMode;
   }

--- a/TFT/src/User/SanityCheck.h
+++ b/TFT/src/User/SanityCheck.h
@@ -18,26 +18,38 @@
     #ifdef CLEAN_MODE_SWITCHING_SUPPORT
     #error "CLEAN_MODE_SWITCHING_SUPPORT is now SERIAL_ALWAYS_ON. Please update your configuration."
     #endif
+#else
+    #if defined(_PIN_TFT35_V2_0_H_) || defined(_PIN_TFT35_V1_0_H_)
+      #ifdef DEFAULT_LCD_MODE
+        #undef DEFAULT_LCD_MODE
+      #endif
+      #define DEFAULT_LCD_MODE SERIAL_TSC  // Just set hardcoded here. 
+      //#warning "DEFAULT_LCD_MODE supports only SERIAL_TSC. Please update/check your configuration."
+    #endif
 #endif
 
+
+
 #ifdef LED_COLOR_PIN
+    #ifdef STARTUP_KNOB_LED_COLOR
+        #if STARTUP_KNOB_LED_COLOR < 0
+            #error "STARTUP_KNOB_LED_COLOR cannot be less than 1"
+        #endif
 
-  #ifdef STARTUP_KNOB_LED_COLOR
-    #if STARTUP_KNOB_LED_COLOR < 0
-        #error "STARTUP_knob_LED_COLOR cannot be less than 1"
-    #endif
-
-    #if STARTUP_KNOB_LED_COLOR > 8
-        #error "STARTUP_knob_LED_COLOR cannot be greater than 9"
-    #endif
-  #else
+        #if STARTUP_KNOB_LED_COLOR > 8
+            #error "STARTUP_KNOB_LED_COLOR cannot be greater than 9"
+        #endif
+    #else
         #define STARTUP_KNOB_LED_COLOR 0
-  #endif
-
+    #endif
 #else
-
+    #ifdef STARTUP_KNOB_LED_COLOR
+        #if STARTUP_KNOB_LED_COLOR > 0
+            //#warning "STARTUP_KNOB_LED_COLOR is not supported on this target and must be set to 0"
+            #undef STARTUP_KNOB_LED_COLOR
+        #endif
+    #endif
     #define STARTUP_KNOB_LED_COLOR 0
-
 #endif
 
 #ifdef EXTRUDE_STEPS


### PR DESCRIPTION
…ild fixes

Check ST7920_SPI on non supported hw targets
undef STARTUP_KNOB_LED_COLOR before (re)define
LCD_ENCODER_SUPPORT dependency check for func encoder_ReadBtn