### PR TITLE
It was missed

### DIFF
--- a/TFT/src/User/Language Packs/language_hu.ini
+++ b/TFT/src/User/Language Packs/language_hu.ini
@@ -30,8 +30,8 @@ label_point_2:2. pont
 label_point_3:3. pont
 label_point_4:4. pont
 label_point_5:5. pont
-label_bed_leveling:Bed Level
-label_bl_complete:Ágy Szintezés Sikeres
+label_bed_leveling:Ágyszint
+label_bl_complete:Ágy Szintezése Sikeres
 label_bl_smart_fill:A hiányzó szonda pontok\nkitöltésre kerültek.\nMegjegyzés: Mentsd el!
 label_bl_enable:BL: be
 label_bl_disable:BL: ki
@@ -39,10 +39,10 @@ label_abl:ABL
 label_bbl:BBL
 label_ubl:UBL
 label_mbl:MBL
-label_mbl_settings:Mesh Bed Leveling
-label_abl_settings:Auto Bed Leveling
-label_abl_settings_bbl:Bilineáris Ágyszintezés
-label_abl_settings_ubl:Egységes Ágyszintezés
+label_mbl_settings:Kézi Rács Szintezés
+label_abl_settings:Automata Szintezés
+label_abl_settings_bbl:Bilineáris Szintezés
+label_abl_settings_ubl:Egységes Szintezés
 label_abl_settings_ubl_save:Mentés szlotba
 label_abl_settings_ubl_load:Betöltés szlotból
 label_abl_slot0:Szlot 0
@@ -54,7 +54,7 @@ label_abl_z:Z Áttűnés
 label_bltouch:BLTouch
 label_bltouch_test:Teszt
 label_bltouch_deploy:Telepítés
-label_bltouch_stow:Elhelyez
+label_bltouch_stow:Elhelyezés
 label_bltouch_repeat:Ismétlés
 label_z_offset:Z Eltolás
 label_probe_offset:Szonda Eltolás
@@ -261,7 +261,7 @@ label_pid_start_info_3:NE ÉRINTSD meg a kijelzőt míg nincs kész! (zöld LED 
 label_tune_extruder:Lépés hangolás
 label_tune_ext_extrude_100:Kiad 100mm
 label_tune_ext_temp:Adagoló hangolás | Fűt
-label_tune_ext_templow:Túl alacsony a kívánt hőfok!\nMinimum temperature: %d C
+label_tune_ext_templow:Túl alacsony a kívánt hőfok!\nMinimum hőmérséklet: %d C
 label_tune_ext_desiredval:A hőfok még nem érte el a kívánt értéket
 label_tune_ext_mark120mm:A 120mm-t jelöld be a szálon\nNyomd '%s' ha kész\nMérd meg a hátralévő hosszt\nadagolás után.
 label_tune_ext_heatoff:Kikapcsolod a fűtést?


### PR DESCRIPTION
A language_en.ini was left out. There’s so much of it already that I didn’t notice. I don't know why so much. But there must be a reason.

By: AntoszHUN