### PR TITLE
Language pack auto-generate script

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_am.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_am.ini
@@ -1,5 +1,5 @@
 #### Language Code:AM
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_ca.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_ca.ini
@@ -1,5 +1,5 @@
 #### Language Code:CA
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_cn.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_cn.ini
@@ -1,5 +1,5 @@
 #### Language Code:CN
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_cz.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_cz.ini
@@ -1,5 +1,5 @@
 #### Language Code:CZ
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_de.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_de.ini
@@ -1,129 +1,129 @@
 #### Language Code:DE
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
 label_language:Deutsch
-label_heat:Heizen
-label_move:Bewegen
+label_heat:heizen
+label_move:bewegen
 label_home:Home XYZ
-label_disable_steppers:Disarm All
-label_print:Drucken
+label_disable_steppers:alle lösen
+label_print:drucken
 label_extrude:Extruder
 label_fan:Lüfter
-label_settings:Einstellung
+label_settings:Einstellungen
 label_screen_settings:Bildschirm
 label_machine_settings:Drucker
-label_feature_settings:Feature
-label_sound:Sound
-label_touch_sound:Touch Töne
-label_toast_sound:Toast Benachrichtigung
-label_alert_sound:Popups und Alarme
-label_shut_down:Auschalten (PS_ON)
+label_feature_settings:Andere
+label_sound:Töne
+label_touch_sound:Eingabe
+label_toast_sound:Toasts
+label_alert_sound:Popups & Alarme
+label_shut_down:auschalten (PS_ON)
 label_rgb_settings:LED Farbe
-label_rgb_off:LED Aus
+label_rgb_off:LED aus
 label_terminal:Terminal
 label_custom:Extras
-label_leveling:Leveling
+label_leveling:justieren
 label_point_1:Punkt 1
 label_point_2:Punkt 2
 label_point_3:Punkt 3
 label_point_4:Punkt 4
 label_point_5:Punkt 5
-label_bed_leveling:Bett Level
-label_bl_complete:Bett Leveling fertiggestellt
-label_bl_smart_fill:Fehlende Messpunkte\nwurden intelligent gefüllt.\n \nHinweis: Denken Sie daran, zu speichern!
-label_bl_enable:BL: An
-label_bl_disable:BL: Aus
+label_bed_leveling:vermessen
+label_bl_complete:Bett-Vermessung ausgeführt
+label_bl_smart_fill:Fehlende Messpunkte\nwurden berechent.\n \nHinweis: Bitte speichern!
+label_bl_enable:BL: an
+label_bl_disable:BL: aus
 label_abl:ABL
 label_bbl:BBL
 label_ubl:UBL
 label_mbl:MBL
-label_mbl_settings:Mesh Bett Leveling
-label_abl_settings:Auto Bett Leveling
-label_abl_settings_bbl:Bilinear Bett Leveling
-label_abl_settings_ubl:Unified Bett Leveling
-label_abl_settings_ubl_save:Speichern im Slot
-label_abl_settings_ubl_load:Lade vom Slot
+label_mbl_settings:Bett Vermessung (Raster)
+label_abl_settings:Bett Vermessung (auto)
+label_abl_settings_bbl:Bett Vermessung (bilinear)
+label_abl_settings_ubl:Bett Vermessung (Unified)
+label_abl_settings_ubl_save:im Slot speichern
+label_abl_settings_ubl_load:aus Slot laden
 label_abl_slot0:Slot 0
 label_abl_slot1:Slot 1
 label_abl_slot2:Slot 2
 label_abl_slot3:Slot 3
-label_abl_slot_eeprom:Slot für den nächsten\nRestart merken?(Im EEPROM speichern)
+label_abl_slot_eeprom:Slot für den nächsten\nNeustart merken?(Im EEPROM speichern)
 label_abl_z:Z Fade
 label_bltouch:BLTouch
-label_bltouch_test:Testen
-label_bltouch_deploy:Ausfahren
-label_bltouch_stow:Einfahren
-label_bltouch_repeat:Widerholen
-label_z_offset:Z Offset
-label_probe_offset:Mess Offset
-label_confirmation:Sind Sie sicher?
-label_down:Ab
-label_up:Auf
-label_save:Speichern
-label_restore:Wiederherstellen
-label_reset:Resetten
+label_bltouch_test:testen
+label_bltouch_deploy:ausfahren
+label_bltouch_stow:einziehen
+label_bltouch_repeat:widerholen
+label_z_offset:Delta Z
+label_probe_offset:Delta Fühler
+label_confirmation:Sicher?
+label_down:ab
+label_up:auf
+label_save:speichern
+label_restore:laden
+label_reset:zurücksetzen
 label_default:Standard
-label_clear:Löschen
-label_next:Nächste
-label_distance:Entfernung
-label_invalid_value:Ungültig(e) Wert(e)
+label_clear:löschen
+label_next:nächster
+label_distance:Abstand
+label_invalid_value:Ungültige(r) Wert(e)
 label_timeout_reached:Timeout erreicht!
 label_process_running:Prozess läuft bereits!
 label_process_completed:Prozess fertiggestellt!
 label_process_aborted:Prozess abgebrochen!
-label_inc:Erhöhen
-label_dec:Verringern
+label_inc:erhöhen
+label_dec:verringern
 label_nozzle:Düse
 label_bed:Heizbett
 label_chamber:Kammer
 label_start:Start
 label_stop:Stop
-label_back:Zurück
+label_back:zurück
 label_page_up:Seite hoch
 label_page_down:Seite runter
-label_resume:Wiederaufnahme
 label_pause:Pause
-label_load:Laden
-label_unload:Entleeren
-label_slow_speed:Langsam
-label_normal_speed:Normal
-label_fast_speed:Schnell
-label_fan_full_speed:Voll
-label_fan_half_speed:Halb
-label_rotate_ui:Drehe UI
+label_resume:Wiederaufnahme
+label_load:laden
+label_unload:entladen
+label_slow_speed:langsam
+label_normal_speed:normal
+label_fast_speed:schnell
+label_fan_full_speed:alles
+label_fan_half_speed:halb
+label_rotate_ui:UI drehen
 label_touchscreen_adjust:TSC kalib.
-label_more:Mehr
+label_more:mehr
 label_screen_info:Info
 label_status:Status
-label_simulator_bg_color:Marlin Simulator Hintergrundfarbe
-label_simulator_font_color:Marlin Simulator Schriftfarbe
-label_white:Weiß
-label_black:Schwarz
-label_blue:Blau
-label_red:Rot
-label_green:Grün
-label_cyan:Cyan
-label_yellow:Gelb
-label_brown:Braun
-label_gray:Grau
-label_orange:Orange
-label_indigo:Indigo
-label_violet:Violet
-label_magenta:Magenta
-label_purple:Purple
-label_lime:Lime
-label_darkblue:DarkBlue
-label_darkgreen:DarkGreen
-label_darkgray:DarkGray
-label_disconnect:Trennen
-label_baudrate:BaudRate
+label_simulator_bg_color:Hintergrundfarbe Marlin
+label_simulator_font_color:Schriftfarbe Marlin
+label_white:weiß
+label_black:schwarz
+label_blue:blau
+label_red:rot
+label_green:grün
+label_cyan:cyan
+label_yellow:gelb
+label_brown:braun
+label_gray:grau
+label_orange:orange
+label_indigo:indigo
+label_violet:violet
+label_magenta:magenta
+label_purple:lila
+label_lime:grüngelb
+label_darkblue:dunkelblau
+label_darkgreen:dunkelgrün
+label_darkgray:dunkelgrau
+label_disconnect:trennen
+label_baudrate:Baudrate
 label_percentage:Prozent
 label_babystep:BabyStep
