### PR TITLE
config.ini cleanup

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -1,282 +1,413 @@
-#### Default Config file for BigTreeTech TFT Controllers
+#--------------------------------------------------------------------
+#
+# DEFAULT CONFIG FILE FOR BigTreeTech TFT CONTROLLERS
+#
+#--------------------------------------------------------------------
+
+
+#--------------------------------------------------------------------
+# Supported TFT Variants
+#--------------------------------------------------------------------
 #
 # BIGTREE_TFT35_V1_1 / BIGTREE_TFT35_V1_2    / BIGTREE_TFT35_V2_0
 # BIGTREE_TFT35_V3_0 / BIGTREE_TFT35_E3_V3_0 / BIGTREE_TFT28_V1_0
 # BIGTREE_TFT28_V3_0 / BIGTREE_TFT24_V1_1    / MKS_32_V1_4
 # MKS_28_V1_0
 #
-# Firmware Source: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware
+# Firmware source: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware
+#
 
 
 #--------------------------------------------------------------------
-# Supported Marlin Firmware Version
+# Supported Marlin Firmware Versions
 #--------------------------------------------------------------------
-#  Minimum Marlin Firmware Version: 2.0.5.4
-#  Distribution date: 2020-05-12
-#  Source: https://github.com/MarlinFirmware/Marlin/releases
+#
+# Minimum Marlin firmware version: 2.0.5.4
+# Distribution date: 2020-05-12
+# Firmware source: https://github.com/MarlinFirmware/Marlin/releases
+#
+# IMPORTANT NOTE:
+#   Ensure that the following options are enabled in Marlin firmware
+#
+# General options:
+#   M115_GEOMETRY_REPORT (in Configuration_adv.h)
+#   M114_DETAIL (in Configuration_adv.h)
+#   REPORT_FAN_CHANGE (in Configuration_adv.h)
+#   EMERGENCY_PARSER (in Configuration_adv.h)
+#   SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#   HOST_ACTION_COMMANDS (in Configuration_adv.h)
+#
+# Options to support printing from onboard SD:
+#   SDSUPPORT (in Configuration.h)
+#   AUTO_REPORT_TEMPERATURES (in Configuration_adv.h)
+#   AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
+#   LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
+#   SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
+#
+# Options to support (Un)Load menu:
+#   FILAMENT_LOAD_UNLOAD_GCODES (in Configuration_adv.h)
 #
 
-#  Note: Ensure that following options are enabled in Marlin firmware
-#
-#  M115_GEOMETRY_REPORT (in Configuration_adv.h)
-#  M114_DETAIL  (in Configuration_adv.h)
-#  REPORT_FAN_CHANGE (in Configuration_adv.h)
-#  EMERGENCY_PARSER (in Configuration_adv.h)
-#  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS  (in Configuration_adv.h)
-#
-# For printing from onboard SD
-#
-#  SDSUPPORT (in Configuration.h)
-#  AUTO_REPORT_TEMPERATURESS (in Configuration_adv.h)
-#  AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
-#  LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
-#  SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
-# 
 
 #--------------------------------------------------------------------
 # General Settings
 #--------------------------------------------------------------------
+#
 
-#### UNIFIED MENU / CLASSIC MENU
-# Select a UI Menu flavour
+#### Unified Menu / Classic Menu
+# Select a UI menu flavour
+#
 # Options: [Unified Menu: 1, Classic Menu: 0]
+#
 unified_menu:1
 
 #### Baudrate
 # Options: [2400: 0, 9600: 1, 19200: 2, 38400: 3, 57600: 4, 115200: 5, 250000: 6, 500000: 7, 1000000: 8]
+#
 baudrate:5
 
 #### Default Touch Mode Language
 # Select the language to display on the LCD while in Touch Mode.
 # To add/flash a second language copy the required "language_xx.ini" file from "Language Packs" folder
-# to the SD root folder. Then preset the reset button to load/flash the copied language file.
-# Options: [Primary Language(English): 0, secondary language: 1]
+# to the SD root folder. Then preset the reset button to load/flash the copied language file
+#
+# Options: [primary language (english): 0, secondary language: 1]
+#
 language:0
 
-#### Default Touch Mode Color Options
+#### Default Touch Mode Colors
 # Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #           ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
-# Or set the color(RGB888 format) hex value directly(start with “0x”).
+#
+# Or set the color (RGB888 format) hex value directly (start with “0x”).
 # Such as: 0xFF0000 : Red, 0x00FF00 : Green, 0x0000FF : Blue
+#
+
 # Title background color
+#
 title_back_color:1
 
 # Background color
+#
 background_color:1
 
 # Font foreground color
+#
 font_color:0
 
-# Reminder font color, such as: "No print attached", "Busy processing", etc.
+# Reminder font color, such as: "No print attached", "Busy processing", etc
+#
 reminder_color:2
 
 # Volume status/reminder font color, such as: "Card inserted", "Card removed"
+#
 volume_status_color:5
 
-# Backgroud color for X Y Z position display in Status Screen.
+# Backgroud color for X Y Z position display in Status Screen menu
+#
 status_xyz_bg_color:15
 
-# List View Border Color
+# List View border color
+#
 list_border_color:15
 
 # List View button background color
+#
 list_button_bg_color:15
 
-# Color used by the Mesh Editor for drawing the mesh with the minimun value in the grid
+# Color used by the Mesh Editor menu for drawing the mesh with the minimun value in the grid
+#
 mesh_min_color:7
 
-# Color used by the Mesh Editor for drawing the mesh with the maximum value in the grid
+# Color used by the Mesh Editor menu for drawing the mesh with the maximum value in the grid
+#
 mesh_max_color:2
 
-#### Rotate UI 180 degrees
+#### Rotate UI
+# Rotate UI by 180 degrees
+#
 # Options: [enable: 1, disable: 0]
+#
 rotate_ui:0
 
-#### Show or hide Temperature ACK in Gcode Terminal
-# Options: [Show: 1, Hide: 0]
+#### Temperature ACK
+# Show or hide temperature ACK in Terminal menu
+#
+# Options: [show: 1, hide: 0]
+#
 terminal_ack:0
 
-#### invert X axis button function in Move menu to match move buttons to actual axis
+#### Inverted Axes For Move Menu
+# Invert axis button function in Move menu in order it matches the actual axis
+#
+# Format: [X<option> Y<option> Z<option> E<option>]
+#
 # Options: [enable: 1, disable: 0]
-# Invert Axis format      [ X<option> Y<option> Z<option> E<option>]
+#
 invert_axis:X0 Y0 Z0
 
-#### Persistent temperature info
-# show persistent temperature info on all menu screens
+#### Persistent Temperature Info
+# Show persistent temperature info on all menus
+#
 # Options: [enable: 1, disable: 0]
+#
 persistent_info:0
 
 #### File List Mode
-# show file as list
+# Display files in list mode instead of icon mode
+#
 # Options: [enable: 1, disable: 0]
+#
 files_list_mode:1
 
-#### Notification style for ACK messages
+#### Notification Style For ACK Messages
 # Set the notification style to use for displaying the ACK messages which start with 'echo:'
 #
 # NOTE: The OFF value is applied to any ACK message type (e.g. even to known echo ACK).
