### PR TITLE
Change ENC_ACTIVE_SIGNAL logic to disable encoder in Marlin firmware when TFT is not in Marlin mode.

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,40 @@
+#
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads-app
+#
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 90
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: [ 'no-locking' ]
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,61 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: Abandoned
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/TFT/src/User/API/BabystepControl.c
+++ b/TFT/src/User/API/BabystepControl.c
@@ -7,7 +7,6 @@ static float babystep_value = BABYSTEP_DEFAULT_VALUE;
 float babystepReset(void)
 {
   babystep_value = BABYSTEP_DEFAULT_VALUE;
-
   return babystep_value;
 }
 
@@ -28,14 +27,12 @@ float babystepResetValue(void)
   float processed_baby_step = 0.0f;
   int8_t neg = 1;
 
-  if (babystep_value < 0.0f)
-    neg = -1;
+  if (babystep_value < 0.0f) neg = -1;
 
   step_count = (babystep_value * neg) / BABYSTEP_MAX_UNIT;
   for (; step_count > 0; step_count--)
   {
     mustStoreCmd("M290 Z%.2f\n", -(BABYSTEP_MAX_UNIT * neg));
-
     processed_baby_step += BABYSTEP_MAX_UNIT;
   }
 
@@ -43,7 +40,6 @@ float babystepResetValue(void)
   if (last_unit > 0.0f)
   {
     mustStoreCmd("M290 Z%.2f\n", -(last_unit * neg));
-
     processed_baby_step += last_unit;
   }
 
@@ -58,11 +54,8 @@ float babystepDecreaseValue(float unit)
   if (babystep_value > BABYSTEP_MIN_VALUE)
   {
     float diff = babystep_value - BABYSTEP_MIN_VALUE;
-
     unit = (diff > unit) ? unit : diff;
-
     mustStoreCmd("M290 Z-%.2f\n", unit);
-
     babystep_value -= unit;
   }
 
@@ -75,11 +68,8 @@ float babystepIncreaseValue(float unit)
   if (babystep_value < BABYSTEP_MAX_VALUE)
   {
     float diff = BABYSTEP_MAX_VALUE - babystep_value;
-
     unit = (diff > unit) ? unit : diff;
-
     mustStoreCmd("M290 Z%.2f\n", unit);
-
     babystep_value += unit;
   }
 

