### PR TITLE
Avoid marking coordinate as unknown when parsing a M18/M84 S<timeout>

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -235,7 +235,17 @@ void sendQueueCmd(void)
           break;
         case 18: //M18/M84 disable steppers
         case 84:
-          coordinateSetKnown(false);
+          if(cmd_seen('S') && !cmd_seen('Y') && !cmd_seen('Z') && !cmd_seen('E'))
+          {
+            // Do not mark coordinate as unknown in this case as this is a M18/M84 S<timeout>
+            // command that doesn't disable the motors right away but will set their idling
+            // timeout.
+          }
+          else
+          {
+            // This is something else than an "M18/M84 S<timeout>", this will disable at least one stepper, set coordinate as unknown
+            coordinateSetKnown(false);
+          }
           break;
 
 #ifdef SERIAL_PORT_2


### PR DESCRIPTION
### Requirements

None

### Description

M18/M84 commands are used to disable steppers, however they also are used to set the stepper inactivity timeout:

    M18 S60; Set the stepper inactivity timeout to 1 minute

When only setting the timeout, steppers are not disabled. 

Thus ,if the print is paused, the printhead would not move to a safe spot as the coordinates would be considered as unknown.

To fix this, I added a simple test, in the case a M18/M84 command is seen, it checks for the arguments and if only S is specified, it will not mark coordinates as unknown as it is not needed.

### Benefits

In the eventuality a M18/M84 S<timeout value> was sent during a print, the next pause command would not move the print head to a safe spot.

This commit fixes this behavior.