-label_percentage_speed:Geschwindigkeit
-label_percentage_flow:Flow
-label_value_zero:Null
+label_percentage_speed:Geschw.
+label_percentage_flow:Fluss
+label_value_zero:0
 label_1_degree:1℃
 label_5_degree:5℃
 label_10_degree:10℃
@@ -147,45 +147,45 @@ label_1_percent:1%
 label_5_percent:5%
 label_10_percent:10%
 label_percent_value:%d%%
-label_ready:Bereit
-label_busy:Bitte warten...
+label_ready:bereit
+label_busy:Bitte warten ...
 label_unconnected:Keine Verbindung zum Drucker!
 label_disconnect_info:Verbindung getrennt!
-label_loading:Laden...
+label_loading:Lade ...
 label_power_failed:Druck fortsetzen?
-label_continue:Fortsetzen
-label_cancel:\u088F Abbruch
+label_continue:fortsetzen
+label_cancel:Abbruch
 label_adjust_title:Touchscreen kalibrieren
-label_adjust_info:Auf den roten Punkt drücken
-label_adjust_ok:Anpassung erfolgreich
-label_adjust_failed:Anpassung fehlgeschlagen, erneut versuchen
+label_adjust_info:roten Punkt antippen
+label_adjust_ok:erfolgreich kalibriert
+label_adjust_failed:Kalibrierung fehlgeschlagen, erneut versuchen.
 label_warning:Warnung
 label_stop_print:Druck abbrechen?
 label_confirm:OK
 label_tftsd:TFT SD
 label_read_tftsd_error:TFT SD Lesefehler!
-label_tftsd_inserted:SD-Karte gesteckt!
-label_tftsd_removed:SD-Karte entnommen!
+label_tftsd_inserted:SD-Karte eingesteckt!
+label_tftsd_removed:SD-Karte entfernt!
 label_u_disk:USB-Stick
 label_read_u_disk_error:USB-Stick Lesefehler!
 label_u_disk_inserted:USB-Stick eingesteckt!
 label_u_disk_removed:USB-Stick entfernt!
 label_onboardsd:Onboard SD
 label_read_onboardsd_error:Onboard SD Lesefehler!
-label_filament_sensor:Filament sensor
-label_filament_runout:Filament runout!
-label_preheat:Vorheizen
-label_preheat_both:Beide
-label_is_pause:Extrudierung während\nDruckvorgangs nicht\nmöglich,\nDruck Pausieren?
+label_filament_sensor:Filament Sensor
+label_filament_runout:Filament alle!
+label_preheat:vorheizen
+label_preheat_both:beide
+label_is_pause:Extrudieren während\nDruckvorgang nicht\nmöglich!\nDruck pausieren?
 label_auto_shut_down:Automatisch AUS (PS_ON)
 label_unifiedmove:Bewegung
 label_unifiedheat:Heiz.Lüft.
-label_cooldown:Abkühlen
-label_emergencystop:NOT STOP!
-label_touch_to_exit:Zum verlassen, Bildschirm berühren.
+label_cooldown:abkühlen
+label_emergencystop:NOT AUS!
+label_touch_to_exit:Zum Verlassen, Bildschirm berühren.
 label_mainmenu:Menü
 label_wait_temp_shut_down:Warte bis Hotend-\nTemperatur unter\n %d℃ fällt.
-label_force_shut_down:Erzwinge
+label_force_shut_down:erzwinge
 label_shutting_down:Fahre herunter...
 label_parameter_setting:Parameter
 label_on:AN
@@ -198,32 +198,32 @@ label_invert_zaxis:Invertiere Z-Achse
 label_move_speed:Geschwindigkeit (XYZ)
 label_knob_led:Drehknopf LED Farbe
 label_knob_led_idle:Drehknopf LED idle Farbe
-label_m0_pause:Pause durch M0 kommando
-label_send_start_gcode:Start-Gcode vor Druck
-label_send_end_gcode:End-Gcode nach Druck
-label_send_cancel_gcode:Gcode abbrechen
-label_persistent_status_info:Speicherungs-status Information
-label_file_listmode:Datei-Ansicht als Liste
+label_m0_pause:Pause durch M0 Befehl
+label_send_start_gcode:Gcode vor Druck
+label_send_end_gcode:Gcode nach Druck
+label_send_cancel_gcode:Gcode bei Abbruch
+label_persistent_status_info:Speicherungs-Status
+label_file_listmode:Datein als Liste
 label_current_setting:Treiber Strom (mA)
-label_steps_setting:Steps per mm
-label_maxfeedrate:Maximale Vorschubgeschwindigkeit
-label_maxacceleration:Maximale Beschleunigung
+label_steps_setting:Steps pro mm
+label_maxfeedrate:max. Geschwindigkeit
+label_maxacceleration:max. Beschleunigung
 label_acceleration:Beschleunigung
-label_print_acceleration:Beschleunigung beim Druck
-label_retract_acceleration:Beschleunigung reduzieren
-label_travel_acceleration:Beschleunigung bei der Fahrt
+label_print_acceleration:Beschleunigung (Druck)
+label_retract_acceleration:Beschleunigung (Rückzug)
+label_travel_acceleration:Beschleunigung (Fahrt)
 label_jerk:Jerk
 label_junction_deviation:Junction Deviation
-label_bump_sensitivity:TMC bump sensitivity
-label_fwretract:FW Retraction
-label_fwrecover:FW Retraction Recover
+label_bump_sensitivity:TMC Empfindlichkeit
+label_fwretract:FW Rückzug
+label_fwrecover:FW Rückeinschub
 label_lin_advance:Linear Advance
-label_reset_settings_info:Hiermit werden alle\nEinstellungen auf Werkseinstellungen\nzurückgesetzt. Fortfahren?
-label_reset_settings_done:Einstellungen wurden\nerfolgreich zurückgesetzt.\nBitte starten Sie das Gerät neu.
+label_reset_settings_info:Hiermit werden alle\nEinstellungen zurückgesetzt. Fortfahren?
+label_reset_settings_done:Einstellungen wurden\nerfolgreich zurückgesetzt.\nBitte neustarten.
 label_info:Info
 label_lcd_brightness:LCD Helligkeit
-label_lcd_brightness_dim:LCD Abdunkel Helligkeit
-label_lcd_dim_idle_timer:LCD Timer Abdunkeln
+label_lcd_brightness_dim:LCD Helligkeit (Standby)
+label_lcd_dim_idle_timer:LCD Timer Standby
 label_5_seconds:5 Sek.
 label_10_seconds:10 Sek.
 label_30_seconds:30 Sek.
@@ -231,7 +231,7 @@ label_60_seconds:1 Min.
 label_120_seconds:2 Min.
 label_300_seconds:5 Min.
 label_custom_seconds:Benutz.
-label_st7920_fullscreen:Marlin Mode im Vollbild
+label_st7920_fullscreen:Marlin Modus im Vollbild
 label_plr_en:Wiederherstellung nach Stromausfall
 label_setting_save:Einstellungen speichern
 label_setting_reset:Einstellungen zurücksetzten
@@ -242,38 +242,39 @@ label_eeprom_restore_info:Einstellungen aus\nEEPROM laden?
 label_eeprom_reset_info:Standardeinstellungen des Druckers wiederherstellen?
 label_retract_feedrate:Rückzugsgeschwindigkeit
 label_retract_length:Rückzugslänge