--- a/TFT/src/User/API/LCD_Encoder.c
+++ b/TFT/src/User/API/LCD_Encoder.c
@@ -25,7 +25,7 @@ void HW_EncoderInit(void)
   void HW_EncActiveSignalInit(void)
   {
     GPIO_InitSet(LCD_ENC_EN_PIN, MGPIO_MODE_OUT_PP, 0);
-    setEncActiveSignal(1);
+    setEncActiveSignal(0);
   }
 
   void setEncActiveSignal(uint8_t status)

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -166,27 +166,17 @@ void initMachineSetting(void){
 
 void setupMachine(void)
 {
-  switch (ENABLE_BL_VALUE)
-  {
-    case 2:
-      infoMachineSettings.leveling = BL_ABL;
-      break;
-
-    case 3:
-      infoMachineSettings.leveling = BL_BBL;
-      break;
-
-    case 4:
-      infoMachineSettings.leveling = BL_UBL;
-      break;
-
-    case 5:
-      infoMachineSettings.leveling = BL_MBL;
-      break;
-
-    default:
-      break;
-  }
+  #ifdef ENABLE_BL_VALUE
+    #if ENABLE_BL_VALUE == 2
+        infoMachineSettings.leveling = BL_ABL;
+    #elif ENABLE_BL_VALUE == 3
+        infoMachineSettings.leveling = BL_BBL;
+    #elif ENABLE_BL_VALUE == 4
+        infoMachineSettings.leveling = BL_UBL;
+    #elif ENABLE_BL_VALUE == 5
+        infoMachineSettings.leveling = BL_MBL;
+    #endif
+  #endif
 
   if (infoMachineSettings.leveling != BL_DISABLED && infoMachineSettings.EEPROM == 1 && infoSettings.auto_load_leveling == 1)
   {

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -814,22 +814,23 @@ void sendQueueCmd(void)
           storeCmd("M503 S0\n");
           break;
 
-        case 29: //G29
-          if(ENABLE_BL_VALUE > 0)              // if not Disabled
-          {
-            if(cmd_seen('A'))
+        #if ENABLE_BL_VALUE > 0              // if not Disabled
+          case 29: //G29
             {
-              setParameter(P_ABL_STATE,0,1);
-              storeCmd("M117 UBL active\n");
+              if(cmd_seen('A'))
+              {
+                setParameter(P_ABL_STATE,0,1);
+                storeCmd("M117 UBL active\n");
+              }
+              if(cmd_seen('D'))
+              {
+                setParameter(P_ABL_STATE,0,0);
+                storeCmd("M117 UBL inactive\n");
+              }
             }
-            if(cmd_seen('D'))
-            {
-              setParameter(P_ABL_STATE,0,0);
-              storeCmd("M117 UBL inactive\n");
-            }
-          }
-          break;
-
+            break;
+        #endif
+        
         case 90: //G90
           coorSetRelative(false);
           break;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -130,7 +130,6 @@ void ackPopupInfo(const char *info)
   }
 }
 
-
 void setIgnoreEcho(ECHO_ID msgId, bool state)
 {
   forceIgnore[msgId] = state;
@@ -553,18 +552,15 @@ void parseACK(void)
                           setDualStepperStatus(E_STEPPER, true);
       }
     // Parse and store ABL type if auto-detect is enabled
-      else if (ack_seen("Auto Bed Leveling") && ENABLE_BL_VALUE == 1)
-      {
+    #if ENABLE_BL_VALUE == 1
+      else if (ack_seen("Auto Bed Leveling"))
         infoMachineSettings.leveling = BL_ABL;
-      }
-      else if (ack_seen("Unified Bed Leveling") && ENABLE_BL_VALUE == 1)
-      {
+      else if (ack_seen("Unified Bed Leveling"))
         infoMachineSettings.leveling = BL_UBL;
-      }
-      else if (ack_seen("Mesh Bed Leveling") && ENABLE_BL_VALUE == 1)
-      {
+      else if (ack_seen("Mesh Bed Leveling"))
         infoMachineSettings.leveling = BL_MBL;
-      }
+    #endif
+
     // Parse ABL state
       else if(ack_seen("echo:Bed Leveling"))
       {

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -11,7 +11,7 @@ const ITEM itemBabyStepUnit[ITEM_BABYSTEP_UNIT_NUM] = {
 };
 
 const float babystep_unit[ITEM_BABYSTEP_UNIT_NUM] = {0.01f, 0.1f, 1};
-static u8   curUnit = 0;
+static u8 curUnit = 0;
 
 static float babystep;
 static float orig_z_offset;

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -19,19 +19,13 @@ static float orig_z_offset;
 /* Initialize Z offset */
 void babyInitZOffset(void)
 {
-  float cur_z_offset = probeOffsetGetValue();
-
-  if (orig_z_offset + babystep != cur_z_offset)
-  {
-    orig_z_offset = cur_z_offset - babystep;
-  }
+  orig_z_offset = probeOffsetGetValue() - babystep;
 }
 
 /* Reset to default */
 void babyReset(void)
 {
   babystepReset();
-
   babyInitZOffset();
 }
 
@@ -134,9 +128,7 @@ void menuBabystep(void)
       // change step unit
       case KEY_ICON_5:
         curUnit = (curUnit + 1) % ITEM_BABYSTEP_UNIT_NUM;
-
         babyStepItems.items[key_num] = itemBabyStepUnit[curUnit];
-
         menuDrawItem(&babyStepItems.items[key_num], key_num);
         break;
 
@@ -154,7 +146,6 @@ void menuBabystep(void)
           if (encoderPosition)
           {
             babystep = babystepUpdateValueByEncoder(unit);
-
             encoderPosition = 0;
           }
         #endif

--- a/TFT/src/User/Menu/Home.c
+++ b/TFT/src/User/Menu/Home.c
@@ -1,7 +1,6 @@
 #include "Home.h"
 #include "includes.h"
 
-//1��title(����), ITEM_PER_PAGE��item(ͼ��+��ǩ)
 const MENUITEMS homeItems = {
 //   title
 LABEL_HOME,

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -1,6 +1,20 @@
 #include "Leveling.h"
 #include "includes.h"
 
+const MENUITEMS manualLevelingItems = {
+  // title
+  LABEL_LEVELING,
+  // icon                         label
+  {{ICON_POINT_1,                 LABEL_POINT_1},
+    {ICON_POINT_2,                 LABEL_POINT_2},
+    {ICON_POINT_3,                 LABEL_POINT_3},
+    {ICON_POINT_4,                 LABEL_POINT_4},
+    {ICON_POINT_5,                 LABEL_POINT_5},
+    {ICON_LEVEL_EDGE_DISTANCE,     LABEL_DISTANCE},
+    {ICON_DISABLE_STEPPERS,        LABEL_XY_UNLOCK},
+    {ICON_BACK,                    LABEL_BACK},}
+};
+
 void moveToLevelingPoint(u8 point)
 {
   s16 pointPosition[5][2] = {
@@ -23,22 +37,8 @@ void moveToLevelingPoint(u8 point)
 
 void menuManualLeveling(void)
 {
-  MENUITEMS manualLevelingItems = {
-    // title
-    LABEL_LEVELING,
-    // icon                         label
-    {{ICON_POINT_1,                 LABEL_POINT_1},
-     {ICON_POINT_2,                 LABEL_POINT_2},
-     {ICON_POINT_3,                 LABEL_POINT_3},
-     {ICON_POINT_4,                 LABEL_POINT_4},
-     {ICON_POINT_5,                 LABEL_POINT_5},
-     {ICON_LEVEL_EDGE_DISTANCE,     LABEL_DISTANCE},
-     {ICON_DISABLE_STEPPERS,        LABEL_XY_UNLOCK},
-     {ICON_BACK,                    LABEL_BACK},}
-  };
-
   KEY_VALUES key_num = KEY_IDLE;
- 
+
   menuDrawPage(&manualLevelingItems);
 
   while (infoMenu.menu[infoMenu.cur] == menuManualLeveling)

--- a/TFT/src/User/Menu/MachineSettings.c
+++ b/TFT/src/User/Menu/MachineSettings.c
@@ -209,33 +209,39 @@ void menuEepromSettings(void)
     key_num = menuKeyGetValue();
     switch(key_num)
     {
-      case KEY_ICON_0:
-        // save to EEPROM
-        if (infoMachineSettings.EEPROM == 1)
-          setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_SAVE_INFO, LABEL_CONFIRM, LABEL_CANCEL);
+    case KEY_ICON_0:
+      // save to EEPROM
+      if (infoMachineSettings.EEPROM == 1)
+      {
+        setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_SAVE_INFO, LABEL_CONFIRM, LABEL_CANCEL);
         showDialog(DIALOG_TYPE_QUESTION, saveEepromSettings, NULL, NULL);
-        break;
+      }
+      break;
 
-      case KEY_ICON_1:
-        // restore from EEPROM
-        if (infoMachineSettings.EEPROM == 1)
-          setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_RESTORE_INFO, LABEL_CONFIRM, LABEL_CANCEL);
-          showDialog(DIALOG_TYPE_QUESTION, restoreEepromSettings, NULL, NULL);
-        break;
+    case KEY_ICON_1:
+      // restore from EEPROM
+      if (infoMachineSettings.EEPROM == 1)
+      {
+        setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_RESTORE_INFO, LABEL_CONFIRM, LABEL_CANCEL);
+        showDialog(DIALOG_TYPE_QUESTION, restoreEepromSettings, NULL, NULL);
+      }
+      break;
 
-      case KEY_ICON_2:
-        // reset EEPROM
-        if (infoMachineSettings.EEPROM == 1)
-          setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_RESET_INFO, LABEL_CONFIRM, LABEL_CANCEL);
-          showDialog(DIALOG_TYPE_QUESTION, resetEepromSettings, NULL, NULL);
-        break;
+    case KEY_ICON_2:
+      // reset EEPROM
+      if (infoMachineSettings.EEPROM == 1)
+      {
+        setDialogText(eepromSettingsItems.title.index, LABEL_EEPROM_RESET_INFO, LABEL_CONFIRM, LABEL_CANCEL);
+        showDialog(DIALOG_TYPE_QUESTION, resetEepromSettings, NULL, NULL);
+      }
+      break;
 
-      case KEY_ICON_7:
-        infoMenu.cur--;
-        break;
+    case KEY_ICON_7:
+      infoMenu.cur--;
+      break;
 
-      default:
-        break;
+    default:
+      break;
     }
 
     loopProcess();

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -40,7 +40,7 @@ void infoMenuSelect(void)
       #endif
 
       #if ENC_ACTIVE_SIGNAL
-        setEncActiveSignal(1);
+        setEncActiveSignal(0);
       #endif
       GUI_RestoreColorDefault();
       if(infoSettings.unified_menu == 1) //if Unified menu is selected
@@ -68,7 +68,7 @@ void infoMenuSelect(void)
 
     case MARLIN:
       #if ENC_ACTIVE_SIGNAL
-        setEncActiveSignal(0);
+        setEncActiveSignal(1);
       #endif
       if (infoSettings.serial_alwaysOn == 1)
       {


### PR DESCRIPTION
- Change `ENC_ACTIVE_SIGNAL` logic to disable encoder in Marlin firmware when TFT is not in Marlin mode. Details in https://github.com/MarlinFirmware/Marlin/pull/19796
- clean-up
- Add stale bot config to manage old abandoned issues. @bigtreetech Needs installing stale app for the repository from here: https://github.com/apps/stale

This will fix #680 after https://github.com/MarlinFirmware/Marlin/pull/19890 is merged in marlin firmware.
Resolves #1206 , Resolves #1045