### PR TITLE
make language set at compile time save ~72kb flash

### DIFF
--- a/TFT/src/User/API/Language/Language.c
+++ b/TFT/src/User/API/Language/Language.c
@@ -1,173 +1,315 @@
+#define LANGUAGE_CHECK
 #include "Language.h"
 #include "includes.h"
+
+#if LANGUAGE_CHECK==0
 #include "language_en.h"
+#elif LANGUAGE_CHECK==1
 #include "language_cn.h"
+#elif LANGUAGE_CHECK==2
 #include "language_ru.h"
+#elif LANGUAGE_CHECK==3
 #include "language_jp.h"
+#elif LANGUAGE_CHECK==5
 #include "language_de.h"
+#elif LANGUAGE_CHECK==4
 #include "language_am.h"
+#elif LANGUAGE_CHECK==6
 #include "language_cz.h"
+#elif LANGUAGE_CHECK==7
 #include "language_es.h"
+#elif LANGUAGE_CHECK==8
 #include "language_fr.h"
+#elif LANGUAGE_CHECK==9
 #include "language_pt.h"
+#elif LANGUAGE_CHECK==10
 #include "language_it.h"
+#elif LANGUAGE_CHECK==11
 #include "language_pl.h"
+#elif LANGUAGE_CHECK==12
 #include "language_sk.h"
+#elif LANGUAGE_CHECK==13
 #include "language_du.h"
+#elif LANGUAGE_CHECK==14
 #include "language_hu.h"
+#elif LANGUAGE_CHECK==15
 #include "language_tr.h"
+#elif LANGUAGE_CHECK==16
 #include "language_gr.h"
+#elif LANGUAGE_CHECK==17
 #include "language_sl.h"
+#elif LANGUAGE_CHECK==18
 #include "language_ca.h"
+#elif LANGUAGE_CHECK==19
 #include "language_tc.h"
+#endif
 //
 // Add new Keywords in Language.inc file Only
 //
