### PR TITLE
Supports Scroll gcode messages in terminal

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -169,6 +169,11 @@ void initMachineSetting(void){
 
 void setupMachine(void)
 {
+  // Avoid repeated calls caused by manually sending M115 in terminal menu
+  static bool firstCall = true;
+  if (!firstCall) return;
+  firstCall = false;
+
   #ifdef ENABLE_BL_VALUE
     #if ENABLE_BL_VALUE == 2
         infoMachineSettings.leveling = BL_ABL;

--- a/TFT/src/User/Menu/SendGcode.h
+++ b/TFT/src/User/Menu/SendGcode.h
@@ -7,6 +7,9 @@ extern "C" {
 
 #include "menu.h"
 
+#define TERMINAL_MAX_CHAR ((LCD_WIDTH / BYTE_WIDTH) * (LCD_HEIGHT / BYTE_HEIGHT) * 4)
+#define MAX_BUFF  20
+
 typedef enum
 {
   GKEY_0 = 0,
@@ -44,6 +47,15 @@ typedef enum
   TERMINAL_ACK,
 }TERMINAL_SRC;
 
+typedef struct
+{
+  char *ptr[MAX_BUFF];        //Pointer into the terminal page buffer , full Screen is one page
+  uint8_t pageHead;           //Buffer top of page
+  uint8_t pageTail;           //Buffer buttom of page
+  uint8_t oldPageHead;
+  uint8_t pageIndex;          //page buffer index
+  uint8_t oldPageIndex;
+}TERMINAL_PAGE;
 
 void menuSendGcode(void);
 void menuTerminal(void);


### PR DESCRIPTION
### Description
On the gcode message display interface of the terminal, touch the upper half screen to turn pages up and touch the lower half screen to turn pages down.
```
screen:
        exit botton
+------------------------+
|                        |
|        page up         |
|                        |
+------------------------+
|                        |
|        page down       |
|                        |
+------------------------+

```
### Related Issues
TFT35 E3 , TFT 43 , TFT 50 FLASH overflowed about 300 bytes