-label_retract_swap_length:Rückzugs Swap Länge
-label_retract_z_lift:Z-Anhebung beim Rückzug
+label_retract_swap_length:Rückzugslänge (Wechsel)
+label_retract_z_lift:Z-Anhebung bei Rückzug
 label_retract_auto:Auto-Rückzug über Firmware
-label_recover_feedrate:Recover feedrate
-label_swap_recover_feedrate:Swap recover feedrate
-label_recover_length:Extra recover length
-label_swap_recover_length:Extra recover swap length
+label_recover_feedrate:Geschw. Rückeinschub
+label_swap_recover_feedrate:Geschw. Rückeinschub (Wechsel)
+label_recover_length:zus. Länge Rückeinschub
+label_swap_recover_length:zus. Länge Rückeinschub (Wechsel)
 label_start_print:Druck starten:\n %s?
-label_ack_notification:ACK Benachrichtigungs-Style
+label_ack_notification:ACK Benachrichtigungs-Stil
 label_leveling_edge_distance:Bettecken-Abstand
-label_xy_unlock:Schalte XY frei
-label_tuning:Tuning
+label_xy_unlock:löse XY
+label_tuning:Justage
 label_pid:PID
 label_pid_title:PID autotune
 label_pid_start_info:PID autotune benötigt\neinige Zeit.\nWeitermachen?
-label_pid_start_info_2:PID autotune in läuft!
-label_pid_start_info_3:Berühren Sie den Bildschirm erst bei Fertigstellung (Grüne LED AN)!
-label_tune_extruder:Tune steps
-label_tune_ext_extrude_100:Ext. 100mm
-label_tune_ext_temp:Extruder Tuning | heat
-label_tune_ext_templow:Eingestellte Temparatur zu niedrig!\nMinimum Temparatur: %d C
-label_tune_ext_desiredval:Temparatur hat noch nicht den gewünschten Wert erreicht
-label_tune_ext_mark120mm:Markiere 120 mm am Filament\nDrücke '%s' wenn sie bereit sind\nMessen sie die Länge erneut\nnach der Extrusion
+label_pid_start_info_2:PID autotune läuft!
+label_pid_start_info_3:Berühren Sie den Bildschirm erst bei Fertigstellung (Grüne LED)!
+label_tune_extruder:Steps anp.
+label_tune_ext_extrude_100:100mm ext.
+label_tune_ext_temp:Ext. Kalib. Temp.
+label_tune_ext_templow:Temparatur zu niedrig!\nMinimale Temparatur: %d C
+label_tune_ext_desiredval:Temparatur hat gewünschten Wert noch nicht erreicht
+label_tune_ext_mark120mm:Filament 120 mm über Einlass markieren,\ndann '%s' drücken & nach Extrusion\nerneut messen
 label_tune_ext_heatoff:Heizung abschalten?
 label_tune_ext_adj_esteps:E-Steps einstellen
-label_tune_ext_esteps_saved:Neue E-steps gespeichert!\nDenken Sie daran die Werte\nim EEPROM abzuspeichern\nNew value: %0.2f
+label_tune_ext_esteps_saved:Neue E-Steps gespeichert!\nBitte auch im EEPROM speichern.\nNeuer Wert: %0.2f
 label_tune_ext_measured:Restliche Länge:
-label_tune_ext_old_estep:Alte e-steps: %0.2f
-label_tune_ext_new_estep:Neue e-steps: %0.2f
+label_tune_ext_old_estep:Alte E-Steps: %0.2f
+label_tune_ext_new_estep:Neue E-Steps: %0.2f
 label_connection_settings:Verbindung
-label_offset_tool:Offset 2te Spitze
+label_offset_tool:Abstand 2te Düse
 label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Benachrichtigungen
-label_mesh_editor:Mesh edit
-label_mesh_tuner:Mesh tuner
+label_mesh_editor:Mesh edit.
+label_mesh_tuner:Mesh anp.
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_du.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_du.ini
@@ -1,5 +1,5 @@
 #### Language Code:DU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_en.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_en.ini
@@ -1,5 +1,5 @@
-#### Language Name:EN
-## Language Version:20201001
+#### Language Code:EN
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -146,7 +146,7 @@ label_200_mm:200mm
 label_1_percent:1%
 label_5_percent:5%
 label_10_percent:10%
-label_percent_value:d%%
+label_percent_value:%d%%
 label_ready:Ready
 label_busy:Busy processing, please wait...
 label_unconnected:No printer attached!
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_es.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_es.ini
@@ -1,5 +1,5 @@
 #### Language Code:ES
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_fr.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_fr.ini
@@ -1,5 +1,5 @@
 #### Language Code:FR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:Seuil Hybride TMC
 label_notifications:Notifications
 label_mesh_editor:Maillage
 label_mesh_tuner:Edition du maillage
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_gr.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_gr.ini
@@ -1,5 +1,5 @@
 #### Language Code:GR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -133,9 +133,9 @@ label_z_inc:Z+
 label_x_dec:X-
 label_y_dec:Y-
 label_z_dec:Z-
-#define GR_X                      X
-#define GR_Y                      Y
-#define GR_Z                      Z
+label_x:X
+label_y:Y
+label_z:Z
 label_001_mm:0.01χιλ
 label_01_mm:0.1χιλ
 label_1_mm:1χιλ
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_hu.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_hu.ini
@@ -1,5 +1,5 @@
 #### Language Code:HU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC Hibrid Küszöbérték
 label_notifications:Értesítések
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_it.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_it.ini
@@ -1,5 +1,5 @@
 #### Language Code:IT
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -196,7 +196,7 @@ label_invert_xaxis:Inverti Asse X
 label_invert_yaxis:Inverti Asse Y
 label_invert_zaxis:Inverti Asse Z
 label_move_speed:Vel. Movimenti (X Y Z)
-label_knob_led:LED Manopola
+label_knob_led:LED Manopola 
 label_knob_led_idle:LED Manopola inattivo
 label_m0_pause:Messo in pausa dal comando M0
 label_send_start_gcode:Gcode prima di stampare
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC Soglia Modo Ibrido
 label_notifications:Notifiche
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_jp.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_jp.ini
@@ -1,5 +1,5 @@
 #### Language Code:JP
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_pl.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_pl.ini
@@ -1,6 +1,5 @@
-
 #### Language Code:PL
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -278,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_pt.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_pt.ini
@@ -1,5 +1,5 @@
 #### Language Code:PT
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_ru.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_ru.ini
@@ -1,5 +1,5 @@
 #### Language Code:RU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -24,13 +24,13 @@ label_rgb_settings:Цвет LED
 label_rgb_off:LED выкл
 label_terminal:Терминал
 label_custom:Своё меню
-label_leveling:Равнение
+label_leveling:Стол вруч.
 label_point_1:Точка 1
 label_point_2:Точка 2
 label_point_3:Точка 3
 label_point_4:Точка 4
 label_point_5:Точка 5
-label_bed_leveling:Bed Level
+label_bed_leveling:Стол равнен.
 label_bl_complete:Выравнивание стола окончено
 label_bl_smart_fill:Отсутствующие точки\nзамера были атоматически\nзаполнены.\nЗапомните для сохраниения!
 label_bl_enable:BL: вкл
@@ -39,8 +39,8 @@ label_abl:ABL
 label_bbl:BBL
 label_ubl:UBL
 label_mbl:MBL
-label_mbl_settings:Mesh Bed Leveling
-label_abl_settings:Auto Bed Leveling
+label_mbl_settings:Равнение по сетке
+label_abl_settings:Автовыравнивание
 label_abl_settings_bbl:Билинейная калибровка
 label_abl_settings_ubl:Универсальная калибровка
 label_abl_settings_ubl_save:Сохранить в ячейку