-#       It means that any kind of ACK message is silently discard
+#       It means that any kind of ACK message is silently discarded
 #
 # Options: [OFF: 0, POPUP: 1, TOAST: 2]
-#   OFF:   No notification. The message is ignored.
-#   POPUP: Display a popup window for user confirmation.
+#   OFF:   No notification. The message is ignored
+#   POPUP: Display a popup window for user confirmation
 #   TOAST: A non-blocking Toast notification is displayed for few seconds. No user interaction is needed
+#
 ack_notification:1
 
+
 #--------------------------------------------------------------------
-# Marlin Mode Settings (Only for TFT24_V1.1 & TFT28/TFT35/TFT43/TFT50/TFT70_V3.0)
+# Marlin Mode Settings (only for TFT24_V1.1 & TFT28/TFT35/TFT43/TFT50/TFT70_V3.0)
 #--------------------------------------------------------------------
+#
 
 #### Default Mode
-# Options: [0: Marlin Mode, 1: Touch Mode]
+# Options: [Marlin Mode: 0, Touch Mode: 1]
+#
 default_mode:1
 
-#### Keep Serial Always ON
-# Keep UART (Serial communication) alive in Marlin Mode
-# Allow seamless OctoPrint UART connection to the TFT's UART/serial expansion port no matter which mode the TFT is in.
-# Options: [0: Disabled, 1: Enabled]
+#### Serial Always ON
+# Keep UART (serial communication) alive in Marlin Mode.
+# Allows seamless OctoPrint UART connection to the TFT's UART/serial expansion port no matter which mode the TFT is in
+#
+# Options: [enable: 1, disable: 0]
+#
 serial_always_on:0
 
-#### Default Marlin Mode Background & Font Color Options
+#### Default Marlin Mode Background & Font Colors
 # Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #           ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
-# Or set the color(RGB888 format) hex value directly(start with “0x”).
+#
+# Or set the color (RGB888 format) hex value directly (start with “0x”).
 # Such as: 0xFF0000 : Red, 0x00FF00 : Green, 0x0000FF : Blue
+#
+
+# Marlin Mode background color
+#
 marlin_bg_color:1
+
+# Marlin Mode font color
+#
 marlin_fn_color:8
 
-#### Marlin Mode show title
+#### Marlin Mode Title Support
+# Show title in Marlin Mode
+#
 # Options: [enable: 1, disable: 0]
+#
 marlin_show_title:1
 
-# Run Marlin Mode in Fullscreen
-# Options: [enable: 1, disable: 0] [Disabled. RECOMMENDED FOR TFT24]
+#### Marlin Mode Fullscreen Support
+# Run Marlin Mode in fullscreen
+#
+# Note: Disable is recommended for TFT24
+#
+# Options: [enable: 1, disable: 0]
+#
 marlin_fullscreen:0
 
-# Select marlin type
+#### Marlin Mode Type
+# Select Marlin Mode type
+#
 # Options: [LCD12864: 1, LCD2004: 0]
+#
 marlin_type:1
 
-#### Text displayed at the top of the TFT in Marlin Mode.
+#### Marlin Mode Title
+# Text displayed at the top of the TFT in Marlin Mode
+#
 marlin_title:LCD12864 Simulator
+
 
 #--------------------------------------------------------------------
 # Printer / Machine Settings
 #--------------------------------------------------------------------
+#
 
 #### Hotend Count
 # Options: [1 to 6]
+#
 hotend_count:1
 
-#### Enable heated Bed
+#### Heated Bed Support
 # Options: [enable: 1, disable: 0]
+#
 heated_bed:1
 
-#### Enable heated chamber
-# The TFT will auto-detect if chamber heating is enabled in marlin firmware.
+#### Heated Chamber Support
+# The TFT will auto-detect if chamber heating is enabled in marlin firmware
+#
 # Options: [enable: 1, disable: 0]
+#
 heated_chamber:0
 
 #### Extruder Count
 # Options: [1 to 6]
+#
 ext_count:1
 
 #### Fan Count
 # Options: [1 to 6]
+#
 fan_count:1
 
 #### Fan Controller Count
 # Options: 0 to 2
+#
 fan_ctrl_count:0
 
 #### Bed / Extruder / Chamber Maximum Temperatures
-# format [max_temp: T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp> BED:<max temp> CHAMBER:<max temp>]
+# Format: [max_temp: T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp> BED:<max temp> CHAMBER:<max temp>]
+#
+# Unit: [°C]
+#
 max_temp:T0:275 T1:275 T2:275 T3:275 T4:275 T5:275 BED:150 CHAMBER:60
 
 #### Cold Extrusion Minimum Temperature
+# Unit: [°C]
+#
 min_temp:180
 
-#### Fan Maximum PWM speed (0 to 255)
-# format [fan_max: F0:<max PWM> F1:<max PWM> F2:<max PWM> F3:<max PWM> F4:<max PWM> F5:<max PWM> CtL:<max PWM> CtI:<max PWM>]
+#### Fan Maximum PWM Speed
+# Format: [fan_max: F0:<max PWM> F1:<max PWM> F2:<max PWM> F3:<max PWM> F4:<max PWM> F5:<max PWM> CtL:<max PWM> CtI:<max PWM>]
+#
+# Value range: [min: 0, max: 255]
+#
 fan_max:F0:255 F1:255 F2:255 F3:255 F4:255 F5:255  CtL:255 CtI:255
 
-#### Machine Size / Build Area (mm)
-# The TFT will auto-detect the machine size in marlin firmware (Requires enabling `M115_GEOMETRY_REPORT`
-# in Configuration_adv.h in Marlin firmware).
-# Options: [X Axis: X, Y Axis: Y, Z Axis: Z]
-# minimum possible value: -2000, maximum possible value: 2000
-# minimum size limit format [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
-# maximum size limit format [size_max: X<maximum distance> Y<maximum distance> Z<maximum distance>]
+#### Machine Size / Build Area
+# The TFT will auto-detect the machine size in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
+# in Configuration_adv.h in Marlin firmware)
+#
+# Format: [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
+#         [size_max: X<maximum distance> Y<maximum distance> Z<maximum distance>]
+#
+# Unit: [mm]
+#
+# Value range: [min: -2000, max: 2000]
+#
+# Options: [X axis: X, Y axis: Y, Z axis: Z]
+#
 size_min:X0 Y0 Z0
 size_max:X235 Y235 Z250
 
-#### default Move Speeds (mm/min)
-# Options: [Slow: S, Normal: N, Fast: F]
-# format   [move_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#### Default Move Speeds
+# Format: [move_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#
+# Unit: [mm/min]
+#
+# Options: [slow: S, normal: N, fast: F]
+#
 move_speed:S1000 N3000 F5000
 
-#### default Extruder Speeds (mm/min)
-# Options: [Slow: S, Normal: N, Fast: F]
-# format   [ext_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#### Default Extruder Speeds
+# Format: [ext_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#
+# Unit: [mm/min]
+#
+# Options: [slow: S, normal: N, fast: F]
+#
 ext_speed:S60 N600 F1200
 
 #### Auto Save Load Leveling Data
 # The TFT will auto-detect if Auto Bed Level is available.
 # Enable this will send "M500" after "G29" to store leveling value
 # and send "M420 S1" to enable leveling state after startup
