### PR TITLE
Enlarged DMA-L1 and Terminal buffer, reduced DMA-L2 buffer

### DIFF
--- a/TFT/src/User/API/parseACK.h
+++ b/TFT/src/User/API/parseACK.h
@@ -11,7 +11,7 @@ extern "C" {
 static const char errormagic[]         = "Error:";
 static const char echomagic[]          = "echo:";
 
-#define ACK_MAX_SIZE 2048
+#define ACK_MAX_SIZE 512
 
 typedef enum                      // popup message types available to display an echo message
 {

--- a/TFT/src/User/Hal/stm32f10x/Serial.h
+++ b/TFT/src/User/Hal/stm32f10x/Serial.h
@@ -10,7 +10,7 @@ typedef struct
   uint16_t rIndex;
 }DMA_CIRCULAR_BUFFER;
 
-#define DMA_TRANS_LEN  ACK_MAX_SIZE
+#define DMA_TRANS_LEN  4096
 
 extern DMA_CIRCULAR_BUFFER dmaL1Data[_UART_CNT];
 

--- a/TFT/src/User/Hal/stm32f2_f4xx/Serial.h
+++ b/TFT/src/User/Hal/stm32f2_f4xx/Serial.h
@@ -10,7 +10,7 @@ typedef struct
   uint16_t rIndex;
 }DMA_CIRCULAR_BUFFER;
 
-#define DMA_TRANS_LEN  ACK_MAX_SIZE
+#define DMA_TRANS_LEN  4096
 
 extern DMA_CIRCULAR_BUFFER dmaL1Data[_UART_CNT];
 

--- a/TFT/src/User/Menu/SendGcode.c
+++ b/TFT/src/User/Menu/SendGcode.c
@@ -1,7 +1,7 @@
 #include "SendGcode.h"
 #include "includes.h"
 
-#define TERMINAL_MAX_CHAR ((LCD_WIDTH / BYTE_WIDTH) * (LCD_HEIGHT / BYTE_HEIGHT) * 4)
+#define TERMINAL_MAX_CHAR ((LCD_WIDTH / BYTE_WIDTH) * (LCD_HEIGHT / BYTE_HEIGHT) * 8)
 #define MAX_BUFF          20
 #define SCROLL_LINE       22
 #define SCROLL_PAGE       1


### PR DESCRIPTION
### Requirements

BTT TFT or MKS TFT

### Description

- enlarged DMA-L1 buffer
- enlarged Terminal buffer
- reduced DMA-L2 buffer to accommodate RAM requirements across the boards, it was unnecessarily large anyway

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->
TFT can display larger responses from Marlin.
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Fixes bigtreetech#1267