@@ -81,10 +81,10 @@ label_chamber:Камера
 label_start:Начать
 label_stop:Стоп
 label_back:Назад
-label_page_up:Previous
-label_page_down:Next
-label_resume:Продолжить
+label_page_up:Стр.
+label_page_down:Стр. 
 label_pause:Пауза
+label_resume:Продолжить
 label_load:Загрузка
 label_unload:Выгрузка
 label_slow_speed:Медленно
@@ -154,7 +154,7 @@ label_disconnect_info:Управление принтером через ком�
 label_loading:Загрузка...
 label_power_failed:Продолжить печать?
 label_continue:Продолжение
-label_cancel:Cancel
+label_cancel:Отмена
 label_adjust_title:Калибровка экрана
 label_adjust_info:Нажмите на красную точку
 label_adjust_ok:Успешная калибровка
@@ -213,7 +213,7 @@ label_print_acceleration:Печати
 label_retract_acceleration:Ретракта
 label_travel_acceleration:Перемещения
 label_jerk:Рывок
-label_junction_deviation:Junction Deviation
+label_junction_deviation:Отклонение узла
 label_bump_sensitivity:TMC чувствительность удара
 label_fwretract:M207 ретракт
 label_fwrecover:M208 восстановление ретракта
@@ -252,7 +252,7 @@ label_swap_recover_length:Длина при смене сопла
 label_start_print:Начать печать:\n %s?
 label_ack_notification:ACK стиль уведомления
 label_leveling_edge_distance:Отступы от краёв стола
-label_xy_unlock:XY отпуск
+label_xy_unlock:Моторы выкл
 label_tuning:Наладка
 label_pid:PID
 label_pid_title:PID автонастройка
@@ -275,5 +275,6 @@ label_connection_settings:Соединение
 label_offset_tool:Смещение 2-го сопла
 label_hybrid_threshold:TMC гибридный порог
 label_notifications:Уведомления
-label_mesh_editor:Mesh edit
-label_mesh_tuner:Mesh tuner
+label_mesh_editor:Сетка ред.
+label_mesh_tuner:Сетка настр.
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_sk.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_sk.ini
@@ -1,5 +1,5 @@
 #### Language Code:SK
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_sl.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_sl.ini
@@ -1,5 +1,5 @@
 #### Language Code:SL
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_tc.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_tc.ini
@@ -1,5 +1,5 @@
 #### Language Code:TC
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -51,7 +51,7 @@ label_abl_slot2:Slot 2
 label_abl_slot3:Slot 3
 label_abl_slot_eeprom:Remember slot for next\nreboot? (Save EEPROM)
 label_abl_z:Z Fade
-label_bltouch:BLTouch
+label_bltouch:BLTouch 
 label_bltouch_test:BLTouch檢測
 label_bltouch_deploy:探針彈出
 label_bltouch_stow:探針收回
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_tr.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs/language_tr.ini
@@ -1,5 +1,5 @@
 #### Language Code:TR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_am.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_am.ini
@@ -1,5 +1,5 @@
 #### Language Code:AM
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_ca.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_ca.ini
@@ -1,5 +1,5 @@
 #### Language Code:CA
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_cn.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_cn.ini
@@ -1,5 +1,5 @@
 #### Language Code:CN
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update/Language Packs/language_cz.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_cz.ini
@@ -1,5 +1,5 @@
 #### Language Code:CZ
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update/Language Packs/language_de.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_de.ini
@@ -1,129 +1,129 @@
 #### Language Code:DE
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
 label_language:Deutsch
-label_heat:Heizen
-label_move:Bewegen
+label_heat:heizen
+label_move:bewegen
 label_home:Home XYZ
-label_disable_steppers:Disarm All
-label_print:Drucken
+label_disable_steppers:alle lösen
+label_print:drucken
 label_extrude:Extruder
 label_fan:Lüfter
-label_settings:Einstellung
+label_settings:Einstellungen
 label_screen_settings:Bildschirm
 label_machine_settings:Drucker
-label_feature_settings:Feature
-label_sound:Sound
-label_touch_sound:Touch Töne
-label_toast_sound:Toast Benachrichtigung
-label_alert_sound:Popups und Alarme
-label_shut_down:Auschalten (PS_ON)
+label_feature_settings:Andere
+label_sound:Töne
+label_touch_sound:Eingabe
+label_toast_sound:Toasts
+label_alert_sound:Popups & Alarme
+label_shut_down:auschalten (PS_ON)
 label_rgb_settings:LED Farbe
-label_rgb_off:LED Aus
+label_rgb_off:LED aus
 label_terminal:Terminal
 label_custom:Extras
-label_leveling:Leveling
+label_leveling:justieren
 label_point_1:Punkt 1
 label_point_2:Punkt 2
 label_point_3:Punkt 3
 label_point_4:Punkt 4
 label_point_5:Punkt 5
-label_bed_leveling:Bett Level
-label_bl_complete:Bett Leveling fertiggestellt
-label_bl_smart_fill:Fehlende Messpunkte\nwurden intelligent gefüllt.\n \nHinweis: Denken Sie daran, zu speichern!
-label_bl_enable:BL: An
-label_bl_disable:BL: Aus
+label_bed_leveling:vermessen
+label_bl_complete:Bett-Vermessung ausgeführt
+label_bl_smart_fill:Fehlende Messpunkte\nwurden berechent.\n \nHinweis: Bitte speichern!
+label_bl_enable:BL: an
+label_bl_disable:BL: aus
 label_abl:ABL
 label_bbl:BBL
 label_ubl:UBL
 label_mbl:MBL
-label_mbl_settings:Mesh Bett Leveling
-label_abl_settings:Auto Bett Leveling
-label_abl_settings_bbl:Bilinear Bett Leveling
-label_abl_settings_ubl:Unified Bett Leveling
-label_abl_settings_ubl_save:Speichern im Slot
-label_abl_settings_ubl_load:Lade vom Slot
+label_mbl_settings:Bett Vermessung (Raster)
+label_abl_settings:Bett Vermessung (auto)
+label_abl_settings_bbl:Bett Vermessung (bilinear)
+label_abl_settings_ubl:Bett Vermessung (Unified)
+label_abl_settings_ubl_save:im Slot speichern
+label_abl_settings_ubl_load:aus Slot laden
 label_abl_slot0:Slot 0
 label_abl_slot1:Slot 1
 label_abl_slot2:Slot 2
 label_abl_slot3:Slot 3
-label_abl_slot_eeprom:Slot für den nächsten\nRestart merken?(Im EEPROM speichern)
+label_abl_slot_eeprom:Slot für den nächsten\nNeustart merken?(Im EEPROM speichern)
 label_abl_z:Z Fade
 label_bltouch:BLTouch
-label_bltouch_test:Testen
-label_bltouch_deploy:Ausfahren
-label_bltouch_stow:Einfahren
-label_bltouch_repeat:Widerholen
-label_z_offset:Z Offset
-label_probe_offset:Mess Offset
-label_confirmation:Sind Sie sicher?
-label_down:Ab
-label_up:Auf
-label_save:Speichern
-label_restore:Wiederherstellen
-label_reset:Resetten
+label_bltouch_test:testen
+label_bltouch_deploy:ausfahren
+label_bltouch_stow:einziehen
+label_bltouch_repeat:widerholen
+label_z_offset:Delta Z
+label_probe_offset:Delta Fühler
+label_confirmation:Sicher?
+label_down:ab
+label_up:auf
+label_save:speichern
+label_restore:laden
+label_reset:zurücksetzen
 label_default:Standard