+#
 # Options: [enable: 1, disable: 0]
+#
 auto_load_leveling:1
 
 #### Onboard / Printer SD Card Support
-# On Marlin Firmware, The TFT will auto detect Onboard SD Card
+# On Marlin firmware, the TFT will auto-detect Onboard SD Card.
 # Auto-detect is not available for other firmwares like Smoothieware
+#
 # Options: [enable: 1, disable: 0, auto-detect: 2]
+#
 onboard_sd_support:2
 
-#### M27 / Printing status refresh time (this will be used if SD_AUTOREPORT is not detected by the TFT)
+#### M27 Printing Status Refresh Time
+# M27 printing status refresh time (this will be used if SD_AUTOREPORT is not detected by the TFT)
+#
+# Unit: [seconds]
+#
 M27_refresh_time:3
 
-#### M27 always active - keep polling M27 even if not printing
+#### M27 Always Active
+# Keep polling M27 even if not printing
+#
 # Options: [enable: 1, disable: 0]
+#
 M27_always_active:1
 
 #### Long File Names Support
-# On Marlin Firmware, The TFT will auto-detect Long File Name supported
+# On Marlin firmware, the TFT will auto-detect Long File Name support.
 # Auto-detect is not available for other firmwares like Smoothieware
+#
 # Options: [enable: 1, disable: 0, auto-detect: 2]
+#
 long_filename_support:2
 
-#### Show Fan Speed as Percentage
+#### Fan Speed As Percentage
+# Show fan speed as percentage
+#
 # Options: [enable: 1, disable: 0]
+#
 fan_speed_percent:1
 
 #### Pause Settings
-# position & Lengths in mm, Feedrates in mm/min
-# minimum possible value: 0, maximum possible value: 2000
-# Pause retract distance format [pause_retract: R<retract length> P<Resume Purge length>]
-# Pause XY position format      [pause_pos: X<position in mm> Y<position in mm>]
-# Pause Z raise format          [pause_z_raise: Z<distance in mm>]
-# Pause feed Rate # format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min> E<feedrate mm/min>]
+# Format: [pause_retract: R<retract length> P<Resume Purge length>]
+#         [pause_pos: X<position in mm> Y<position in mm>]
+#         [pause_z_raise: Z<distance in mm>]
+#         [pause_feedrate: X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min> E<feedrate mm/min>]
+#
+# Unit: [position & length: mm, feedrate: mm/min]
+#
+# Value range: [min: 0, max: 2000]
+#
 pause_retract:R15 P16
 pause_pos:X10 Y10
 pause_z_raise:10
 pause_feedrate:X6000 Y6000 Z6000 E600
 
-### Manual Level Points Edge distance (mm)
-# distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [level_edge_distance: <distance from edge in mm>]
-# Leveling Z Position format     [level_z_pos: Z<position in mm>]
-# Leveling Z raise format        [level_z_raise: Z<distance in mm>]
-# Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
+#### Manual Level Points Edge Distance
+# Format: [level_edge_distance: <distance from edge in mm>]
+#         [level_z_pos: Z<position in mm>]
+#         [level_z_raise: Z<distance in mm>]
+#         [level_feedrate: X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
+#
+# Unit: [distance: mm, feedrate: mm/min]
+#
 level_edge_distance:20
 level_z_pos:0.2
 level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 
-#### Preheat Temperature
-# Maximum Filament name length 7 characters
-# format [T<hotend temp> B<bed temp>]
+#### Preheat Temperatures
+# Format: [T<hotend temp> B<bed temp>]
+#
+# Unit: [°C]
+#
+# Value range: [filament name: max 7 characters]
+#
 preheat_name1:PLA
 preheat_temp1:T200 B60
 
@@ -295,110 +426,157 @@ preheat_temp5:T220 B50
 preheat_name6:NYLON
 preheat_temp6:T250 B90
 
+
 #--------------------------------------------------------------------
-# Power Supply Settings (if connected to TFT Controller)
+# Power Supply Settings (if connected to TFT controller)
 #--------------------------------------------------------------------
+#
 
 #### Default Power Supply Mode
-# Options: [OFF: 0, ON: 1: Auto:2]
+# Options: [OFF: 0, ON: 1, AUTO: 2]
+#
 ps_on:0
 
-#### Power Supply Active HIGH Settings
+#### Power Supply Active HIGH
 # Options: [HIGH: 1, LOW: 0]
+#
 ps_on_active_high:1
 
-#### Maximum hot-end temperature of automatic shut down after printing (only if auto power is enabled)
-# wait for the hot-end temperature to be lower than this value, then turn off the power automatically
+#### Power Supply Auto Shutdown Temperature
+# Maximum hot-end temperature of automatic shut down after printing (only if auto power is enabled).
+# Wait for the hot-end temperature to be lower than this value, then turn off the power automatically
+#
+# Unit: [°C]
+#
 auto_shutdown_temp:50
 
-#--------------------------------------------------------------------
-# Filament Runout Settings (if connected to TFT Controller)
-#--------------------------------------------------------------------
 
-#### Default FIlament Sensor
-# Options: [NONE: 0, Normal: 1, SMART: 2]
+#--------------------------------------------------------------------
+# Filament Runout Settings (if connected to TFT controller)
+#--------------------------------------------------------------------
+#
+
+#### Default Filament Runout Sensor
+# Options: [NONE: 0, NORMAL: 1, SMART: 2]
+#
 fil_runout:0
 
-#### Filament runout inverting - invert the logic of the sensor.
+#### Inverted Filament Runout Logic
+# Invert the logic of the sensor
+#
 # Options: [true: 1, false: 0]
+#
 fil_runout_inverting:1
 
-#### filament noise threshold  - Pause print when filament runout is detected for this time period in (ms).
-# time duration in ms
+#### Filament Noise Threshold
+# Pause print when filament runout is detected for this time period
+#
+# Unit: [ms]
+#
 fil_noise_threshold:100
 
-#### Smart filament runout detection
+#### Smart Filament Runout Detection
 # For use with an encoder disc that toggles runout pin as filament moves
+#
+# Unit: [mm]
+#
 fil_runout_distance:7
 
+
 #--------------------------------------------------------------------
-# Power Loss Recovery & BTT UPS Settings (if connected to TFT Controller)
+# Power Loss Recovery & BTT UPS Settings (if connected to TFT controller)
 #--------------------------------------------------------------------
-#### Power Loss recovery default enable, disable to reduce the loss of SD card or U disk
+#
+
+#### Default Power Loss Recovery Mode
+# Enabled by default.
+# Disable to reduce the loss of SD card or U disk
+#
 # Options: [enable: 1, disable: 0]
+#
 pl_recovery_en:1
 
-#### Home before Power Loss recovery
+#### Power Loss Recovery Homing
+# Home before power loss recovery
+#
 # Options: [enable: 1, disable: 0]
+#
 pl_recovery_home:0
 
