### PR TITLE
Fix to display M117 messages in info area

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -21,7 +21,6 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -21,6 +21,7 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
 #  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -21,7 +21,6 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -21,6 +21,7 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -21,7 +21,6 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings
@@ -30,7 +29,7 @@
 #### UNIFIED MENU / CLASSIC MENU
 # Select a UI Menu flavour
 # Options: [Unified Menu: 1, Classic Menu: 0]
-unified_menu:0
+unified_menu:1
 
 #### Baudrate
 # Options: [2400: 0, 9600: 1, 19200: 2, 38400: 3, 57600: 4, 115200: 5, 250000: 6, 500000: 7, 1000000: 8]

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
 #  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -192,7 +192,7 @@ void hostActionCommands(void)
 {
   char *find = strchr(dmaL2Cache + ack_index, '\n');
   *find = '\0';
-    if(ack_seen("notification "))
+  if(ack_seen("notification "))
   {
     strcpy(hostAction.prompt_begin, dmaL2Cache + ack_index);
     statusScreen_setMsg((u8 *)echomagic, (u8 *)dmaL2Cache + ack_index);

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -192,6 +192,12 @@ void hostActionCommands(void)
 {
   char *find = strchr(dmaL2Cache + ack_index, '\n');
   *find = '\0';
+    if(ack_seen("notification "))
+  {
+    strcpy(hostAction.prompt_begin, dmaL2Cache + ack_index);
+    statusScreen_setMsg((u8 *)echomagic, (u8 *)dmaL2Cache + ack_index);
+  }
+  
   if(ack_seen("prompt_begin "))
   {
     hostAction.button = 0;

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -21,7 +21,6 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -21,6 +21,7 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------
 # General Settings

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -20,6 +20,7 @@
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
+#  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
 #  HOST_ACTION_COMMANDS / HOST_PROMPT_SUPPORT / HOST_START_MENU_ITEM (in Configuration_adv.h)
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Fix to display M117 messages send by Octoprint plugin like DisplayLayerProgress in info area.

resolves #494
resolves #1050