-label_clear:Löschen
-label_next:Nächste
-label_distance:Entfernung
-label_invalid_value:Ungültig(e) Wert(e)
+label_clear:löschen
+label_next:nächster
+label_distance:Abstand
+label_invalid_value:Ungültige(r) Wert(e)
 label_timeout_reached:Timeout erreicht!
 label_process_running:Prozess läuft bereits!
 label_process_completed:Prozess fertiggestellt!
 label_process_aborted:Prozess abgebrochen!
-label_inc:Erhöhen
-label_dec:Verringern
+label_inc:erhöhen
+label_dec:verringern
 label_nozzle:Düse
 label_bed:Heizbett
 label_chamber:Kammer
 label_start:Start
 label_stop:Stop
-label_back:Zurück
+label_back:zurück
 label_page_up:Seite hoch
 label_page_down:Seite runter
-label_resume:Wiederaufnahme
 label_pause:Pause
-label_load:Laden
-label_unload:Entleeren
-label_slow_speed:Langsam
-label_normal_speed:Normal
-label_fast_speed:Schnell
-label_fan_full_speed:Voll
-label_fan_half_speed:Halb
-label_rotate_ui:Drehe UI
+label_resume:Wiederaufnahme
+label_load:laden
+label_unload:entladen
+label_slow_speed:langsam
+label_normal_speed:normal
+label_fast_speed:schnell
+label_fan_full_speed:alles
+label_fan_half_speed:halb
+label_rotate_ui:UI drehen
 label_touchscreen_adjust:TSC kalib.
-label_more:Mehr
+label_more:mehr
 label_screen_info:Info
 label_status:Status
-label_simulator_bg_color:Marlin Simulator Hintergrundfarbe
-label_simulator_font_color:Marlin Simulator Schriftfarbe
-label_white:Weiß
-label_black:Schwarz
-label_blue:Blau
-label_red:Rot
-label_green:Grün
-label_cyan:Cyan
-label_yellow:Gelb
-label_brown:Braun
-label_gray:Grau
-label_orange:Orange
-label_indigo:Indigo
-label_violet:Violet
-label_magenta:Magenta
-label_purple:Purple
-label_lime:Lime
-label_darkblue:DarkBlue
-label_darkgreen:DarkGreen
-label_darkgray:DarkGray
-label_disconnect:Trennen
-label_baudrate:BaudRate
+label_simulator_bg_color:Hintergrundfarbe Marlin
+label_simulator_font_color:Schriftfarbe Marlin
+label_white:weiß
+label_black:schwarz
+label_blue:blau
+label_red:rot
+label_green:grün
+label_cyan:cyan
+label_yellow:gelb
+label_brown:braun
+label_gray:grau
+label_orange:orange
+label_indigo:indigo
+label_violet:violet
+label_magenta:magenta
+label_purple:lila
+label_lime:grüngelb
+label_darkblue:dunkelblau
+label_darkgreen:dunkelgrün
+label_darkgray:dunkelgrau
+label_disconnect:trennen
+label_baudrate:Baudrate
 label_percentage:Prozent
 label_babystep:BabyStep
-label_percentage_speed:Geschwindigkeit
-label_percentage_flow:Flow
-label_value_zero:Null
+label_percentage_speed:Geschw.
+label_percentage_flow:Fluss
+label_value_zero:0
 label_1_degree:1℃
 label_5_degree:5℃
 label_10_degree:10℃
@@ -147,45 +147,45 @@ label_1_percent:1%
 label_5_percent:5%
 label_10_percent:10%
 label_percent_value:%d%%
-label_ready:Bereit
-label_busy:Bitte warten...
+label_ready:bereit
+label_busy:Bitte warten ...
 label_unconnected:Keine Verbindung zum Drucker!
 label_disconnect_info:Verbindung getrennt!
-label_loading:Laden...
+label_loading:Lade ...
 label_power_failed:Druck fortsetzen?
-label_continue:Fortsetzen
-label_cancel:\u088F Abbruch
+label_continue:fortsetzen
+label_cancel:Abbruch
 label_adjust_title:Touchscreen kalibrieren
-label_adjust_info:Auf den roten Punkt drücken
-label_adjust_ok:Anpassung erfolgreich
-label_adjust_failed:Anpassung fehlgeschlagen, erneut versuchen
+label_adjust_info:roten Punkt antippen
+label_adjust_ok:erfolgreich kalibriert
+label_adjust_failed:Kalibrierung fehlgeschlagen, erneut versuchen.
 label_warning:Warnung
 label_stop_print:Druck abbrechen?
 label_confirm:OK
 label_tftsd:TFT SD
 label_read_tftsd_error:TFT SD Lesefehler!
-label_tftsd_inserted:SD-Karte gesteckt!
-label_tftsd_removed:SD-Karte entnommen!
+label_tftsd_inserted:SD-Karte eingesteckt!
+label_tftsd_removed:SD-Karte entfernt!
 label_u_disk:USB-Stick
 label_read_u_disk_error:USB-Stick Lesefehler!
 label_u_disk_inserted:USB-Stick eingesteckt!
 label_u_disk_removed:USB-Stick entfernt!
 label_onboardsd:Onboard SD
 label_read_onboardsd_error:Onboard SD Lesefehler!
-label_filament_sensor:Filament sensor
-label_filament_runout:Filament runout!
-label_preheat:Vorheizen
-label_preheat_both:Beide
-label_is_pause:Extrudierung während\nDruckvorgangs nicht\nmöglich,\nDruck Pausieren?
+label_filament_sensor:Filament Sensor
+label_filament_runout:Filament alle!
+label_preheat:vorheizen
+label_preheat_both:beide
+label_is_pause:Extrudieren während\nDruckvorgang nicht\nmöglich!\nDruck pausieren?
 label_auto_shut_down:Automatisch AUS (PS_ON)
 label_unifiedmove:Bewegung
 label_unifiedheat:Heiz.Lüft.
-label_cooldown:Abkühlen
-label_emergencystop:NOT STOP!
-label_touch_to_exit:Zum verlassen, Bildschirm berühren.
+label_cooldown:abkühlen
+label_emergencystop:NOT AUS!
+label_touch_to_exit:Zum Verlassen, Bildschirm berühren.
 label_mainmenu:Menü
 label_wait_temp_shut_down:Warte bis Hotend-\nTemperatur unter\n %d℃ fällt.
-label_force_shut_down:Erzwinge
+label_force_shut_down:erzwinge
 label_shutting_down:Fahre herunter...
 label_parameter_setting:Parameter
 label_on:AN
@@ -198,32 +198,32 @@ label_invert_zaxis:Invertiere Z-Achse
 label_move_speed:Geschwindigkeit (XYZ)
 label_knob_led:Drehknopf LED Farbe
 label_knob_led_idle:Drehknopf LED idle Farbe
-label_m0_pause:Pause durch M0 kommando
-label_send_start_gcode:Start-Gcode vor Druck
-label_send_end_gcode:End-Gcode nach Druck
-label_send_cancel_gcode:Gcode abbrechen
-label_persistent_status_info:Speicherungs-status Information
-label_file_listmode:Datei-Ansicht als Liste
+label_m0_pause:Pause durch M0 Befehl
+label_send_start_gcode:Gcode vor Druck
+label_send_end_gcode:Gcode nach Druck
+label_send_cancel_gcode:Gcode bei Abbruch
+label_persistent_status_info:Speicherungs-Status
+label_file_listmode:Datein als Liste
 label_current_setting:Treiber Strom (mA)