-#### Power Loss Z raise (mm)
+#### Power Loss Z Raise
 # Raise Z axis on resume (on power loss with UPS)
+#
+# Unit: [mm]
+#
 pl_z_raise:10
 
-#### Enable BTT UPS
+#### BTT UPS Support
+# Enable BTT UPS
+#
 # Options: [enable: 1, disable: 0]
+#
 btt_mini_ups:0
 
 
 #--------------------------------------------------------------------
-# Other device-specific settings
+# Other Device-Specific Settings
 #--------------------------------------------------------------------
+#
 
 #### Sounds / Buzzer
-# set sounds ON or OFF
+# Set sound ON or OFF
+#
+# Variants:
 #   touch_sound: enable/disable this to control touch feedback sound
 #   toast_sound: enable/disable this to control all toast notification sounds
 #   alert_sound: enable/disable this to control all popup and alert sounds
-#                 like print finish alert, dialog sound etc.
-# NOTE: Error messages from printer will always play the error sound.
+#                like print finish alert, dialog sound etc
+#
+# NOTE: Error messages from printer will always play the error sound
+#
 # Options: [enable: 1, disable: 0]
+#
 touch_sound:1
 toast_sound:1
 alert_sound:1
 
-#### Knob Led Color (only for TFT35 E3.0)
+#### Knob LED Color (only for TFT35 E3.0)
 # Options: [LED_OFF: 0, LED_WHITE: 1, LED_RED: 2, LED_ORANGE: 3, LED_YELLOW: 4, LED_GREEN: 5, LED_BLUE: 6, LED_INDIGO: 7, LED_VIOLET: 8]
+#
 knob_led_color:0
 
-#### Knob idle state
+#### Knob Idle State
 # Options: [true: 1, false: 0]
+#
 knob_led_idle:1
 
-#### Default LCD Brightness levels (only for TFT35v3.0 & TFT28v3.0)
+#### Default LCD Brightness Levels (only for TFT35v3.0 & TFT28v3.0)
 # Options: [(off) 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 (full)]
+#
 lcd_brightness:11
 lcd_idle_brightness:5
 
-#### Default LCD idle time (only for TFT35v3.0 & TFT28v3.0)
-# Options [Off: 0, 5Sec: 1, 10Sec: 2, 30sec: 3, 1min: 4, 2min: 5, 5min: 6, 10min: 7]
+#### Default LCD Idle Time (only for TFT35v3.0 & TFT28v3.0)
+# Options: [Off: 0, 5sec: 1, 10sec: 2, 30sec: 3, 1min: 4, 2min: 5, 5min: 6, 10min: 7]
+#
 lcd_idle_delay:4
 
 
 #--------------------------------------------------------------------
-# Custom G-Code Commands (up to 15 custom G-code)
+# Custom Gcode Commands
 #--------------------------------------------------------------------
+#
 
-#### To enable a custom Command:
-# Remove '#' at the begining custom commands label & gcode.
-
-#### To disable a custom Command:
-# Add '#' at the begining custom commands label & gcode.
-
-# if the values are left blank then default name and G-code will be used
-
-# Options: [Label maximum length: 24 characters, G-code Maximum length 70 characters]
-
+#### Custom Gcode Commands
+# Up to 15 custom gcode commands that will be available in the Custom menu
+#
+# To enable a custom command, remove '#' at the begining of custom commands label & gcode.
+# To disable a custom command, add '#' at the begining of custom commands label & gcode.
+#
+# Note: If the values are left blank then default name and gcode will be used
+#
+# Value range: [label: max 24 characters, gcode: max 70 characters]
+#
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
@@ -430,30 +608,44 @@ custom_gcode_7:M502\n
 #custom_label_15:custom15
 #custom_gcode_15:M105\n
 
+
 #--------------------------------------------------------------------
-# Start, End & Cancel G-codes
+# Start, End & Cancel Gcode Commands
 #--------------------------------------------------------------------
+#
 
 #### Default Start Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 start_gcode_enabled:0
 
 #### Default End Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 end_gcode_enabled:0
 
 #### Default Cancel Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 cancel_gcode_enabled:0
 
-#### Start G-code - run this G-code before starting print
-# maximum length 75 characters
+#### Start Gcode
+# Run this gcode before starting print
+#
+# Value range: [max 75 characters]
+#
 start_gcode:G28 XY R20\n
 
-#### End G-code - run this G-code after finishing print
-# maximum length 75 characters
+#### End Gcode
+# Run this gcode after finishing print
+#
+# Value range: [max 75 characters]
+#
 end_gcode:M104 S0\nM140 S0\nM18\n
 
-#### Cancel G-code - run this G-code after canceling print
-# maximum length 75 characters
+#### Cancel Gcode
+# Run this gcode after canceling print
+#
+# Value range: [max 75 characters]
+#
 cancel_gcode:M104 S0\nM140 S0\nG28 XY R10\n

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -294,7 +294,7 @@ min_temp:180
 fan_max:F0:255 F1:255 F2:255 F3:255 F4:255 F5:255  CtL:255 CtI:255
 
 #### Machine Size / Build Area
-# The TFT will auto-detect the machine size in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
+# The TFT will auto-detect the machine size (min and max) in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
 # in Configuration_adv.h in Marlin firmware)
 #
 # Format: [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
@@ -374,6 +374,11 @@ long_filename_support:2
 fan_speed_percent:1
 
 #### Pause Settings
+# Pause retract distance
+# Pause XY position
+# Pause Z raise
+# Pause feed rate
+#
 # Format: [pause_retract: R<retract length> P<Resume Purge length>]
 #         [pause_pos: X<position in mm> Y<position in mm>]
 #         [pause_z_raise: Z<distance in mm>]
@@ -389,6 +394,11 @@ pause_z_raise:10
 pause_feedrate:X6000 Y6000 Z6000 E600
 
 #### Manual Level Points Edge Distance
+# Leveling edge distance
+# Leveling Z position
+# Leveling Z raise
+# Leveling feed rate
+#
 # Format: [level_edge_distance: <distance from edge in mm>]
 #         [level_z_pos: Z<position in mm>]
 #         [level_z_raise: Z<distance in mm>]

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -1,282 +1,413 @@
-#### Default Config file for BigTreeTech TFT Controllers
+#--------------------------------------------------------------------
+#
+# DEFAULT CONFIG FILE FOR BigTreeTech TFT CONTROLLERS
+#
+#--------------------------------------------------------------------
+
+
+#--------------------------------------------------------------------
+# Supported TFT Variants
+#--------------------------------------------------------------------
 #
 # BIGTREE_TFT35_V1_1 / BIGTREE_TFT35_V1_2    / BIGTREE_TFT35_V2_0
 # BIGTREE_TFT35_V3_0 / BIGTREE_TFT35_E3_V3_0 / BIGTREE_TFT28_V1_0
 # BIGTREE_TFT28_V3_0 / BIGTREE_TFT24_V1_1    / MKS_32_V1_4
 # MKS_28_V1_0
 #
-# Firmware Source: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware
+# Firmware source: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware
+#
 
 
 #--------------------------------------------------------------------
