### PR TITLE
Temperature update when printing from onboard SD

### DIFF
--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -18,10 +18,11 @@
 #  Note: Ensure that following options are enabled in Marlin firmware
 #
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
+#  M114_DETAIL  (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS  (in Configuration_adv.h)
 #
 # For printing from onboard SD
 #

--- a/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
+++ b/Copy to SD Card root directory to update - Unified Menu Material theme/config.ini
@@ -21,6 +21,16 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#
+# For printing from onboard SD
+#
+#  SDSUPPORT (in Configuration.h)
+#  AUTO_REPORT_TEMPERATURESS (in Configuration_adv.h)
+#  AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
+#  LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
+#  SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
+# 
 
 #--------------------------------------------------------------------
 # General Settings

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -18,10 +18,11 @@
 #  Note: Ensure that following options are enabled in Marlin firmware
 #
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
+#  M114_DETAIL  (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS  (in Configuration_adv.h)
 #
 # For printing from onboard SD
 #

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -21,6 +21,16 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#
+# For printing from onboard SD
+#
+#  SDSUPPORT (in Configuration.h)
+#  AUTO_REPORT_TEMPERATURESS (in Configuration_adv.h)
+#  AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
+#  LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
+#  SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
+# 
 
 #--------------------------------------------------------------------
 # General Settings

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -76,7 +76,15 @@ bool scanPrintFilesGcodeFs(void)
         else
           longfilename = line;
 
-        Pstr_tmp = strchr(longfilename, '\n');
+        /*
+          When AUTO_REPORT_TEMPERATURES is enabled by M155, The response of M33 may become the following
+            SENDING: M33 /1A29A~1.GCO
+            T:29.43 /0.00 B:27.95 /0.00 @:0 B@:0
+            /1.gcode
+            ok
+          So the longfilename will be parsed "0.00 @:0 B@:0" instead of "1.gcode" if the truncated character is '\n' not string "\nok"
+        */
+        Pstr_tmp = strstr(longfilename, "\nok");
         if (Pstr_tmp != NULL)
           *Pstr_tmp = 0;                          //remove end of M33 command
 

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -7,11 +7,11 @@ const char* const heatDisplayID[MAX_HEATER_COUNT] = HEAT_DISPLAY_ID;
 const char* heatCmd[MAX_HEATER_COUNT]             = HEAT_CMD;
 const char* heatWaitCmd[MAX_HEATER_COUNT]         = HEAT_WAIT_CMD;
 
-static HEATER   heater = {{}, NOZZLE0};
-static int16_t  lastTarget[MAX_HEATER_COUNT] = {0};
-static uint32_t heat_update_time = TEMPERATURE_QUERY_SLOW_DURATION;
-static bool     heat_update_waiting = false;
-static bool     heat_send_waiting[MAX_HEATER_COUNT];
+static HEATER  heater = {{}, NOZZLE0};
+static int16_t lastTarget[MAX_HEATER_COUNT] = {0};
+static uint8_t heat_update_seconds = 0;
+static bool    heat_update_waiting = false;
+static bool    heat_send_waiting[MAX_HEATER_COUNT];
 
 uint32_t nextHeatCheckTime = 0;
 
@@ -65,13 +65,14 @@ bool heatHasWaiting(void)
 void heatSetIsWaiting(uint8_t tool, HEATER_WAIT isWaiting)
 {
   heater.T[tool].waiting = isWaiting;
+
   if(isWaiting != WAIT_NONE) // wait heating now, query more frequently
   {
-    heat_update_time = TEMPERATURE_QUERY_FAST_DURATION;
+    heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
   }
   else if(heatHasWaiting() == false)
   {
-    heat_update_time = TEMPERATURE_QUERY_SLOW_DURATION;
+    heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
   }
 }
 
@@ -81,7 +82,7 @@ void heatClearIsWaiting(void)
   {
     heater.T[i].waiting = WAIT_NONE;
   }
-  heat_update_time = TEMPERATURE_QUERY_SLOW_DURATION;
+  heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }
 
 // Set current Tool (Extruder)