-label_steps_setting:Steps per mm
-label_maxfeedrate:Maximale Vorschubgeschwindigkeit
-label_maxacceleration:Maximale Beschleunigung
+label_steps_setting:Steps pro mm
+label_maxfeedrate:max. Geschwindigkeit
+label_maxacceleration:max. Beschleunigung
 label_acceleration:Beschleunigung
-label_print_acceleration:Beschleunigung beim Druck
-label_retract_acceleration:Beschleunigung reduzieren
-label_travel_acceleration:Beschleunigung bei der Fahrt
+label_print_acceleration:Beschleunigung (Druck)
+label_retract_acceleration:Beschleunigung (Rückzug)
+label_travel_acceleration:Beschleunigung (Fahrt)
 label_jerk:Jerk
 label_junction_deviation:Junction Deviation
-label_bump_sensitivity:TMC bump sensitivity
-label_fwretract:FW Retraction
-label_fwrecover:FW Retraction Recover
+label_bump_sensitivity:TMC Empfindlichkeit
+label_fwretract:FW Rückzug
+label_fwrecover:FW Rückeinschub
 label_lin_advance:Linear Advance
-label_reset_settings_info:Hiermit werden alle\nEinstellungen auf Werkseinstellungen\nzurückgesetzt. Fortfahren?
-label_reset_settings_done:Einstellungen wurden\nerfolgreich zurückgesetzt.\nBitte starten Sie das Gerät neu.
+label_reset_settings_info:Hiermit werden alle\nEinstellungen zurückgesetzt. Fortfahren?
+label_reset_settings_done:Einstellungen wurden\nerfolgreich zurückgesetzt.\nBitte neustarten.
 label_info:Info
 label_lcd_brightness:LCD Helligkeit
-label_lcd_brightness_dim:LCD Abdunkel Helligkeit
-label_lcd_dim_idle_timer:LCD Timer Abdunkeln
+label_lcd_brightness_dim:LCD Helligkeit (Standby)
+label_lcd_dim_idle_timer:LCD Timer Standby
 label_5_seconds:5 Sek.
 label_10_seconds:10 Sek.
 label_30_seconds:30 Sek.
@@ -231,7 +231,7 @@ label_60_seconds:1 Min.
 label_120_seconds:2 Min.
 label_300_seconds:5 Min.
 label_custom_seconds:Benutz.
-label_st7920_fullscreen:Marlin Mode im Vollbild
+label_st7920_fullscreen:Marlin Modus im Vollbild
 label_plr_en:Wiederherstellung nach Stromausfall
 label_setting_save:Einstellungen speichern
 label_setting_reset:Einstellungen zurücksetzten
@@ -242,38 +242,39 @@ label_eeprom_restore_info:Einstellungen aus\nEEPROM laden?
 label_eeprom_reset_info:Standardeinstellungen des Druckers wiederherstellen?
 label_retract_feedrate:Rückzugsgeschwindigkeit
 label_retract_length:Rückzugslänge
-label_retract_swap_length:Rückzugs Swap Länge
-label_retract_z_lift:Z-Anhebung beim Rückzug
+label_retract_swap_length:Rückzugslänge (Wechsel)
+label_retract_z_lift:Z-Anhebung bei Rückzug
 label_retract_auto:Auto-Rückzug über Firmware
-label_recover_feedrate:Recover feedrate
-label_swap_recover_feedrate:Swap recover feedrate
-label_recover_length:Extra recover length
-label_swap_recover_length:Extra recover swap length
+label_recover_feedrate:Geschw. Rückeinschub
+label_swap_recover_feedrate:Geschw. Rückeinschub (Wechsel)
+label_recover_length:zus. Länge Rückeinschub
+label_swap_recover_length:zus. Länge Rückeinschub (Wechsel)
 label_start_print:Druck starten:\n %s?
-label_ack_notification:ACK Benachrichtigungs-Style
+label_ack_notification:ACK Benachrichtigungs-Stil
 label_leveling_edge_distance:Bettecken-Abstand
-label_xy_unlock:Schalte XY frei
-label_tuning:Tuning
+label_xy_unlock:löse XY
+label_tuning:Justage
 label_pid:PID
 label_pid_title:PID autotune
 label_pid_start_info:PID autotune benötigt\neinige Zeit.\nWeitermachen?
-label_pid_start_info_2:PID autotune in läuft!
-label_pid_start_info_3:Berühren Sie den Bildschirm erst bei Fertigstellung (Grüne LED AN)!
-label_tune_extruder:Tune steps
-label_tune_ext_extrude_100:Ext. 100mm
-label_tune_ext_temp:Extruder Tuning | heat
-label_tune_ext_templow:Eingestellte Temparatur zu niedrig!\nMinimum Temparatur: %d C
-label_tune_ext_desiredval:Temparatur hat noch nicht den gewünschten Wert erreicht
-label_tune_ext_mark120mm:Markiere 120 mm am Filament\nDrücke '%s' wenn sie bereit sind\nMessen sie die Länge erneut\nnach der Extrusion
+label_pid_start_info_2:PID autotune läuft!
+label_pid_start_info_3:Berühren Sie den Bildschirm erst bei Fertigstellung (Grüne LED)!
+label_tune_extruder:Steps anp.
+label_tune_ext_extrude_100:100mm ext.
+label_tune_ext_temp:Ext. Kalib. Temp.
+label_tune_ext_templow:Temparatur zu niedrig!\nMinimale Temparatur: %d C
+label_tune_ext_desiredval:Temparatur hat gewünschten Wert noch nicht erreicht
+label_tune_ext_mark120mm:Filament 120 mm über Einlass markieren,\ndann '%s' drücken & nach Extrusion\nerneut messen
 label_tune_ext_heatoff:Heizung abschalten?
 label_tune_ext_adj_esteps:E-Steps einstellen
-label_tune_ext_esteps_saved:Neue E-steps gespeichert!\nDenken Sie daran die Werte\nim EEPROM abzuspeichern\nNew value: %0.2f
+label_tune_ext_esteps_saved:Neue E-Steps gespeichert!\nBitte auch im EEPROM speichern.\nNeuer Wert: %0.2f
 label_tune_ext_measured:Restliche Länge:
-label_tune_ext_old_estep:Alte e-steps: %0.2f
-label_tune_ext_new_estep:Neue e-steps: %0.2f
+label_tune_ext_old_estep:Alte E-Steps: %0.2f
+label_tune_ext_new_estep:Neue E-Steps: %0.2f
 label_connection_settings:Verbindung
-label_offset_tool:Offset 2te Spitze
+label_offset_tool:Abstand 2te Düse
 label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Benachrichtigungen
-label_mesh_editor:Mesh edit
-label_mesh_tuner:Mesh tuner
+label_mesh_editor:Mesh edit.
+label_mesh_tuner:Mesh anp.
+

--- a/Copy to SD Card root directory to update/Language Packs/language_du.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_du.ini
@@ -1,5 +1,5 @@
 #### Language Code:DU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update/Language Packs/language_en.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_en.ini
@@ -1,5 +1,5 @@
-#### Language Name:EN
-## Language Version:20201001
+#### Language Code:EN
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -146,7 +146,7 @@ label_200_mm:200mm
 label_1_percent:1%
 label_5_percent:5%
 label_10_percent:10%
-label_percent_value:d%%
+label_percent_value:%d%%
 label_ready:Ready
 label_busy:Busy processing, please wait...
 label_unconnected:No printer attached!
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_es.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_es.ini
@@ -1,5 +1,5 @@
 #### Language Code:ES
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_fr.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_fr.ini
@@ -1,5 +1,5 @@
 #### Language Code:FR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:Seuil Hybride TMC
 label_notifications:Notifications
 label_mesh_editor:Maillage
 label_mesh_tuner:Edition du maillage