-# Supported Marlin Firmware Version
+# Supported Marlin Firmware Versions
 #--------------------------------------------------------------------
-#  Minimum Marlin Firmware Version: 2.0.5.4
-#  Distribution date: 2020-05-12
-#  Source: https://github.com/MarlinFirmware/Marlin/releases
+#
+# Minimum Marlin firmware version: 2.0.5.4
+# Distribution date: 2020-05-12
+# Firmware source: https://github.com/MarlinFirmware/Marlin/releases
+#
+# IMPORTANT NOTE:
+#   Ensure that the following options are enabled in Marlin firmware
+#
+# General options:
+#   M115_GEOMETRY_REPORT (in Configuration_adv.h)
+#   M114_DETAIL (in Configuration_adv.h)
+#   REPORT_FAN_CHANGE (in Configuration_adv.h)
+#   EMERGENCY_PARSER (in Configuration_adv.h)
+#   SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
+#   HOST_ACTION_COMMANDS (in Configuration_adv.h)
+#
+# Options to support printing from onboard SD:
+#   SDSUPPORT (in Configuration.h)
+#   AUTO_REPORT_TEMPERATURES (in Configuration_adv.h)
+#   AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
+#   LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
+#   SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
+#
+# Options to support (Un)Load menu:
+#   FILAMENT_LOAD_UNLOAD_GCODES (in Configuration_adv.h)
 #
 
-#  Note: Ensure that following options are enabled in Marlin firmware
-#
-#  M115_GEOMETRY_REPORT (in Configuration_adv.h)
-#  M114_DETAIL  (in Configuration_adv.h)
-#  REPORT_FAN_CHANGE (in Configuration_adv.h)
-#  EMERGENCY_PARSER (in Configuration_adv.h)
-#  SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
-#  HOST_ACTION_COMMANDS  (in Configuration_adv.h)
-#
-# For printing from onboard SD
-#
-#  SDSUPPORT (in Configuration.h)
-#  AUTO_REPORT_TEMPERATURESS (in Configuration_adv.h)
-#  AUTO_REPORT_SD_STATUS (in Configuration_adv.h)
-#  LONG_FILENAME_HOST_SUPPORT (in Configuration_adv.h)
-#  SDCARD_CONNECTION ONBOARD (in Configuration_adv.h)
-# 
 
 #--------------------------------------------------------------------
 # General Settings
 #--------------------------------------------------------------------
+#
 
-#### UNIFIED MENU / CLASSIC MENU
-# Select a UI Menu flavour
+#### Unified Menu / Classic Menu
+# Select a UI menu flavour
+#
 # Options: [Unified Menu: 1, Classic Menu: 0]
+#
 unified_menu:1
 
 #### Baudrate
 # Options: [2400: 0, 9600: 1, 19200: 2, 38400: 3, 57600: 4, 115200: 5, 250000: 6, 500000: 7, 1000000: 8]
+#
 baudrate:5
 
 #### Default Touch Mode Language
 # Select the language to display on the LCD while in Touch Mode.
 # To add/flash a second language copy the required "language_xx.ini" file from "Language Packs" folder
-# to the SD root folder. Then preset the reset button to load/flash the copied language file.
-# Options: [Primary Language(English): 0, secondary language: 1]
+# to the SD root folder. Then preset the reset button to load/flash the copied language file
+#
+# Options: [primary language (english): 0, secondary language: 1]
+#
 language:0
 
-#### Default Touch Mode Color Options
+#### Default Touch Mode Colors
 # Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #           ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
-# Or set the color(RGB888 format) hex value directly(start with “0x”).
+#
+# Or set the color (RGB888 format) hex value directly (start with “0x”).
 # Such as: 0xFF0000 : Red, 0x00FF00 : Green, 0x0000FF : Blue
+#
+
 # Title background color
+#
 title_back_color:1
 
 # Background color
+#
 background_color:1
 
 # Font foreground color
+#
 font_color:0
 
-# Reminder font color, such as: "No print attached", "Busy processing", etc.
+# Reminder font color, such as: "No print attached", "Busy processing", etc
+#
 reminder_color:2
 
 # Volume status/reminder font color, such as: "Card inserted", "Card removed"
+#
 volume_status_color:5
 
-# Backgroud color for X Y Z position display in Status Screen.
+# Backgroud color for X Y Z position display in Status Screen menu
+#
 status_xyz_bg_color:15
 
-# List View Border Color
+# List View border color
+#
 list_border_color:15
 
 # List View button background color
+#
 list_button_bg_color:15
 
-# Color used by the Mesh Editor for drawing the mesh with the minimun value in the grid
+# Color used by the Mesh Editor menu for drawing the mesh with the minimun value in the grid
+#
 mesh_min_color:7
 
-# Color used by the Mesh Editor for drawing the mesh with the maximum value in the grid
+# Color used by the Mesh Editor menu for drawing the mesh with the maximum value in the grid
+#
 mesh_max_color:2
 
-#### Rotate UI 180 degrees
+#### Rotate UI
+# Rotate UI by 180 degrees
+#
 # Options: [enable: 1, disable: 0]
+#
 rotate_ui:0
 
-#### Show or hide Temperature ACK in Gcode Terminal
-# Options: [Show: 1, Hide: 0]
+#### Temperature ACK
+# Show or hide temperature ACK in Terminal menu
+#
+# Options: [show: 1, hide: 0]
+#
 terminal_ack:0
 
-#### invert X axis button function in Move menu to match move buttons to actual axis
+#### Inverted Axes For Move Menu
+# Invert axis button function in Move menu in order it matches the actual axis
+#
+# Format: [X<option> Y<option> Z<option> E<option>]
+#
 # Options: [enable: 1, disable: 0]
-# Invert Axis format      [ X<option> Y<option> Z<option> E<option>]
+#
 invert_axis:X0 Y0 Z0
 
-#### Persistent temperature info
-# show persistent temperature info on all menu screens
+#### Persistent Temperature Info
+# Show persistent temperature info on all menus
+#
 # Options: [enable: 1, disable: 0]
+#
 persistent_info:0
 
 #### File List Mode
-# show file as list
+# Display files in list mode instead of icon mode
+#
 # Options: [enable: 1, disable: 0]
+#
 files_list_mode:1
 
-#### Notification style for ACK messages
+#### Notification Style For ACK Messages
 # Set the notification style to use for displaying the ACK messages which start with 'echo:'
 #
 # NOTE: The OFF value is applied to any ACK message type (e.g. even to known echo ACK).
-#       It means that any kind of ACK message is silently discard
+#       It means that any kind of ACK message is silently discarded
 #
 # Options: [OFF: 0, POPUP: 1, TOAST: 2]
-#   OFF:   No notification. The message is ignored.
-#   POPUP: Display a popup window for user confirmation.
+#   OFF:   No notification. The message is ignored
+#   POPUP: Display a popup window for user confirmation
 #   TOAST: A non-blocking Toast notification is displayed for few seconds. No user interaction is needed
+#
 ack_notification:1
 
+
 #--------------------------------------------------------------------