+#if(LANGUAGE_CHECK==0)
 const char *const en_pack[LABEL_NUM] = {
   #define X_WORD(NAME) EN_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+
+
+#elif(LANGUAGE_CHECK==1)
 const char *const cn_pack[LABEL_NUM] = {
   #define X_WORD(NAME) CN_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+
+#elif(LANGUAGE_CHECK==2)
 const char *const ru_pack[LABEL_NUM] = {
   #define X_WORD(NAME) RU_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+
+#elif(LANGUAGE_CHECK==3)
 const char *const jp_pack[LABEL_NUM] = {
   #define X_WORD(NAME) JP_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+
+#elif(LANGUAGE_CHECK==4)
 const char *const am_pack[LABEL_NUM] = {
   #define X_WORD(NAME) AM_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+
+#elif(LANGUAGE_CHECK==5)
 const char *const de_pack[LABEL_NUM] = {
   #define X_WORD(NAME) DE_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==6)
 const char *const cz_pack[LABEL_NUM] = {
   #define X_WORD(NAME) CZ_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==7)
 const char *const es_pack[LABEL_NUM] = {
   #define X_WORD(NAME) ES_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==8)
 const char *const fr_pack[LABEL_NUM] = {
   #define X_WORD(NAME) FR_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==9)
 const char *const pt_pack[LABEL_NUM] = {
   #define X_WORD(NAME) PT_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==10)
 const char *const it_pack[LABEL_NUM] = {
   #define X_WORD(NAME) IT_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==11)
 const char *const pl_pack[LABEL_NUM] = {
   #define X_WORD(NAME) PL_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==12)
 const char *const sk_pack[LABEL_NUM] = {
   #define X_WORD(NAME) SK_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==13)
 const char *const du_pack[LABEL_NUM] = {
   #define X_WORD(NAME) DU_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==14)
 const char *const hu_pack[LABEL_NUM] = {
   #define X_WORD(NAME) HU_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==15)
 const char *const tr_pack[LABEL_NUM] = {
   #define X_WORD(NAME) TR_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==16)
 const char *const gr_pack[LABEL_NUM] = {
   #define X_WORD(NAME) GR_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==17)
 const char *const sl_pack[LABEL_NUM] = {
   #define X_WORD(NAME) SL_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==18)
 const char *const ca_pack[LABEL_NUM] = {
   #define X_WORD(NAME) CA_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
 
+#elif(LANGUAGE_CHECK==19)
 const char *const tc_pack[LABEL_NUM] = {
   #define X_WORD(NAME) TC_##NAME ,
   #include "Language.inc"
   #undef  X_WORD
 };
+#endif
 
+#if(LANGUAGE_CHECK==0)
 uint8_t *textSelect(uint16_t sel)
 {
-  switch(infoSettings.language)
-  {
-    case ENGLISH:       return (uint8_t *)en_pack[sel];
-    case CHINESE:       return (uint8_t *)cn_pack[sel];
-    case RUSSIAN:       return (uint8_t *)ru_pack[sel];
-    case JAPANESE:      return (uint8_t *)jp_pack[sel];
-    case ARMENIAN:      return (uint8_t *)am_pack[sel];
-    case GERMAN:        return (uint8_t *)de_pack[sel];
-    case CZECH:         return (uint8_t *)cz_pack[sel];
-    case SPAIN:         return (uint8_t *)es_pack[sel];
-    case FRENCH:        return (uint8_t *)fr_pack[sel];
-    case PORTUGUESE:    return (uint8_t *)pt_pack[sel];
-    case ITALIAN:       return (uint8_t *)it_pack[sel];
-    case POLISH:        return (uint8_t *)pl_pack[sel];
-    case SLOVAK:        return (uint8_t *)sk_pack[sel];
-    case DUTCH:         return (uint8_t *)du_pack[sel];
-    case HUNGARIAN:     return (uint8_t *)hu_pack[sel];
-    case TURKISH:       return (uint8_t *)tr_pack[sel];
-    case GREEK:         return (uint8_t *)gr_pack[sel];
-    case SLOVENIAN:     return (uint8_t *)sl_pack[sel];
-    case CATALAN:       return (uint8_t *)ca_pack[sel];
-    case TRAD_CHINESE:  return (uint8_t *)tc_pack[sel];
-
-    default:            return NULL;
-  }
+  return (uint8_t *)en_pack[sel];
 }
+
+#elif(LANGUAGE_CHECK==1)
+uint8_t *textSelect(uint16_t sel)
+{
+     return (uint8_t *)cn_pack[sel];
+}
+   
+#elif(LANGUAGE_CHECK==2)
+uint8_t *textSelect(uint16_t sel)
+{
+     return (uint8_t *)ru_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==3)
+uint8_t *textSelect(uint16_t sel)
+{
+    return (uint8_t *)jp_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==4)
+ uint8_t *textSelect(uint16_t sel)
+{
+    return (uint8_t *)am_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==5)
+ uint8_t *textSelect(uint16_t sel)
+{
+      return (uint8_t *)de_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==6)
+ uint8_t *textSelect(uint16_t sel)
+{
+       return (uint8_t *)cz_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==7)
+ uint8_t *textSelect(uint16_t sel)
+{
+       return (uint8_t *)es_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==8)
+ uint8_t *textSelect(uint16_t sel)
+{
+      return (uint8_t *)fr_pack[sel];
+}
+   
+#elif(LANGUAGE_CHECK==9)
+ uint8_t *textSelect(uint16_t sel)
+{
+    case PORTUGUESE:    return (uint8_t *)pt_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==10)
+ uint8_t *textSelect(uint16_t sel)
+{
+     return (uint8_t *)it_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==11)
+ uint8_t *textSelect(uint16_t sel)
+{
+      return (uint8_t *)pl_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==12)
+ uint8_t *textSelect(uint16_t sel)
+{
+      return (uint8_t *)sk_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==13)
+ uint8_t *textSelect(uint16_t sel)
+{
+       return (uint8_t *)du_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==14)
+ uint8_t *textSelect(uint16_t sel)
+{
+     case HUNGARIAN:     return (uint8_t *)hu_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==15)
+ uint8_t *textSelect(uint16_t sel)
+{
+      return (uint8_t *)tr_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==16)
+ uint8_t *textSelect(uint16_t sel)
+{
+       return (uint8_t *)gr_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==17)
+ uint8_t *textSelect(uint16_t sel)
+{
+    case SLOVENIAN:     return (uint8_t *)sl_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==18)
+ uint8_t *textSelect(uint16_t sel)
+{
+     return (uint8_t *)ca_pack[sel];
+}
+
+#elif(LANGUAGE_CHECK==19)
+ uint8_t *textSelect(uint16_t sel)
+{
+    return (uint8_t *)tc_pack[sel];
+}
+#endif

--- a/TFT/src/User/API/Language/Language.h
+++ b/TFT/src/User/API/Language/Language.h
@@ -4,9 +4,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 #include <stdbool.h>
 #include "variants.h"
+#include "SetLanguage.h"
 
 enum
 {

--- a/TFT/src/User/API/Language/SetLanguage.h
+++ b/TFT/src/User/API/Language/SetLanguage.h
@@ -1,0 +1,53 @@
+#define _SetLanguage_H_
+// Please set LANGUAGE_CHECK and DEAGAULT_LANGUAGE here. 
+
+/*
+# Select the language to display on the LCD while in Touch Mode.
+# Options: [ENGLISH: 0,  CHINESE: 1,     RUSSIAN: 2,  JAPANESE: 3,    ARMENIAN: 4,
+#            GERMAN: 5,    CZECH: 6,       SPAIN: 7,    FRENCH: 8,  PORTUGUESE: 9,
+#           ITALIAN: 10,  POLISH: 11,     SLOVAK: 12,    DUTCH: 13,  HUNGARIAN: 14,
+#           TURKISH: 15,   GREEK: 16,  SLOVENIAN: 17,  CATALAN: 18]
+*/
+#ifdef LANGUAGE_CHECK
+#undef LANGUAGE_CHECK
+#define LANGUAGE_CHECK 0
+#endif
+
+/**
+ * Default Touch Mode Language
+ * Select the language to display on the LCD while in Touch Mode.
+ * Options: ARMENIAN, CHINESE, CZECH, DUTCH, ENGLISH, FRENCH, GERMAN, HUNGARIAN, ITALIAN, JAPANESE, POLISH, PORTUGUESE, RUSSIAN, SLOVAK, SPAIN, CATALAN
+ */
+#ifdef DEFAULT_LANGUAGE
+#undef DEFAULT_LANGUAGE
+#define DEFAULT_LANGUAGE ENGLISH
+#endif
+
+
+/* 
+*********************changes made to make language set at compile time **********
+added #include "SetLanguage.h" to: language.h and configuration.h
+edited default_language and its comment in configuration.h
+Removed set language from screensettings menu. replaced with background.
+*************************** can removed *********
+* after some more tweaking the following maynot be needed:
+* config.c (line 470):
+     case C_INDEX_LANGUAGE:
+    if (inLimit(config_int(), 0, LANGUAGE_NUM-1))
+      infoSettings.language = config_int();
+    break;
+*
+* config.h (line 20)
+    #define CONFIG_LANGUAGE             "language:"
+*
+* Config.ini (line 37 to line 43)
+*
+*Settings.h line 78
+*
+*congif.inc line 12 X_CONFIG(LANGUAGE)
+*
+*flashstore.c line 75 and line 211
+ infoSettings.language             = byteToWord(data + (index += 4), 4);
+*
+* language.h line 11 to line 35
+*/

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1,6 +1,15 @@
 #ifndef _CONFIGURATION_H_
 #define _CONFIGURATION_H_
 #define CONFIG_VERSION 20200810
+
+/**
+ * Default Touch Mode Language
+ do not change it is set in SetLanguage.h
+ */
+#define DEFAULT_LANGUAGE
+
+#include "SetLanguage.h"
+
 //===========================================================================
 //============================= General Settings ============================
 //===========================================================================
@@ -106,13 +115,6 @@
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
 #define BAUDRATE 115200
-
-/**
- * Default Touch Mode Language
- * Select the language to display on the LCD while in Touch Mode.
- * Options: ARMENIAN, CHINESE, CZECH, DUTCH, ENGLISH, FRENCH, GERMAN, HUNGARIAN, ITALIAN, JAPANESE, POLISH, PORTUGUESE, RUSSIAN, SLOVAK, SPAIN, CATALAN
- */
-#define DEFAULT_LANGUAGE ENGLISH
 
 /**
  * Show bootscreen when starting up

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -16,76 +16,6 @@
   #define LCD12864_FN_INDEX (LCD12864_BG_INDEX+1)
 #endif
 
-
-void menuLanguage(void)
-{
-  #define LANGUAGE_PAGE_COUNT  (LANGUAGE_NUM + LISTITEM_PER_PAGE - 1) / LISTITEM_PER_PAGE
-  LABEL title = {LABEL_LANGUAGE};
-  LISTITEM totalItems[LANGUAGE_NUM];
-  KEY_VALUES key_num = KEY_IDLE;
-  SETTINGS now = infoSettings;
-
-  // fill language items
-  uint8_t tmp_language = infoSettings.language;
-  for(uint8_t i = 0; i < COUNT(totalItems); i++) {
-    if (i == tmp_language) {
-      totalItems[i].icon = ICONCHAR_CHECKED;
-    } else {
-      totalItems[i].icon = ICONCHAR_UNCHECKED;
-    }
-    infoSettings.language = i;
-    totalItems[i].itemType = LIST_LABEL;
-    totalItems[i].titlelabel.address = textSelect(LABEL_LANGUAGE);
-  }
-  infoSettings.language = tmp_language;
-
-  listWidgetCreate(title, totalItems, COUNT(totalItems), infoSettings.language / LISTITEM_PER_PAGE);
-
-  while (infoMenu.menu[infoMenu.cur] == menuLanguage)
-  {
-    key_num = menuKeyGetValue();
-    switch (key_num)
-    {
-    case KEY_ICON_5:
-      listWidgetPreviousPage();
-      break;
-
-    case KEY_ICON_6:
-      listWidgetNextPage();
-      break;
-
-    case KEY_ICON_7:
-      infoMenu.cur--;
-      break;
-
-    default:
-      if(key_num < LISTITEM_PER_PAGE){
-        uint16_t cur_item = infoSettings.language;
-        uint16_t tmp_i = listWidgetGetCurPage() * LISTITEM_PER_PAGE + key_num;
-        if (tmp_i != cur_item) { // has changed
-          totalItems[cur_item].icon = ICONCHAR_UNCHECKED;
-          listWidgetRefreshItem(cur_item); // refresh unchecked status
-          cur_item = tmp_i;
-          totalItems[cur_item].icon = ICONCHAR_CHECKED;
-          listWidgetRefreshItem(cur_item); // refresh checked status
-
-          infoSettings.language = cur_item;
-          menuDrawTitle(textSelect(LABEL_LANGUAGE));
-        }
-      }
-      break;
-    }
-
-    loopProcess();
-  }
-
-  if(memcmp(&now, &infoSettings, sizeof(SETTINGS)))
-  {
-    statusScreen_setReady(); // restore msg buffer when language is changed
-    storePara();
-  }
-}
-
 #ifdef ST7920_SPI
 const LABEL lcd_colors_names[LCD_COLOR_COUNT] =
 {
@@ -313,7 +243,7 @@ void menuScreenSettings(void)
   // icon                       label
    {{ICON_ROTATE_UI,            LABEL_ROTATE_UI},
     {ICON_TOUCHSCREEN_ADJUST,   LABEL_TOUCHSCREEN_ADJUST},
-    {ICON_LANGUAGE,             LABEL_LANGUAGE},
+    {ICON_BACKGROUND,           LABEL_BACKGROUND},
     {ICON_BACKGROUND,           LABEL_BACKGROUND},
     {ICON_BACKGROUND,           LABEL_BACKGROUND},
     {ICON_BACKGROUND,           LABEL_BACKGROUND},
@@ -374,10 +304,6 @@ void menuScreenSettings(void)
       case KEY_ICON_1:
         TSC_Calibration();
         menuDrawPage(&screenSettingsItems);
-        break;
-
-      case KEY_ICON_2:
-        infoMenu.menu[++infoMenu.cur] = menuLanguage;
         break;
 
       #ifdef BUZZER_PIN

--- a/TFT/src/User/Menu/ScreenSettings.h
+++ b/TFT/src/User/Menu/ScreenSettings.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 void menuScreenSettings(void);
-void menuLanguage(void);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
The changes makes the user have to set the language in the setlanguage.h. removes the menu for changing language. The code only #defines one language and it's assets, omitting all others. This frees up 28% Of flash or 72.2kb.

Spi flash has about 500kb left of 7Mb, maybe can move there, but do we need all the bloated language files?

I read btt was thinking about doing this, here is a start, could free up some more read the setlanguage.h

### Benefit

Flash was basically full. All the languages used 28% of the flash or 72.2kb. this gives you that flash space back, but makes language set at compile time.

Compile should be faster based on the way #elif works.


I have not coded in years, this was basically me familiarizing myself with the code and knocking the dust of my boots
 Feel free to criticize. Thanks for your time.