+

--- a/Copy to SD Card root directory to update/Language Packs/language_gr.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_gr.ini
@@ -1,5 +1,5 @@
 #### Language Code:GR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -133,9 +133,9 @@ label_z_inc:Z+
 label_x_dec:X-
 label_y_dec:Y-
 label_z_dec:Z-
-#define GR_X                      X
-#define GR_Y                      Y
-#define GR_Z                      Z
+label_x:X
+label_y:Y
+label_z:Z
 label_001_mm:0.01χιλ
 label_01_mm:0.1χιλ
 label_1_mm:1χιλ
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_hu.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_hu.ini
@@ -1,5 +1,5 @@
 #### Language Code:HU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC Hibrid Küszöbérték
 label_notifications:Értesítések
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_it.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_it.ini
@@ -1,5 +1,5 @@
 #### Language Code:IT
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -196,7 +196,7 @@ label_invert_xaxis:Inverti Asse X
 label_invert_yaxis:Inverti Asse Y
 label_invert_zaxis:Inverti Asse Z
 label_move_speed:Vel. Movimenti (X Y Z)
-label_knob_led:LED Manopola
+label_knob_led:LED Manopola 
 label_knob_led_idle:LED Manopola inattivo
 label_m0_pause:Messo in pausa dal comando M0
 label_send_start_gcode:Gcode prima di stampare
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC Soglia Modo Ibrido
 label_notifications:Notifiche
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_jp.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_jp.ini
@@ -1,5 +1,5 @@
 #### Language Code:JP
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/Copy to SD Card root directory to update/Language Packs/language_pl.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_pl.ini
@@ -1,6 +1,5 @@
-
 #### Language Code:PL
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -278,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_pt.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_pt.ini
@@ -1,5 +1,5 @@
 #### Language Code:PT
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_ru.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_ru.ini
@@ -1,5 +1,5 @@
 #### Language Code:RU
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -24,13 +24,13 @@ label_rgb_settings:Цвет LED
 label_rgb_off:LED выкл
 label_terminal:Терминал
 label_custom:Своё меню
-label_leveling:Равнение
+label_leveling:Стол вруч.
 label_point_1:Точка 1
 label_point_2:Точка 2
 label_point_3:Точка 3
 label_point_4:Точка 4
 label_point_5:Точка 5
-label_bed_leveling:Bed Level
+label_bed_leveling:Стол равнен.
 label_bl_complete:Выравнивание стола окончено
 label_bl_smart_fill:Отсутствующие точки\nзамера были атоматически\nзаполнены.\nЗапомните для сохраниения!
 label_bl_enable:BL: вкл
@@ -39,8 +39,8 @@ label_abl:ABL
 label_bbl:BBL
 label_ubl:UBL
 label_mbl:MBL
-label_mbl_settings:Mesh Bed Leveling
-label_abl_settings:Auto Bed Leveling
+label_mbl_settings:Равнение по сетке
+label_abl_settings:Автовыравнивание
 label_abl_settings_bbl:Билинейная калибровка
 label_abl_settings_ubl:Универсальная калибровка
 label_abl_settings_ubl_save:Сохранить в ячейку
@@ -81,10 +81,10 @@ label_chamber:Камера
 label_start:Начать
 label_stop:Стоп
 label_back:Назад
-label_page_up:Previous
-label_page_down:Next
-label_resume:Продолжить
+label_page_up:Стр.
+label_page_down:Стр. 
 label_pause:Пауза
+label_resume:Продолжить
 label_load:Загрузка
 label_unload:Выгрузка
 label_slow_speed:Медленно
@@ -154,7 +154,7 @@ label_disconnect_info:Управление принтером через ком�
 label_loading:Загрузка...
 label_power_failed:Продолжить печать?
 label_continue:Продолжение
-label_cancel:Cancel
+label_cancel:Отмена
 label_adjust_title:Калибровка экрана
 label_adjust_info:Нажмите на красную точку
 label_adjust_ok:Успешная калибровка
@@ -213,7 +213,7 @@ label_print_acceleration:Печати
 label_retract_acceleration:Ретракта
 label_travel_acceleration:Перемещения
 label_jerk:Рывок
-label_junction_deviation:Junction Deviation
+label_junction_deviation:Отклонение узла
 label_bump_sensitivity:TMC чувствительность удара
 label_fwretract:M207 ретракт
 label_fwrecover:M208 восстановление ретракта
@@ -252,7 +252,7 @@ label_swap_recover_length:Длина при смене сопла
 label_start_print:Начать печать:\n %s?
 label_ack_notification:ACK стиль уведомления
 label_leveling_edge_distance:Отступы от краёв стола
-label_xy_unlock:XY отпуск
+label_xy_unlock:Моторы выкл
 label_tuning:Наладка
 label_pid:PID
 label_pid_title:PID автонастройка
@@ -275,5 +275,6 @@ label_connection_settings:Соединение
 label_offset_tool:Смещение 2-го сопла
 label_hybrid_threshold:TMC гибридный порог
 label_notifications:Уведомления
-label_mesh_editor:Mesh edit
-label_mesh_tuner:Mesh tuner
+label_mesh_editor:Сетка ред.
+label_mesh_tuner:Сетка настр.
+

--- a/Copy to SD Card root directory to update/Language Packs/language_sk.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_sk.ini
@@ -1,5 +1,5 @@
 #### Language Code:SK
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_sl.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_sl.ini
@@ -1,5 +1,5 @@
 #### Language Code:SL
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_tc.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_tc.ini
@@ -1,5 +1,5 @@
 #### Language Code:TC
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -51,7 +51,7 @@ label_abl_slot2:Slot 2
 label_abl_slot3:Slot 3
 label_abl_slot_eeprom:Remember slot for next\nreboot? (Save EEPROM)
 label_abl_z:Z Fade
-label_bltouch:BLTouch
+label_bltouch:BLTouch 
 label_bltouch_test:BLTouch檢測
 label_bltouch_deploy:探針彈出
 label_bltouch_stow:探針收回
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/Copy to SD Card root directory to update/Language Packs/language_tr.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_tr.ini
@@ -1,5 +1,5 @@
 #### Language Code:TR
-## Language Version:20201001
+## Language Version:20201007
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 
@@ -277,3 +277,4 @@ label_hybrid_threshold:TMC HybridThreshold
 label_notifications:Notifications
 label_mesh_editor:Mesh edit
 label_mesh_tuner:Mesh tuner
+

--- a/buildroot/scripts/auto_gen_language_pack.py
+++ b/buildroot/scripts/auto_gen_language_pack.py
@@ -2,7 +2,6 @@
 # Auto generate language_xx.ini files from language keyword header files.
 # ** Author: Gurmeet Athwal https://github.com/guruathwal **
 
-Import("env")
 import os
 import re
 import glob
@@ -30,19 +29,7 @@ setting_path = "/TFT/src/User/API/Settings.h"
 file_count = 0
 key_count = 0
 lang_sign = ""
-label = ""
-repo_path = os.path.dirname(os.path.realpath("__file__"))
-
-# The working dir is change to root firmware directory if the
-# script is executed through platformIO
-# This makes sure correct dir path is selected
-def check_wdir():
-    global repo_path
-    #print(repo_path)
-    isdir = os.path.isdir(repo_path + "/TFT/src/user")
-    while (isdir == False):
-        repo_path = os.path.dirname(repo_path)
-        isdir = os.path.isdir(repo_path + "/TFT/src/user")
+repo_path = ""
 
 def get_langcode(line):
     code = line[-4:-2]