-# Marlin Mode Settings (Only for TFT24_V1.1 & TFT28/TFT35/TFT43/TFT50/TFT70_V3.0)
+# Marlin Mode Settings (only for TFT24_V1.1 & TFT28/TFT35/TFT43/TFT50/TFT70_V3.0)
 #--------------------------------------------------------------------
+#
 
 #### Default Mode
-# Options: [0: Marlin Mode, 1: Touch Mode]
+# Options: [Marlin Mode: 0, Touch Mode: 1]
+#
 default_mode:1
 
-#### Keep Serial Always ON
-# Keep UART (Serial communication) alive in Marlin Mode
-# Allow seamless OctoPrint UART connection to the TFT's UART/serial expansion port no matter which mode the TFT is in.
-# Options: [0: Disabled, 1: Enabled]
+#### Serial Always ON
+# Keep UART (serial communication) alive in Marlin Mode.
+# Allows seamless OctoPrint UART connection to the TFT's UART/serial expansion port no matter which mode the TFT is in
+#
+# Options: [enable: 1, disable: 0]
+#
 serial_always_on:0
 
-#### Default Marlin Mode Background & Font Color Options
+#### Default Marlin Mode Background & Font Colors
 # Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #           ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
-# Or set the color(RGB888 format) hex value directly(start with “0x”).
+#
+# Or set the color (RGB888 format) hex value directly (start with “0x”).
 # Such as: 0xFF0000 : Red, 0x00FF00 : Green, 0x0000FF : Blue
+#
+
+# Marlin Mode background color
+#
 marlin_bg_color:1
+
+# Marlin Mode font color
+#
 marlin_fn_color:8
 
-#### Marlin Mode show title
+#### Marlin Mode Title Support
+# Show title in Marlin Mode
+#
 # Options: [enable: 1, disable: 0]
+#
 marlin_show_title:1
 
-# Run Marlin Mode in Fullscreen
-# Options: [enable: 1, disable: 0] [Disabled. RECOMMENDED FOR TFT24]
+#### Marlin Mode Fullscreen Support
+# Run Marlin Mode in fullscreen
+#
+# Note: Disable is recommended for TFT24
+#
+# Options: [enable: 1, disable: 0]
+#
 marlin_fullscreen:0
 
-# Select marlin type
+#### Marlin Mode Type
+# Select Marlin Mode type
+#
 # Options: [LCD12864: 1, LCD2004: 0]
+#
 marlin_type:1
 
-#### Text displayed at the top of the TFT in Marlin Mode.
+#### Marlin Mode Title
+# Text displayed at the top of the TFT in Marlin Mode
+#
 marlin_title:LCD12864 Simulator
+
 
 #--------------------------------------------------------------------
 # Printer / Machine Settings
 #--------------------------------------------------------------------
+#
 
 #### Hotend Count
 # Options: [1 to 6]
+#
 hotend_count:1
 
-#### Enable heated Bed
+#### Heated Bed Support
 # Options: [enable: 1, disable: 0]
+#
 heated_bed:1
 
-#### Enable heated chamber
-# The TFT will auto-detect if chamber heating is enabled in marlin firmware.
+#### Heated Chamber Support
+# The TFT will auto-detect if chamber heating is enabled in marlin firmware
+#
 # Options: [enable: 1, disable: 0]
+#
 heated_chamber:0
 
 #### Extruder Count
 # Options: [1 to 6]
+#
 ext_count:1
 
 #### Fan Count
 # Options: [1 to 6]
+#
 fan_count:1
 
 #### Fan Controller Count
 # Options: 0 to 2
+#
 fan_ctrl_count:0
 
 #### Bed / Extruder / Chamber Maximum Temperatures
-# format [max_temp: T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp> BED:<max temp> CHAMBER:<max temp>]
+# Format: [max_temp: T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp> BED:<max temp> CHAMBER:<max temp>]
+#
+# Unit: [°C]
+#
 max_temp:T0:275 T1:275 T2:275 T3:275 T4:275 T5:275 BED:150 CHAMBER:60
 
 #### Cold Extrusion Minimum Temperature
+# Unit: [°C]
+#
 min_temp:180
 
-#### Fan Maximum PWM speed (0 to 255)
-# format [fan_max: F0:<max PWM> F1:<max PWM> F2:<max PWM> F3:<max PWM> F4:<max PWM> F5:<max PWM> CtL:<max PWM> CtI:<max PWM>]
+#### Fan Maximum PWM Speed
+# Format: [fan_max: F0:<max PWM> F1:<max PWM> F2:<max PWM> F3:<max PWM> F4:<max PWM> F5:<max PWM> CtL:<max PWM> CtI:<max PWM>]
+#
+# Value range: [min: 0, max: 255]
+#
 fan_max:F0:255 F1:255 F2:255 F3:255 F4:255 F5:255  CtL:255 CtI:255
 
-#### Machine Size / Build Area (mm)
-# The TFT will auto-detect the machine size in marlin firmware (Requires enabling `M115_GEOMETRY_REPORT`
-# in Configuration_adv.h in Marlin firmware).
-# Options: [X Axis: X, Y Axis: Y, Z Axis: Z]
-# minimum possible value: -2000, maximum possible value: 2000
-# minimum size limit format [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
-# maximum size limit format [size_max: X<maximum distance> Y<maximum distance> Z<maximum distance>]
+#### Machine Size / Build Area
+# The TFT will auto-detect the machine size in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
+# in Configuration_adv.h in Marlin firmware)
+#
+# Format: [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
+#         [size_max: X<maximum distance> Y<maximum distance> Z<maximum distance>]
+#
+# Unit: [mm]
+#
+# Value range: [min: -2000, max: 2000]
+#
+# Options: [X axis: X, Y axis: Y, Z axis: Z]
+#
 size_min:X0 Y0 Z0
 size_max:X235 Y235 Z250
 
-#### default Move Speeds (mm/min)
-# Options: [Slow: S, Normal: N, Fast: F]
-# format   [move_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#### Default Move Speeds
+# Format: [move_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#
+# Unit: [mm/min]
+#
+# Options: [slow: S, normal: N, fast: F]
+#
 move_speed:S1000 N3000 F5000
 
-#### default Extruder Speeds (mm/min)
-# Options: [Slow: S, Normal: N, Fast: F]
-# format   [ext_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#### Default Extruder Speeds
+# Format: [ext_speed: S<feedrate mm/min> N<feedrate mm/min> F<feedrate mm/min>]
+#
+# Unit: [mm/min]
+#
+# Options: [slow: S, normal: N, fast: F]
+#
 ext_speed:S60 N600 F1200
 
 #### Auto Save Load Leveling Data
 # The TFT will auto-detect if Auto Bed Level is available.
 # Enable this will send "M500" after "G29" to store leveling value
 # and send "M420 S1" to enable leveling state after startup
+#
 # Options: [enable: 1, disable: 0]
+#
 auto_load_leveling:1
 
 #### Onboard / Printer SD Card Support
-# On Marlin Firmware, The TFT will auto detect Onboard SD Card
+# On Marlin firmware, the TFT will auto-detect Onboard SD Card.
 # Auto-detect is not available for other firmwares like Smoothieware
+#
 # Options: [enable: 1, disable: 0, auto-detect: 2]
+#
 onboard_sd_support:2
 
