### PR TITLE
Option for Mixing_extruder

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -581,7 +581,7 @@ void parseACK(void)
         {
           string = (uint8_t *)&dmaL2Cache[ack_index];
           string_start = ack_index;
-          if (ack_seen("EXTRUDER_COUNT:"))
+          if (ack_seen("EXTRUDER_COUNT:")&&(MIXING_EXTRUDER ==0))
           {
             infoSettings.ext_count = ack_value();
             string_end = ack_index - sizeof("EXTRUDER_COUNT:");

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -581,9 +581,12 @@ void parseACK(void)
         {
           string = (uint8_t *)&dmaL2Cache[ack_index];
           string_start = ack_index;
-          if (ack_seen("EXTRUDER_COUNT:")&&(MIXING_EXTRUDER ==0))
+          if (ack_seen("EXTRUDER_COUNT:"))
           {
+            if (MIXING_EXTRUDER == 0)
+            {
             infoSettings.ext_count = ack_value();
+            }
             string_end = ack_index - sizeof("EXTRUDER_COUNT:");
           }
           infoSetMachineType(string, string_end - string_start); // Set firmware name

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -171,6 +171,7 @@
 #define EXTRUDER_NUM 1    // set in 1~6
 #define FAN_NUM      1    // set in 1~6
 #define FAN_CTRL_NUM 0    // set in 1~2
+#define MIXING_EXTRUDER 0 // set default 0, for mixing_extruder 1 (this option turns off autodetection of the number of extruders)
 
 #define PREHEAT_LABELS   {"PLA", "PETG", "ABS", "WOOD", "TPU", "NYLON"}
 #define PREHEAT_HOTEND   {200,   240,    230,   170,    220,   250}


### PR DESCRIPTION
If the Mixing_extruder option is selected in Marlin, the printer uses two extruders, but reports only one extruder at the M115 command.

The FW display overwrites the manually entered number of extruders with what the printer reports.
This option disables the value override, and the value specified in Configuration.h is used

resolves #1055
resolves #1043

