### PR TITLE
Fixed update of print speed value in PrintingMenu

### DIFF
--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -60,7 +60,7 @@ void loopSpeed(void)
 
 void speedQuery(void)
 {
-  if (infoHost.connected == true && infoHost.wait == false)
+  if (infoHost.connected == true)
   {
     if (!queryWait)
     {

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -261,6 +261,7 @@ void toggleinfo(void)
       reDrawFan(FAN_ICON_POS);
     }
 
+    storeCmd("M220\nM221\n");
     c_speedID = (c_speedID + 1) % 2;
     nextTime = OS_GetTimeMs() + toggle_time;
     rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling


### PR DESCRIPTION
Fixed update of print speed value in PrintingMenu

Resolves #1048 

PR #1051 only worked when heating the pad and hotend. The print speed value was no longer updated after the print head started moving.
PR #1065 works all the time