-#### M27 / Printing status refresh time (this will be used if SD_AUTOREPORT is not detected by the TFT)
+#### M27 Printing Status Refresh Time
+# M27 printing status refresh time (this will be used if SD_AUTOREPORT is not detected by the TFT)
+#
+# Unit: [seconds]
+#
 M27_refresh_time:3
 
-#### M27 always active - keep polling M27 even if not printing
+#### M27 Always Active
+# Keep polling M27 even if not printing
+#
 # Options: [enable: 1, disable: 0]
+#
 M27_always_active:1
 
 #### Long File Names Support
-# On Marlin Firmware, The TFT will auto-detect Long File Name supported
+# On Marlin firmware, the TFT will auto-detect Long File Name support.
 # Auto-detect is not available for other firmwares like Smoothieware
+#
 # Options: [enable: 1, disable: 0, auto-detect: 2]
+#
 long_filename_support:2
 
-#### Show Fan Speed as Percentage
+#### Fan Speed As Percentage
+# Show fan speed as percentage
+#
 # Options: [enable: 1, disable: 0]
+#
 fan_speed_percent:1
 
 #### Pause Settings
-# position & Lengths in mm, Feedrates in mm/min
-# minimum possible value: 0, maximum possible value: 2000
-# Pause retract distance format [pause_retract: R<retract length> P<Resume Purge length>]
-# Pause XY position format      [pause_pos: X<position in mm> Y<position in mm>]
-# Pause Z raise format          [pause_z_raise: Z<distance in mm>]
-# Pause feed Rate # format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min> E<feedrate mm/min>]
+# Format: [pause_retract: R<retract length> P<Resume Purge length>]
+#         [pause_pos: X<position in mm> Y<position in mm>]
+#         [pause_z_raise: Z<distance in mm>]
+#         [pause_feedrate: X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min> E<feedrate mm/min>]
+#
+# Unit: [position & length: mm, feedrate: mm/min]
+#
+# Value range: [min: 0, max: 2000]
+#
 pause_retract:R15 P16
 pause_pos:X10 Y10
 pause_z_raise:10
 pause_feedrate:X6000 Y6000 Z6000 E600
 
-### Manual Level Points Edge distance (mm)
-# distance in mm, Feedrates in mm/min
-# Leveling Edge distance format  [level_edge_distance: <distance from edge in mm>]
-# Leveling Z Position format     [level_z_pos: Z<position in mm>]
-# Leveling Z raise format        [level_z_raise: Z<distance in mm>]
-# Leveling feed Rate format      [ X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
+#### Manual Level Points Edge Distance
+# Format: [level_edge_distance: <distance from edge in mm>]
+#         [level_z_pos: Z<position in mm>]
+#         [level_z_raise: Z<distance in mm>]
+#         [level_feedrate: X<feedrate mm/min> Y<feedrate mm/min> Z<feedrate mm/min>]
+#
+# Unit: [distance: mm, feedrate: mm/min]
+#
 level_edge_distance:20
 level_z_pos:0.2
 level_z_raise:10
 level_feedrate:X6000 Y6000 Z6000
 
-#### Preheat Temperature
-# Maximum Filament name length 7 characters
-# format [T<hotend temp> B<bed temp>]
+#### Preheat Temperatures
+# Format: [T<hotend temp> B<bed temp>]
+#
+# Unit: [°C]
+#
+# Value range: [filament name: max 7 characters]
+#
 preheat_name1:PLA
 preheat_temp1:T200 B60
 
@@ -295,110 +426,157 @@ preheat_temp5:T220 B50
 preheat_name6:NYLON
 preheat_temp6:T250 B90
 
+
 #--------------------------------------------------------------------
-# Power Supply Settings (if connected to TFT Controller)
+# Power Supply Settings (if connected to TFT controller)
 #--------------------------------------------------------------------
+#
 
 #### Default Power Supply Mode
-# Options: [OFF: 0, ON: 1: Auto:2]
+# Options: [OFF: 0, ON: 1, AUTO: 2]
+#
 ps_on:0
 
-#### Power Supply Active HIGH Settings
+#### Power Supply Active HIGH
 # Options: [HIGH: 1, LOW: 0]
+#
 ps_on_active_high:1
 
-#### Maximum hot-end temperature of automatic shut down after printing (only if auto power is enabled)
-# wait for the hot-end temperature to be lower than this value, then turn off the power automatically
+#### Power Supply Auto Shutdown Temperature
+# Maximum hot-end temperature of automatic shut down after printing (only if auto power is enabled).
+# Wait for the hot-end temperature to be lower than this value, then turn off the power automatically
+#
+# Unit: [°C]
+#
 auto_shutdown_temp:50
 
-#--------------------------------------------------------------------
-# Filament Runout Settings (if connected to TFT Controller)
-#--------------------------------------------------------------------
 
-#### Default FIlament Sensor
-# Options: [NONE: 0, Normal: 1, SMART: 2]
+#--------------------------------------------------------------------
+# Filament Runout Settings (if connected to TFT controller)
+#--------------------------------------------------------------------
+#
+
+#### Default Filament Runout Sensor
+# Options: [NONE: 0, NORMAL: 1, SMART: 2]
+#
 fil_runout:0
 
-#### Filament runout inverting - invert the logic of the sensor.
+#### Inverted Filament Runout Logic
+# Invert the logic of the sensor
+#
 # Options: [true: 1, false: 0]
+#
 fil_runout_inverting:1
 
-#### filament noise threshold  - Pause print when filament runout is detected for this time period in (ms).
-# time duration in ms
+#### Filament Noise Threshold
+# Pause print when filament runout is detected for this time period
+#
+# Unit: [ms]
+#
 fil_noise_threshold:100
 
-#### Smart filament runout detection
+#### Smart Filament Runout Detection
 # For use with an encoder disc that toggles runout pin as filament moves
+#
+# Unit: [mm]
+#
 fil_runout_distance:7
 
+
 #--------------------------------------------------------------------
-# Power Loss Recovery & BTT UPS Settings (if connected to TFT Controller)
+# Power Loss Recovery & BTT UPS Settings (if connected to TFT controller)
 #--------------------------------------------------------------------
-#### Power Loss recovery default enable, disable to reduce the loss of SD card or U disk
+#
+
+#### Default Power Loss Recovery Mode
+# Enabled by default.
+# Disable to reduce the loss of SD card or U disk
+#
 # Options: [enable: 1, disable: 0]
+#
 pl_recovery_en:1
 
-#### Home before Power Loss recovery
+#### Power Loss Recovery Homing
+# Home before power loss recovery
+#
 # Options: [enable: 1, disable: 0]
+#
 pl_recovery_home:0
 
-#### Power Loss Z raise (mm)
+#### Power Loss Z Raise
 # Raise Z axis on resume (on power loss with UPS)
+#
+# Unit: [mm]
+#
 pl_z_raise:10
 
-#### Enable BTT UPS
+#### BTT UPS Support
+# Enable BTT UPS
+#
 # Options: [enable: 1, disable: 0]
+#
 btt_mini_ups:0
 
 
 #--------------------------------------------------------------------
