### PR TITLE
Compatible with RepRapFirmware

### DIFF
--- a/TFT/src/User/API/ProbeHeightControl.c
+++ b/TFT/src/User/API/ProbeHeightControl.c
@@ -14,6 +14,12 @@ void probeHeightEnable(void)
 
   if (curSoftwareEndstops)                                 // if software endstops is enabled, disable it temporary
     mustStoreCmd("M211 S0\n");                             // disable software endstops to move nozzle minus Zero (Z0) if necessary
+#ifdef  RepRapFirmware
+  if(infoMachineSettings.isMarlinFirmware == 0)
+  {
+    mustStoreCmd("M564 S0 H0\n");
+  }
+#endif
 }
 
 /* Disable probe height
@@ -23,6 +29,12 @@ void probeHeightDisable(void)
 {
   if (curSoftwareEndstops)                                 // if software endstops was originally enabled, enable it again
     mustStoreCmd("M211 S1\n");                             // enable software endstops
+  #ifdef RepRapFirmware
+  if(infoMachineSettings.isMarlinFirmware == 0)
+  {
+    mustStoreCmd("M564 S1 H1\n");
+  }
+  #endif
 }
 
 /* Start probe height */

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -63,7 +63,7 @@ void loopSpeed(void)
       if (send_waiting[i] == false)
       {
         send_waiting[i] = true;
-        send_waiting[i] = storeCmd("%s S%d\n", speedCmd[i], percent[i]);
+        send_waiting[i] = storeCmd("%s S%d D%d\n",speedCmd[i], percent[i], heatGetCurrentTool());
       }
       if (send_waiting[i] == true)
         curPercent[i] = percent[i];
@@ -76,7 +76,8 @@ void speedQuery(void)
 {
   if (infoHost.connected && !infoHost.wait && !queryWait)
   {
-    storeCmd("M220\nM221\n");
+    storeCmd("M220\n");
+    storeCmd("M221 D%d\n",heatGetCurrentTool());
     queryWait = true;
   }
 }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -399,7 +399,8 @@ void sendQueueCmd(void)
         case 29: //M29
           if (!fromTFT)
           {
-            storeCmd("M105\nM114\nM220\nM221\n");
+            mustStoreScript("M105\nM114\nM220\n");
+            storeCmd("M221 D%d\n",heatGetCurrentTool());
             ispolling = true;
           }
             break;

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -6,6 +6,11 @@
 //===========================================================================
 
 /**
+ * To work with RepRapFirmware, Add M575 P1 S2 B115200 to the end of config.g file in sd card
+*/
+#define RepRapFirmware
+
+/**
  * Default Mode
  *
  * Mode switching is still possible by holding down the encorder for two seconds.

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -49,7 +49,8 @@ void menuSpeed(void)
 
   percentageItems.items[KEY_ICON_5] = itemPercent[percentSteps_index];
 
-  storeCmd("M220\nM221\n");
+  storeCmd("M220\n");
+  storeCmd("M221 D%d\n",heatGetCurrentTool());
   KEY_VALUES key_num;
 
   u16 now = speedGetPercent(itemPercentType_index);


### PR DESCRIPTION
### Requirements

Need to add M575 P1 S2 B115200 in the config.g of the sd card of the duet motherboard.  

### Description

ReprapFirmware Versions: 3.1.1  
This is achieved by enabling the Marlin compatibility mode of the ReprapFirmware.   
Realizes function:  
TFT printing,  
Control of extrusion and bed temperature,  
CNC fan,   
Speed and flow control etc.  
Which can completely replace Panel Due.  


### Related Issues

Due to the lack of \n when the Reprapfirmware responds to M20, it cannot read the onboard sd card normally.  
Some advanced settings of marlin different from reprap are not available. 