@@ -113,9 +114,28 @@ bool heaterIsValid(uint8_t index)
 }
 
 // Set temperature update time interval
-void heatSetUpdateTime(u32 time)
+void heatSetUpdateSeconds(uint8_t seconds)
 {
-  heat_update_time=time;
+  if (heat_update_seconds == seconds) return;
+
+  heat_update_seconds = seconds;
+  if (infoMachineSettings.autoReportTemp && !heat_update_waiting)
+  {
+    heat_update_waiting = true;
+    storeCmd("M155 ");
+  }
+}
+
+// Get query temperature seconds
+uint8_t heatGetUpdateSeconds(void)
+{
+  return heat_update_seconds;
+}
+
+// Set query temperature seconds
+void heatSyncUpdateSeconds(uint8_t seconds)
+{
+  heat_update_seconds = seconds;
 }
 
 // Set whether we need to query the current temperature
@@ -138,23 +158,26 @@ bool heatGetSendWaiting(uint8_t index)
 
 void updateNextHeatCheckTime(void)
 {
-  nextHeatCheckTime = OS_GetTimeMs() + heat_update_time;
+  nextHeatCheckTime = OS_GetTimeMs() + heat_update_seconds * 1000;
 }
 
 void loopCheckHeater(void)
 {
-  do
-  {  // Send M105 query temperature continuously
-    if(heat_update_waiting == true) {updateNextHeatCheckTime();break;}
-    if(OS_GetTimeMs() < nextHeatCheckTime)     break;
-    if(requestCommandInfoIsRunning())          break; //to avoid colision in Gcode response processing
-    if(storeCmd("M105\n") == false)            break;
-    updateNextHeatCheckTime();
-    heat_update_waiting = true;
-  }while(0);
+  if (!infoMachineSettings.autoReportTemp) // TFT need not M105 to query the temperature, but uses M155 to automatically report if motherboard supports AUTO_REPORT_TEMPERATURESS feature
+  {
+    do
+    {  // Send M105 query temperature continuously
+      if (heat_update_waiting == true) {updateNextHeatCheckTime();break;}
+      if (OS_GetTimeMs() < nextHeatCheckTime)     break;
+      if (requestCommandInfoIsRunning())          break; // To avoid colision in Gcode response processing
+      if (storeCmd("M105\n") == false)            break;
+      updateNextHeatCheckTime();
+      heat_update_waiting = true;
+    }while(0);
+  }
 
   // Query the heater that needs to wait for the temperature to rise, whether it reaches the set temperature
-  for(uint8_t i=0; i< MAX_HEATER_COUNT; i++)
+  for (uint8_t i=0; i< MAX_HEATER_COUNT; i++)
   {
     if (heater.T[i].waiting == WAIT_NONE)                              continue;
     else if (heater.T[i].waiting == WAIT_HEATING) {
@@ -167,16 +190,16 @@ void loopCheckHeater(void)
     heater.T[i].waiting = WAIT_NONE;
     if (heatHasWaiting())                                              continue;
 
-    if(infoMenu.menu[infoMenu.cur] == menuHeat)                        break;
-    heat_update_time = TEMPERATURE_QUERY_SLOW_DURATION;
+    if (infoMenu.menu[infoMenu.cur] == menuHeat)                        break;
+    heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
   }
 
-  for(uint8_t i = 0; i < MAX_HEATER_COUNT; i++) // If the target temperature changes, send a Gcode to set the motherboard
+  for (uint8_t i = 0; i < MAX_HEATER_COUNT; i++) // If the target temperature changes, send a Gcode to set the motherboard
   {
-    if(lastTarget[i] != heater.T[i].target)
+    if (lastTarget[i] != heater.T[i].target)
     {
       lastTarget[i] = heater.T[i].target;
-      if(heat_send_waiting[i] != true)
+      if (heat_send_waiting[i] != true)
       {
         heat_send_waiting[i] = true;
         storeCmd("%s ",heatCmd[i]);

--- a/TFT/src/User/API/Temperature.h
+++ b/TFT/src/User/API/Temperature.h
@@ -10,8 +10,8 @@ extern "C" {
 #include "Configuration.h"
 #include "Settings.h"
 
-#define TEMPERATURE_QUERY_FAST_DURATION 1000  // "M105" query temperature every 1s
-#define TEMPERATURE_QUERY_SLOW_DURATION 3000  // 3s
+#define TEMPERATURE_QUERY_FAST_SECONDS 1  // "M105" query temperature every 1s
+#define TEMPERATURE_QUERY_SLOW_SECONDS 3  // 3s
 
 typedef enum {
   WAIT_NONE = 0,
@@ -75,7 +75,9 @@ void heatSetIsWaiting(uint8_t index,HEATER_WAIT isWaiting);
 void heatClearIsWaiting(void);
 
 void updateNextHeatCheckTime(void);
-void heatSetUpdateTime(uint32_t time);
+void heatSetUpdateSeconds(uint8_t seconds);
+uint8_t heatGetUpdateSeconds(void);
+void heatSyncUpdateSeconds(uint8_t seconds);
 void heatSetUpdateWaiting(bool isWaiting);
 void heatSetSendWaiting(uint8_t index, bool isWaiting);
 bool heatGetSendWaiting(uint8_t index);

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -498,6 +498,23 @@ void sendQueueCmd(void)
           }
           break;
 
+        case 155: //M155
+          if (fromTFT)
+          {
+            heatSetUpdateWaiting(false);
+            if(cmd_seen('S'))
+            {
+              heatSyncUpdateSeconds(cmd_value());
+            }
+            else if (!cmd_seen('\n'))
+            {
+              char buf[12];
+              sprintf(buf, "S%u\n", heatGetUpdateSeconds());
+              strcat(infoCmd.queue[infoCmd.index_r].gcode, (const char*)buf);
+            }
+          }
+          break;
+
         case 106: //M106
         {
           uint8_t i = cmd_seen('P') ? cmd_value() : 0;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -642,6 +642,10 @@ void parseACK(void)
       else if(ack_seen("Cap:AUTOREPORT_TEMP:"))
       {
         infoMachineSettings.autoReportTemp = ack_value();
+        if (infoMachineSettings.autoReportTemp)
+        {
+          storeCmd("M155 ");
+        }
       }
       else if(ack_seen("Cap:AUTOLEVEL:") && infoMachineSettings.leveling == BL_DISABLED)
       {

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -67,7 +67,7 @@ void menuHeat(void)
     {ICON_BACK,                 LABEL_BACK},}
   };
 
-  heatSetUpdateTime(TEMPERATURE_QUERY_FAST_DURATION);
+  heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
 
   heatItems.items[KEY_ICON_4] = itemTool[c_heater];
   heatItems.items[KEY_ICON_5] = itemDegree[item_degree_i];
@@ -159,5 +159,5 @@ void menuHeat(void)
 
   // Set slow update time if not waiting for target temperature
   if(heatHasWaiting() == false)
-    heatSetUpdateTime(TEMPERATURE_QUERY_SLOW_DURATION);
+    heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }

--- a/TFT/src/User/Menu/Mode.c
+++ b/TFT/src/User/Menu/Mode.c
@@ -28,6 +28,7 @@ void infoMenuSelect(void)
   {
     case SERIAL_TSC:
     {
+      initMachineSetting();     // load default machine settings
       Serial_ReSourceInit();
       #ifdef BUZZER_PIN
         Buzzer_Config();
@@ -52,14 +53,14 @@ void infoMenuSelect(void)
         if (freshboot)
         {
           u32 startUpTime = OS_GetTimeMs();
-          heatSetUpdateTime(TEMPERATURE_QUERY_FAST_DURATION);
+          heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
           LOGO_ReadDisplay();
           updateNextHeatCheckTime(); // send "M105" 1s later not now, because of mega2560 will be hanged when received data at startup
           while (OS_GetTimeMs() - startUpTime < 3000) //Display 3s logo
           {
             loopProcess();
           }
-          heatSetUpdateTime(TEMPERATURE_QUERY_SLOW_DURATION);
+          heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshboot = false;
         }
       #endif

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -406,7 +406,6 @@ void menuPrint(void)
             list_mode = true; //force list mode in Onboard sd card
             infoFile.source = BOARD_SD;
             infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;   //TODO: fix here,  onboard sd card PLR feature
-            storeCmd("M155 S3\n");
             goto selectEnd;
           }
           break;

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -406,7 +406,7 @@ void menuPrint(void)
             list_mode = true; //force list mode in Onboard sd card
             infoFile.source = BOARD_SD;
             infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;   //TODO: fix here,  onboard sd card PLR feature
-            storeCmd("M155 S1\n");
+            storeCmd("M155 S3\n");
             goto selectEnd;
           }
           break;

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -406,6 +406,7 @@ void menuPrint(void)
             list_mode = true; //force list mode in Onboard sd card
             infoFile.source = BOARD_SD;
             infoMenu.menu[++infoMenu.cur] = menuPrintFromSource;   //TODO: fix here,  onboard sd card PLR feature
+            storeCmd("M155 S1\n");
             goto selectEnd;
           }
           break;

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -93,7 +93,7 @@ void menuTuneExtruder(void)
   int16_t actCurrent;
   int16_t actTarget;
 
-  heatSetUpdateTime(TEMPERATURE_QUERY_FAST_DURATION);
+  heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
 
   menuDrawPage(&tuneExtruderItems);
   showExtrudeTemperature(c_heater);
@@ -216,7 +216,7 @@ void menuTuneExtruder(void)
 
   // Set slow update time if not waiting for target temperature
   if (heatHasWaiting() == false)
-    heatSetUpdateTime(TEMPERATURE_QUERY_SLOW_DURATION);
+    heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }
 
 void menuNewExtruderESteps(void)

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -18,10 +18,11 @@
 #  Note: Ensure that following options are enabled in Marlin firmware
 #
 #  M115_GEOMETRY_REPORT (in Configuration_adv.h)
+#  M114_DETAIL  (in Configuration_adv.h)
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#  HOST_ACTION_COMMANDS  (in Configuration_adv.h)
 #
 # For printing from onboard SD
 #

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -21,6 +21,16 @@
 #  REPORT_FAN_CHANGE (in Configuration_adv.h)
 #  EMERGENCY_PARSER (in Configuration_adv.h)
 #  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#  REPORT_FAN_CHANGE (in Configuration_adv.h)
+#
+# For printing from onboard SD
+#
+#  SDSUPPORT (in Configuration.h)
+#  AUTO_REPORT_TEMPERATURESS (in Configuration_adv.h)
+#  AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
+#  LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
+#  SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
+# 
 
 #--------------------------------------------------------------------
 # General Settings

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -49,7 +49,6 @@ void Hardware_GenericInit(void)
   LCD_RefreshDirection();   // refresh display direction after reading settings
   scanUpdates();            // scan icon, fonts and config files
   checkflashSign();         // check font/icon/config signature in SPI flash for update
-  initMachineSetting();     // load default machine settings
 
   #ifdef LED_COLOR_PIN
     knob_LED_Init();


### PR DESCRIPTION
After printing from the onboard SD, the bed and nozzle temperatures are not updated until they reach the target temperature.
This adjustment solves it.
Adding code "M155 S1" to start G-code does not work.
Adding a code to the start code in Cura also does not work.
First the heating is started and only then the start code is activated.
Therefore, the values on the display are not updated until the target temperature is reached.

resolves #1127
resolves #1225
resolves #1070

Add a comment to Config.ini, with information about the required settings in Marlin
PS:
When printing from the onboard SD, there is still a problem and detecting the print height. If someone knew the solution, it would be good to add it as well.
If https://github.com/MarlinFirmware/Marlin/pull/18427 is merged, it could be used to display the current print height.