-# Other device-specific settings
+# Other Device-Specific Settings
 #--------------------------------------------------------------------
+#
 
 #### Sounds / Buzzer
-# set sounds ON or OFF
+# Set sound ON or OFF
+#
+# Variants:
 #   touch_sound: enable/disable this to control touch feedback sound
 #   toast_sound: enable/disable this to control all toast notification sounds
 #   alert_sound: enable/disable this to control all popup and alert sounds
-#                 like print finish alert, dialog sound etc.
-# NOTE: Error messages from printer will always play the error sound.
+#                like print finish alert, dialog sound etc
+#
+# NOTE: Error messages from printer will always play the error sound
+#
 # Options: [enable: 1, disable: 0]
+#
 touch_sound:1
 toast_sound:1
 alert_sound:1
 
-#### Knob Led Color (only for TFT35 E3.0)
+#### Knob LED Color (only for TFT35 E3.0)
 # Options: [LED_OFF: 0, LED_WHITE: 1, LED_RED: 2, LED_ORANGE: 3, LED_YELLOW: 4, LED_GREEN: 5, LED_BLUE: 6, LED_INDIGO: 7, LED_VIOLET: 8]
+#
 knob_led_color:0
 
-#### Knob idle state
+#### Knob Idle State
 # Options: [true: 1, false: 0]
+#
 knob_led_idle:1
 
-#### Default LCD Brightness levels (only for TFT35v3.0 & TFT28v3.0)
+#### Default LCD Brightness Levels (only for TFT35v3.0 & TFT28v3.0)
 # Options: [(off) 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 (full)]
+#
 lcd_brightness:11
 lcd_idle_brightness:5
 
-#### Default LCD idle time (only for TFT35v3.0 & TFT28v3.0)
-# Options [Off: 0, 5Sec: 1, 10Sec: 2, 30sec: 3, 1min: 4, 2min: 5, 5min: 6, 10min: 7]
+#### Default LCD Idle Time (only for TFT35v3.0 & TFT28v3.0)
+# Options: [Off: 0, 5sec: 1, 10sec: 2, 30sec: 3, 1min: 4, 2min: 5, 5min: 6, 10min: 7]
+#
 lcd_idle_delay:4
 
 
 #--------------------------------------------------------------------
-# Custom G-Code Commands (up to 15 custom G-code)
+# Custom Gcode Commands
 #--------------------------------------------------------------------
+#
 
-#### To enable a custom Command:
-# Remove '#' at the begining custom commands label & gcode.
-
-#### To disable a custom Command:
-# Add '#' at the begining custom commands label & gcode.
-
-# if the values are left blank then default name and G-code will be used
-
-# Options: [Label maximum length: 24 characters, G-code Maximum length 70 characters]
-
+#### Custom Gcode Commands
+# Up to 15 custom gcode commands that will be available in the Custom menu
+#
+# To enable a custom command, remove '#' at the begining of custom commands label & gcode.
+# To disable a custom command, add '#' at the begining of custom commands label & gcode.
+#
+# Note: If the values are left blank then default name and gcode will be used
+#
+# Value range: [label: max 24 characters, gcode: max 70 characters]
+#
 custom_label_1:Disable steppers
 custom_gcode_1:M84\n
 custom_label_2:Init sd card
@@ -430,30 +608,44 @@ custom_gcode_7:M502\n
 #custom_label_15:custom15
 #custom_gcode_15:M105\n
 
+
 #--------------------------------------------------------------------
-# Start, End & Cancel G-codes
+# Start, End & Cancel Gcode Commands
 #--------------------------------------------------------------------
+#
 
 #### Default Start Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 start_gcode_enabled:0
 
 #### Default End Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 end_gcode_enabled:0
 
 #### Default Cancel Gcode Status
 # Options: [enable: 1, disable: 0]
+#
 cancel_gcode_enabled:0
 
-#### Start G-code - run this G-code before starting print
-# maximum length 75 characters
+#### Start Gcode
+# Run this gcode before starting print
+#
+# Value range: [max 75 characters]
+#
 start_gcode:G28 XY R20\n
 
-#### End G-code - run this G-code after finishing print
-# maximum length 75 characters
+#### End Gcode
+# Run this gcode after finishing print
+#
+# Value range: [max 75 characters]
+#
 end_gcode:M104 S0\nM140 S0\nM18\n
 
-#### Cancel G-code - run this G-code after canceling print
-# maximum length 75 characters
+#### Cancel Gcode
+# Run this gcode after canceling print
+#
+# Value range: [max 75 characters]
+#
 cancel_gcode:M104 S0\nM140 S0\nG28 XY R10\n

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -294,7 +294,7 @@ min_temp:180
 fan_max:F0:255 F1:255 F2:255 F3:255 F4:255 F5:255  CtL:255 CtI:255
 
 #### Machine Size / Build Area
-# The TFT will auto-detect the machine size in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
+# The TFT will auto-detect the machine size (min and max) in Marlin firmware (requires enabling `M115_GEOMETRY_REPORT`
 # in Configuration_adv.h in Marlin firmware)
 #
 # Format: [size_min: X<minimum distance> Y<minimum distance> Z<minimum distance>]
@@ -374,6 +374,11 @@ long_filename_support:2
 fan_speed_percent:1
 
 #### Pause Settings
+# Pause retract distance
+# Pause XY position
+# Pause Z raise
+# Pause feed rate
+#
 # Format: [pause_retract: R<retract length> P<Resume Purge length>]
 #         [pause_pos: X<position in mm> Y<position in mm>]
 #         [pause_z_raise: Z<distance in mm>]
@@ -389,6 +394,11 @@ pause_z_raise:10
 pause_feedrate:X6000 Y6000 Z6000 E600
 
 #### Manual Level Points Edge Distance
+# Leveling edge distance
+# Leveling Z position
+# Leveling Z raise
+# Leveling feed rate
+#
 # Format: [level_edge_distance: <distance from edge in mm>]
 #         [level_z_pos: Z<position in mm>]
 #         [level_z_raise: Z<distance in mm>]


### PR DESCRIPTION
A general cleanup on config.ini file:
* Title on section part ALWAYS uses capital letters for any word
* Title on paramter part ALWAYS uses capital letters for any word
* Title on paramter part NEVER provides any comment/description
* A parameter comment/description is provided ONLY on paramter body part
* Parameter qualifiers such as:
  * Format
  * Unit
  * Value range
  * Options

  are ALWAYS provided on parameter body part when neeeded (e.g. °C, mm, seconds etc...)

**PR STATE:**
* **FINAL:** Ready to be merged with BTT main branch:

\
\
\
SECTION PART:

\#--------------------------------------------------------------------
\# <TITLE> (e.g. Supported TFT Variants)
\#--------------------------------------------------------------------
\# <comment/description>
\#___________________________________________________________________<- this empty comment line is always present
\
\
\
PARAMETER PART:

\#### <TITLE> (e.g. Unified Menu / Classic Menu) 
\# <comment/description>
\#
\# Format: [...]
\#
\# Unit: [...]
\#
\# Value range: [...]
\#
\# Options: [....]
\#___________________________________________________________________<- this empty comment line is always present
