### PR TITLE
Add send gcode check

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -575,8 +575,8 @@ void sendQueueCmd(void)
 #ifdef GCODE_CHECKING
         case 110:  //M110  Set Line Number  "M110 N<line>"
           {
-            uint32_t line;
-            if(cmd_seen('N'))
+            uint32_t line = 0;
+            if (cmd_seen('N'))
             {
               line = cmd_value();
               infoCmd.line = line;
@@ -902,30 +902,39 @@ void sendQueueCmd(void)
   } // end parsing cmd
 
   setCurrentAckSrc(infoCmd.queue[infoCmd.index_r].src);
+
 #ifdef GCODE_CHECKING
-  if(checking_flag==1)
+  if (checking_flag == 1)
   {
-    uint8_t index=0;
+    uint8_t index = 0;
     uint8_t cs = 0;
-    uint8_t num=0;
-    char line_str[CMD_MAX_CHAR]={0};
+    uint8_t num = 0;
+    char line_str[CMD_MAX_CHAR] = {0};
 
     infoCmd.line++;
     sprintf(line_str, "N%u ", infoCmd.line);
     strcat(line_str, infoCmd.queue[infoCmd.index_r].gcode);
 
-    while(line_str[index] != '\n') index++;
+    while (line_str[index] != '\n')
+    {
+      index++;
+    }
 
     num = index;
-    for(; index; )
+    for (; index; )
+    {
       cs = cs ^ line_str[--index];
+    }
     cs &= 0xff;
-    sprintf(line_str+num, "*%d\n", cs);
+    sprintf(line_str + num, "*%d\n", cs);
     strcpy(infoCmd.queue[infoCmd.index_r].gcode, line_str);
   }
-  if(checking_flag==0)
+  if (checking_flag == 0)
+  {
     checking_flag = 1;
+  }
 #endif //GCODE_CHECKING
+
   Serial_Puts(SERIAL_PORT, infoCmd.queue[infoCmd.index_r].gcode);
   if (avoid_terminal != true){
     sendGcodeTerminalCache(infoCmd.queue[infoCmd.index_r].gcode, TERMINAL_GCODE);

--- a/TFT/src/User/API/interfaceCmd.h
+++ b/TFT/src/User/API/interfaceCmd.h
@@ -23,6 +23,7 @@ typedef struct
   uint8_t index_r; // Ring buffer read position
   uint8_t index_w; // Ring buffer write position
   uint8_t count;   // Count of commands in the queue
+  uint32_t line;   // Gcode valid line number
 }GCODE_QUEUE;
 
 extern GCODE_QUEUE infoCmd;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -335,13 +335,14 @@ void parseACK(void)
       goto parse_end;
     }
     // Onboard sd Gcode command response end
-    static uint8_t old_line=0;
+
+    static uint8_t old_line = 0;
   #ifdef GCODE_CHECKING
     if(ack_seen("Resend: "))   //checking error
     {
       static char *str;                            //Save needs to rewrite string
       uint8_t line = atoi(dmaL2Cache+ack_index);   //Get checking error line number  e.g. Resend: 25
-      if(old_line != line)
+      if (old_line != line)
       {
         old_line = line;
         str = infoCmd.queue[infoCmd.index_r-1].gcode;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -335,11 +335,10 @@ void parseACK(void)
       goto parse_end;
     }
     // Onboard sd Gcode command response end
-
+    static uint8_t old_line=0;
   #ifdef GCODE_CHECKING
     if(ack_seen("Resend: "))   //checking error
     {
-      static uint8_t old_line=0;
       static char *str;                            //Save needs to rewrite string
       uint8_t line = atoi(dmaL2Cache+ack_index);   //Get checking error line number  e.g. Resend: 25
       if(old_line != line)
@@ -356,6 +355,7 @@ void parseACK(void)
     if(ack_cmp("ok\n"))
     {
       infoHost.wait = false;
+      old_line = 0;
     }
     else
     {

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -442,6 +442,14 @@
 #define RAPID_SERIAL_COMM
 
 /**
+ * Check gcode line number and checksum.
+ *  e.g. N123 [...G Code in here...] *123
+ * You can open Marlin ADVANCED_OK and check the reception status
+ * https://reprap.org/wiki/G-code#N:_Line_number
+ */
+#define GCODE_CHECKING
+
+/**
  * Custom G-code Commands
  *
  * Support for up to 15 custom G-codes. Uncomment CUSTOM_*_LABEL and CUSTOM_*_GCODE to enable custom G-code.

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -213,7 +213,7 @@ void menuPrintFromSource(void)
   KEY_VALUES key_num = KEY_IDLE;
 
   u8 update=0;
-
+  storeCmd("M110 N0\n");    //Clear line number
   GUI_Clear(infoSettings.bg_color);
   GUI_DispStringInRect(0, 0, LCD_WIDTH, LCD_HEIGHT, LABEL_LOADING);
 


### PR DESCRIPTION
### Description

Add check and error response according to the [reprap.org](https://reprap.org/wiki/G-code#N:_Line_number) description.
The line number will be cleared before choosing to print the file.


Include N line number  , * checksum.
e.g. N123 [...G Code in here...] *123

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

~~If two errors appear in the same line number, the error content will be sent.~~