@@ -76,7 +63,7 @@ def get_string(line):
 
 def get_lang_sign():
     global lang_sign
-    set_file = open(os.path.normpath(repo_path + setting_path), 'r', encoding="utf8")
+    set_file = open(repo_path + setting_path, 'r', encoding="utf8")
     lines_list = set_file.readlines()
     for text_line in lines_list:
         text_line = text_line.strip()
@@ -86,11 +73,11 @@ def get_lang_sign():
     #print("lang sign :" + lang_sign)
     set_file.close()
 
-#####
-
-def gen_lang_files(source, target, env):
-    global label, source_file, key_count, file_count
-    check_wdir()
+    #####
+try:
+    print("Generate language_xx.ini files:")
+    repo_path = os.path.realpath("")
+    #print(repo_path)
     get_lang_sign()
 
     for src_file in glob.glob(repo_path + input_path + "/" + source_file):
@@ -126,6 +113,6 @@ def gen_lang_files(source, target, env):
     else:
         print("Total language files processed: " + str(file_count))
 
-env.AddPostAction("buildprog", gen_lang_files)
-
+except:
+    print("Unable to get correct path")
 # %%

--- a/buildroot/scripts/auto_gen_language_pack.py
+++ b/buildroot/scripts/auto_gen_language_pack.py
@@ -1,0 +1,131 @@
+#%%
+# Auto generate language_xx.ini files from language keyword header files.
+# ** Author: Gurmeet Athwal https://github.com/guruathwal **
+
+Import("env")
+import os
+import re
+import glob
+import shutil
+
+bytesize = 250                                      # Max string size in bytes
+old_prefix = "string_"                              # Old Prefix of defined keyword
+new_prefix = "label_"                               # New Prefix for keyword name
+source_file = "language_??.h"                       # Source file name wilecard
+line_start = "#define STRING_"                      # Starting characters for key line to be processed
+lang_sign_prefix = "#define LANGUAGE_FLASH_SIGN"    # Prefix to identify language Sign string
+reg_ex = r"([\\][u][0-F]{4}\s?)"                    # regex to find escape sequence for unicode characters
+
+#Header string to write in ini file
+string_header = """#### Language Code:_code_
+## Language Version:_sign_
+## Maximum byte per keyword is 250 Bytes.
+## Escape characters are not supported except newline '\\n'\n\n"""
+
+input_path = "/TFT/src/User/API/Language"
+output_path = "/Copy to SD Card root directory to update/Language Packs"
+output_path2 = "/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs"
+setting_path = "/TFT/src/User/API/Settings.h"
+
+file_count = 0
+key_count = 0
+lang_sign = ""
+label = ""
+repo_path = os.path.dirname(os.path.realpath("__file__"))
+
+# The working dir is change to root firmware directory if the
+# script is executed through platformIO
+# This makes sure correct dir path is selected
+def check_wdir():
+    global repo_path
+    #print(repo_path)
+    isdir = os.path.isdir(repo_path + "/TFT/src/user")
+    while (isdir == False):
+        repo_path = os.path.dirname(repo_path)
+        isdir = os.path.isdir(repo_path + "/TFT/src/user")
+
+def get_langcode(line):
+    code = line[-4:-2]
+    return code.upper()
+
+def get_filename(line):
+    line = os.path.split(line)
+    return ''.join(line[1])
+
+def dest_filepath(line):
+    filename = get_filename(line).replace(".h", ".ini")
+    d_path = repo_path + output_path + "/" + filename
+    return d_path
+
+def make_label(line):
+    word_list = line.split()
+    line = word_list[1].lower()
+    return line.replace(old_prefix, new_prefix)
+
+def get_defined_name(line):
+    word_list = line.split()
+    return word_list[1]
+
+def get_string(line):
+    str_array = line.rsplit('"')
+    val_string = label + ':' + str_array[1]
+    has_ex = re.search(reg_ex, val_string)
+    if has_ex:
+        val_string = val_string.replace(has_ex.group(),'')
+    return val_string
+
+def get_lang_sign():
+    global lang_sign
+    set_file = open(os.path.normpath(repo_path + setting_path), 'r', encoding="utf8")
+    lines_list = set_file.readlines()
+    for text_line in lines_list:
+        text_line = text_line.strip()
+        if text_line.startswith(lang_sign_prefix):
+                l = text_line.split()
+                lang_sign = l[2]
+    #print("lang sign :" + lang_sign)
+    set_file.close()
+
+#####
+
+def gen_lang_files(source, target, env):
+    global label, source_file, key_count, file_count
+    check_wdir()
+    get_lang_sign()
+
+    for src_file in glob.glob(repo_path + input_path + "/" + source_file):
+        key_count = 0
+        file_count += 1
+        print("Processing: " + get_filename(src_file), end =": ")
+        source_file = open(src_file, 'r', encoding="utf8")
+        dest_file = open(dest_filepath(src_file), 'w', encoding="utf8")
+        header = string_header.replace("_code_",get_langcode(get_filename(src_file)))
+        header = header.replace("_sign_",lang_sign)
+        dest_file.writelines(header)
+        lines_list = source_file.readlines()
+
+        for text_line in lines_list:
+            text_line = text_line.strip()
+            if text_line.startswith(line_start):
+                key_count+=1
+                label = make_label(text_line)
+                val_string = get_string(text_line)
+                #print(val_string)
+                if len(val_string.encode('utf-8')) > bytesize:
+                    raise Exception(">> Size of key '" + get_defined_name(text_line) + "' in " + get_filename(src_file) + " is larger than " + str(bytesize) + " Bytes!\n")
+                dest_file.writelines(val_string + "\n")
+
+        dest_file.writelines("\n") #add new line at the end of the file
+        source_file.close()
+        dest_file.close()
+        shutil.copy(dest_filepath(src_file), repo_path + output_path2) #copy file to second folder
+        print("Total keywords found:" + str(key_count) + ", File generated:" + get_filename(dest_filepath(src_file)))
+
+    if file_count == 0:
+        print("No files found.")
+    else:
+        print("Total language files processed: " + str(file_count))
+
+env.AddPostAction("buildprog", gen_lang_files)
+
+# %%

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,8 +56,9 @@ build_flags = -fmax-errors=5
   -ITFT/src/User/Hal/STM32_USB_OTG_Driver/inc
   -DSOFTWARE_VERSION=26.x
   -DSOFTWARE_VERSION_SHORT=26
-extra_scripts = post:buildroot/scripts/short_out_filename.py
-  pre:buildroot/scripts/custom_filename.py
+extra_scripts = pre:buildroot/scripts/custom_filename.py
+  post:buildroot/scripts/short_out_filename.py
+  post:buildroot/scripts/auto_gen_language_pack.py
 
 
 [stm32f10x]
@@ -193,7 +194,7 @@ upload_protocol = cmsis-dap
 src_filter    = ${stm32f2xx.default_src_filter} +<src/Libraries/Startup/stm32f2xx>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f2xx_0x8000_iap.py
-                
+
 build_flags   = ${stm32f2xx.build_flags}
   -DSTM32F2XX=
   -DHSE_VALUE=8000000ul


### PR DESCRIPTION
- Add language pack auto-generate script to keep the ini files in sync with the source
  The `language_xx.ini` files are now auto-generated while compiling the firmware and are copied to the respective folder. 
  The String size for each keyword is checked to make sure it is within max limit
- Add language flash size check to prevent compiling if the size of total keywords is larger than allocated size.