### PR TITLE
add M73 support [WIP]

### DIFF
--- a/Copy to SD Card root directory to update/Language Packs/language_ru.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_ru.ini
@@ -289,3 +289,4 @@ label_print_summary:Время печати: %02u:%02u:%02u\nПотрачено 
 label_print_complete:Печать окончена
 label_ext_templow:Температура сопла ниже\nминимальной (%d℃).
 label_cold_ext:Экструзия холодным\nсоплом запрещена
+

--- a/Copy to SD Card root directory to update/Language Packs/language_uk.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_uk.ini
@@ -288,5 +288,5 @@ label_print_summary_popup:Екран підсумування друку
 label_print_summary:Час друку: %02u:%02u:%02u\nВикористано філаменту: %3.2f метрів
 label_print_complete:Друк завершено.
 label_ext_templow:Температура хотенду нижче\nмінімальної температури (%d℃).
-label_cold_ext:Убережено від холодної екструзії
+label_cold_ext:Убережено від холодної екструзії 
 

--- a/Printing.c
+++ b/Printing.c
@@ -1,0 +1,487 @@
+#include "includes.h"
+#include "Printing.h"
+
+
+PRINTING infoPrinting;
+
+static bool update_waiting = false;
+
+static float filament_used;
+static float last_E_pos;
+
+void resetFilamentUsed(void)
+{
+  filament_used = 0;
+  last_E_pos = ((infoFile.source == BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
+}
+
+void updateFilamentUsed(void)
+{
+  float E_pos = ((infoFile.source == BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
+  if ((E_pos + 20) < last_E_pos) //Check whether E position reset. If retract more than 20mm, false filament used values would be calculated.
+  {
+    filament_used = filament_used + E_pos;
+    last_E_pos = E_pos;
+  } else if (E_pos > last_E_pos)
+  {
+    filament_used = filament_used + (E_pos - last_E_pos);
+    last_E_pos = E_pos;
+  }
+}
+
+//
+bool isPrinting(void)
+{
+  return infoPrinting.printing;
+}
+
+//
+bool isPause(void)
+{
+  return infoPrinting.pause;
+}
+
+bool isM0_Pause(void)
+{
+  return infoPrinting.m0_pause;
+}
+
+//
+void setPrintingTime(uint32_t RTtime)
+{
+  if(RTtime%1000 == 0)
+  {
+    if(isPrinting() && !isPause())
+    {
+      infoPrinting.time++;
+      if (infoPrinting.remaining_time > 0)
+      {
+        infoPrinting.remaining_time--;
+      }
+    }
+  }
+}
+
+//
+uint32_t getPrintSize(void)
+{
+  return infoPrinting.size;
+}
+
+//
+void setPrintSize(uint32_t size)
+{
+  infoPrinting.size = size;
+}
+
+//
+uint32_t getPrintCur(void)
+{
+  return infoPrinting.cur;
+}
+
+//
+void setPrintCur(uint32_t cur)
+{
+  infoPrinting.cur = cur;
+}
+
+bool getPrintRunout(void)
+{
+  return infoPrinting.runout;
+}
+
+void setPrintRunout(bool runout)
+{
+  infoPrinting.runout = runout;
+}
+
+void setPrintModelIcon(bool exist)
+{
+  infoPrinting.model_icon = exist;
+}
+
+bool getPrintModelIcon(void)
+{
+  return infoPrinting.model_icon;
+}
+
+uint8_t getPrintProgress(void)
+{
+  return infoPrinting.progress;
+}
+
+uint32_t getPrintTime(void)
+{
+  return infoPrinting.time;
+}
+
+void printSetUpdateWaiting(bool isWaiting)
+{
+  update_waiting = isWaiting;
+}
+
+//only return gcode file name except path
+//for example:"SD:/test/123.gcode"
+//only return "123.gcode"
+uint8_t *getCurGcodeName(char *path)
+{
+  int i=strlen(path);
+  for(; path[i]!='/'&& i>0; i--)
+  {}
+  return (u8* )(&path[i+1]);
+}
+
+//send print codes [0: start gcode, 1: end gcode 2: cancel gcode]
+void sendPrintCodes(uint8_t index)
+{
+  PRINT_GCODES printcodes;
+  W25Qxx_ReadBuffer((uint8_t*)&printcodes,PRINT_GCODES_ADDR,sizeof(PRINT_GCODES));
+  switch (index)
+  {
+  case 0:
+    mustStoreScript(printcodes.start_gcode);
+    break;
+  case 1:
+    mustStoreScript(printcodes.end_gcode);
+    break;
+  case 2:
+    mustStoreScript(printcodes.cancel_gcode);
+    break;
+
+  default:
+    break;
+  }
+}
+
+static inline void setM0Pause(bool m0_pause)
+{
+  infoPrinting.m0_pause = m0_pause;
+}
+
+bool setPrintPause(bool is_pause, bool is_m0pause)
+{
+  static bool pauseLock = false;
+  if(pauseLock)                      return false;
+  if(!isPrinting())                  return false;
+  if(infoPrinting.pause == is_pause) return false;
+
+  pauseLock = true;
+  switch (infoFile.source)
+  {
+    case BOARD_SD:
+      infoPrinting.pause = is_pause;
+      if (is_pause){
+        request_M25();
+      } else {
+        request_M24(0);
+      }
+      break;
+
+    case TFT_UDISK:
+    case TFT_SD:
+      infoPrinting.pause = is_pause;
+      if(infoPrinting.pause == true && is_m0pause == false){
+      while (infoCmd.count != 0) {loopProcess();}
+      }
+
+      bool isCoorRelative = coorGetRelative();
+      bool isExtrudeRelative = eGetRelative();
+      static COORDINATE tmp;
+
+      if(infoPrinting.pause)
+      {
+        //restore status before pause
+        //if pause was triggered through M0/M1 then break
+      if(is_m0pause == true) {
+        setM0Pause(is_m0pause);
+        popupReminder(DIALOG_TYPE_ALERT, LABEL_PAUSE, LABEL_PAUSE);
+        break;
+        }
+
+        coordinateGetAll(&tmp);
+        if (isCoorRelative == true)     mustStoreCmd("G90\n");
+        if (isExtrudeRelative == true)  mustStoreCmd("M82\n");
+
+        if (heatGetCurrentTemp(heatGetCurrentHotend()) > infoSettings.min_ext_temp)
+        {
+          mustStoreCmd("G1 E%.5f F%d\n", tmp.axis[E_AXIS] - infoSettings.pause_retract_len, infoSettings.pause_feedrate[E_AXIS]);
+        }
+        if (coordinateIsKnown())
+        {
+          mustStoreCmd("G1 Z%.3f F%d\n", tmp.axis[Z_AXIS] + infoSettings.pause_z_raise, infoSettings.pause_feedrate[Z_AXIS]);
+          mustStoreCmd("G1 X%.3f Y%.3f F%d\n", infoSettings.pause_pos[X_AXIS], infoSettings.pause_pos[Y_AXIS], infoSettings.pause_feedrate[X_AXIS]);
+        }
+
+        if (isCoorRelative == true)     mustStoreCmd("G91\n");
+        if (isExtrudeRelative == true)  mustStoreCmd("M83\n");
+      }
+      else
+      {
+        if(isM0_Pause() == true)
+        {
+          setM0Pause(is_m0pause);
+          breakAndContinue();
+          break;
+        }
+        if (isCoorRelative == true)     mustStoreCmd("G90\n");
+        if (isExtrudeRelative == true)  mustStoreCmd("M82\n");
+
+        if (coordinateIsKnown())
+        {
+          mustStoreCmd("G1 X%.3f Y%.3f F%d\n", tmp.axis[X_AXIS], tmp.axis[Y_AXIS], infoSettings.pause_feedrate[X_AXIS]);
+          mustStoreCmd("G1 Z%.3f F%d\n", tmp.axis[Z_AXIS], infoSettings.pause_feedrate[Z_AXIS]);
+        }
+        if(heatGetCurrentTemp(heatGetCurrentHotend()) > infoSettings.min_ext_temp)
+        {
+          mustStoreCmd("G1 E%.5f F%d\n", tmp.axis[E_AXIS] - infoSettings.pause_retract_len + infoSettings.resume_purge_len, infoSettings.pause_feedrate[E_AXIS]);
+        }
+        mustStoreCmd("G92 E%.5f\n", tmp.axis[E_AXIS]);
+        mustStoreCmd("G1 F%d\n", tmp.feedrate);
+
+        if (isCoorRelative == true)     mustStoreCmd("G91\n");
+        if (isExtrudeRelative == true)  mustStoreCmd("M83\n");
+      }
+      break;
+  }
+  pauseLock = false;
+  return true;
+}
+
+
+void exitPrinting(void)
+{
+  memset(&infoPrinting, 0, sizeof(PRINTING));
+  ExitDir();
+}
+
+void endPrinting(void)
+{
+  switch (infoFile.source)
+  {
+    case BOARD_SD:
+      request_M27(0);
+      break;
+
+    case TFT_UDISK:
+    case TFT_SD:
+      f_close(&infoPrinting.file);
+      break;
+  }
+  infoPrinting.printing = infoPrinting.pause = false;
+  powerFailedClose();
+  powerFailedDelete();
+  if((infoFile.source != BOARD_SD) && (infoSettings.send_end_gcode == 1))
+  {
+    sendPrintCodes(1);
+  }
+  if (infoSettings.print_summary)
+  {
+    infoMenu.cur = 0;
+    char tempstr[140];
+    u8 hour = infoPrinting.time / 3600;
+    u8 min = infoPrinting.time % 3600 / 60;
+    u8 sec = infoPrinting.time % 60;
+    sprintf(tempstr, (char *)textSelect(LABEL_PRINT_SUMMARY), hour, min, sec, filament_used / 1000);
+    resetFilamentUsed();
+    popupReminder(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, (u8 *)tempstr);
+  }
+}
+
+void printingFinished(void)
+{
+  BUZZER_PLAY(sound_success);
+  endPrinting();
+  if(infoSettings.auto_off) // Auto shut down after printing
+  {
+    startShutdown();
+  }
+}
+
+void abortPrinting(void)
+{
+  switch (infoFile.source)
+  {
+    case BOARD_SD:
+      infoHost.printing = false;
+      breakAndContinue(); //Several M108 is sent to Marlin because consecutive blocking oprations such as heat bed, heat extruder may defer processing of M524
+      breakAndContinue();
+      breakAndContinue();
+      breakAndContinue();
+      request_M524();
+      break;
+
+    case TFT_UDISK:
+    case TFT_SD:
+      clearCmdQueue();
+      if (infoSettings.send_cancel_gcode == 1)
+        sendPrintCodes(2);
+      break;
+  }
+  heatClearIsWaiting();
+
+  endPrinting();
+  exitPrinting();
+}
+
+// Shut down menu, when the hotend temperature is higher than "AUTO_SHUT_DOWN_MAXTEMP"
+// wait for cool down, in the meantime, you can shut down by force
+void shutdown(void)
+{
+  for(u8 i = 0; i < infoSettings.fan_count; i++)
+  {
+    if(fanIsType(i, FAN_TYPE_F)) mustStoreCmd("%s S0\n", fanCmd[i]);
+  }
+  mustStoreCmd("M81\n");
+  popupReminder(DIALOG_TYPE_INFO, LABEL_SHUT_DOWN, LABEL_SHUTTING_DOWN);
+}
+
+void shutdownLoop(void)
+{
+  bool tempIsLower = true;
+  for (uint8_t i = NOZZLE0; i < infoSettings.hotend_count; i++)
+  {
+    if (heatGetCurrentTemp(i) >= AUTO_SHUT_DOWN_MAXTEMP)
+      tempIsLower = false;
+  }
+  if (tempIsLower)
+  {
+   shutdown();
+  }
+}
+
+void startShutdown(void)
+{
+  char tempstr[75];
+  labelChar(tempbody, LABEL_WAIT_TEMP_SHUT_DOWN);
+  sprintf(tempstr, tempbody, infoSettings.auto_off_temp);
+
+  for(u8 i = 0; i < infoSettings.fan_count; i++)
+  {
+    if(fanIsType(i,FAN_TYPE_F)) mustStoreCmd("%s S255\n", fanCmd[i]);
+  }
+  setDialogText(LABEL_SHUT_DOWN, (u8 *)tempstr, LABEL_FORCE_SHUT_DOWN, LABEL_CANCEL);
+  showDialog(DIALOG_TYPE_INFO, shutdown, NULL, shutdownLoop);
+}
+
+
+// get gcode command from sd card
+void getGcodeFromFile(void)
+{
+  bool    sd_comment_mode = false;
+  bool    sd_comment_space = true;
+  char    sd_char;
+  u8      sd_count = 0;
+  UINT    br = 0;
+
+  if(isPrinting()==false || infoFile.source == BOARD_SD)  return;
+
+  powerFailedCache(infoPrinting.file.fptr);
+
+  if(heatHasWaiting() || infoCmd.count || infoPrinting.pause )  return;
+
+  if(moveCacheToCmd() == true) return;
+
+  for(;infoPrinting.cur < infoPrinting.size;)
+  {
+    if(f_read(&infoPrinting.file, &sd_char, 1, &br)!=FR_OK) break;
+
+    infoPrinting.cur++;
+
+    //Gcode
+    if (sd_char == '\n' )         //'\n' is end flag for per command
+    {
+      sd_comment_mode = false;   //for new command
+      sd_comment_space= true;
+      if(sd_count!=0)
+      {
+        infoCmd.queue[infoCmd.index_w].gcode[sd_count++] = '\n';
+        infoCmd.queue[infoCmd.index_w].gcode[sd_count] = 0; //terminate string
+        infoCmd.queue[infoCmd.index_w].src = SERIAL_PORT;
+        sd_count = 0; //clear buffer
+        infoCmd.index_w = (infoCmd.index_w + 1) % CMD_MAX_LIST;
+        infoCmd.count++;
+        break;
+      }
+    }
+    else if (sd_count >= CMD_MAX_CHAR - 2) {  }   //when the command length beyond the maximum, ignore the following bytes
+    else
+    {
+      if (sd_char == ';')             //';' is comment out flag
+        sd_comment_mode = true;
+      else
+      {
+        if(sd_comment_space && (sd_char== 'G'||sd_char == 'M'||sd_char == 'T'))  //ignore ' ' space bytes
+          sd_comment_space = false;
+        if (!sd_comment_mode && !sd_comment_space && sd_char != '\r')  //normal gcode
+          infoCmd.queue[infoCmd.index_w].gcode[sd_count++] = sd_char;
+      }
+    }
+  }
+
+  if((infoPrinting.cur>=infoPrinting.size) && isPrinting())  // end of .gcode file
+  {
+    printingFinished();
+  }
+}
+
+void breakAndContinue(void)
+{
+   Serial_Puts(SERIAL_PORT, "M108\n");
+}
+
+void resumeAndPurge(void)
+{
+   Serial_Puts(SERIAL_PORT, "M876 S0\n");
+}
+
+void resumeAndContinue(void)
+{
+   Serial_Puts(SERIAL_PORT, "M876 S1\n");
+}
+
+bool hasPrintingMenu(void)
+{
+  for (uint8_t i = 0; i <= infoMenu.cur; i++) {
+    if (infoMenu.menu[i] == menuPrinting) return true;
+  }
+  return false;
+}
+
+void loopCheckPrinting(void)
+{
+  #if defined(ST7920_SPI) || defined(LCD2004_simulator)
+    if(infoMenu.menu[infoMenu.cur] == menuMarlinMode) return;
+  #endif
+
+  if (infoHost.printing && !infoPrinting.printing)
+  {
+    infoPrinting.printing = true;
+    if (!hasPrintingMenu())
+    {
+      infoMenu.menu[++infoMenu.cur] = menuPrinting;
+    }
+  }
+
+  if (!infoPrinting.printing && (infoMenu.menu[infoMenu.cur] == menuPrinting) && infoSettings.print_summary)
+  {
+    infoMenu.cur = 0;
+  }
+
+  if (infoFile.source != BOARD_SD) return;
+  if (infoMachineSettings.autoReportSDStatus == ENABLED) return;
+  if (!infoSettings.m27_active && !infoPrinting.printing) return;
+
+  static uint32_t  nextTime=0;
+  uint32_t update_time = infoSettings.m27_refresh_time * 1000;
+  do
+  {  /* WAIT FOR M27  */
+    if(update_waiting == true) {nextTime = OS_GetTimeMs() + update_time; break;}
+    if(OS_GetTimeMs() < nextTime) break;
+
+    if(storeCmd("M27\n") == false) break;
+
+    nextTime = OS_GetTimeMs() + update_time;
+    update_waiting = true;
+  }while(0);
+}

--- a/Printing.h
+++ b/Printing.h
@@ -1,0 +1,95 @@
+#ifndef _PRINTING_H_
+#define _PRINTING_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include "variants.h"
+#include "ff.h"
+
+
+#ifndef M27_WATCH_OTHER_SOURCES
+#define M27_WATCH_OTHER_SOURCES    false
+#endif
+
+#ifndef M27_REFRESH
+#define M27_REFRESH   3
+#endif
+
+#ifdef RAPID_SERIAL_COMM
+#define rapid_serial_loop()  loopBackEnd()
+#define rapid_serial_comm()  if(isPrinting() == true && infoSettings.serial_alwaysOn != 1){loopBackEnd();}
+#else
+#define rapid_serial_loop()
+#define rapid_serial_comm()
+#endif
+
+
+typedef struct
+{
+  FIL file;
+
+  uint32_t time; // Printed time in sec
+  uint32_t size; // Gcode file total size
+  uint32_t cur;  // Gcode has printed file size
+  uint8_t  progress;
+  uint32_t remaining_time; //current priny remaining time in sec(if set with m73)
+  bool     printing; // 1 means printing, 0 means idle
+  bool     pause;    // 1 means paused
+  bool     m0_pause; // pause triggered through M0/M1 gcode
+  bool     runout;   // 1: runout in printing, 0: idle
+  bool     model_icon; // 1: model preview icon exist, 0: not exist
+  bool     slicer_progress; //0: progress managed by btt, 1: by slicer (autoset if we encounter a M77 command)
+}PRINTING;
+
+extern PRINTING infoPrinting;
+
+bool isPrinting(void);
+bool isPause(void);
+bool isM0_Pause(void);
+void breakAndContinue(void);
+void resumeAndPurge(void);
+void resumeAndContinue(void);
+void setPrintingTime(uint32_t RTtime);
+
+void exitPrinting(void);
+void endPrinting(void);
+void printingFinished(void);
+void abortPrinting(void);
+uint8_t *getCurGcodeName(char *path);
+void sendPrintCodes(uint8_t index);
+
+bool setPrintPause(bool is_pause, bool is_m0pause);
+
+void setPrintSize(uint32_t size);
+void setPrintCur(uint32_t cur);
+uint32_t getPrintSize(void);
+uint32_t getPrintCur(void);
+bool getPrintRunout(void);
+void setPrintRunout(bool runout);
+void setPrintModelIcon(bool exist);
+bool getPrintModelIcon(void);
+
+uint8_t   getPrintProgress(void);
+uint32_t  getPrintTime(void);
+
+void printSetUpdateWaiting(bool isWaiting);
+
+void getGcodeFromFile(void);
+
+void shutdown(void);
+void shutdownLoop(void);
+void startShutdown(void);
+
+void loopCheckPrinting(void);
+
+void resetFilamentUsed(void);
+void updateFilamentUsed(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/PrintingMenu.c
+++ b/PrintingMenu.c
@@ -1,0 +1,455 @@
+#include "Printing.h"
+#include "includes.h"
+
+const GUI_POINT printinfo_points[6] = {
+  {START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0, ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0},
+  {START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1, ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0},
+  {START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2, ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0},
+  {START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0, ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1},
+  {START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1, ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1},
+  {START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2, ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1},
+};
+
+const GUI_RECT printinfo_val_rect[6] = {
+  {START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0 + PICON_VAL_X,              ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0 + PICON_VAL_LG_EX,     ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y + BYTE_HEIGHT},
+
+  {START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1 + PICON_VAL_X,              ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1 + PICON_VAL_LG_EX,     ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y + BYTE_HEIGHT},
+
+  {START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2 + PICON_VAL_X,              ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2 + PICON_VAL_SM_EX,     ICON_START_Y + PICON_HEIGHT*0 + PICON_SPACE_Y*0 + PICON_VAL_Y + BYTE_HEIGHT},
+
+  {START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0 + PICON_VAL_X,              ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*0 + PICON_SPACE_X*0 + PICON_VAL_LG_EX,     ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y + BYTE_HEIGHT},
+
+  {START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1 + PICON_VAL_X,              ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*1 + PICON_SPACE_X*1 + PICON_VAL_LG_EX,     ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y + BYTE_HEIGHT},
+
+  {START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2 + PICON_VAL_X,               ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y,
+        START_X + PICON_LG_WIDTH*2 + PICON_SPACE_X*2 + PICON_VAL_SM_EX,     ICON_START_Y + PICON_HEIGHT*1 + PICON_SPACE_Y*1 + PICON_VAL_Y + BYTE_HEIGHT},
+};
+
+static uint32_t nextToggleTime = 0;
+static uint32_t nextDrawTime = 0;
+const char *const Speed_ID[2] = {"Speed","Flow"};
+
+#define TOGGLE_TIME 2000; // 1 seconds is 1000
+#define DRAW_TIME 500; // 1 seconds is 1000
+
+#define LAYER_TITLE "Layer"
+#define EXT_ICON_POS  0
+#define BED_ICON_POS  1
+#define FAN_ICON_POS  2
+#define TIM_ICON_POS  3
+#define Z_ICON_POS    4
+#define SPD_ICON_POS  5
+
+const ITEM itemIsPause[2] = {
+// icon                       label
+  {ICON_PAUSE,                LABEL_PAUSE},
+  {ICON_RESUME,               LABEL_RESUME},
+};
+
+const ITEM itemIsPrinting[2] = {
+// icon                       label
+  {ICON_BACK,                 LABEL_BACK},
+  {ICON_STOP,                 LABEL_STOP},
+};
+
+void menuBeforePrinting(void)
+{
+  //load stat/end/cancel gcodes from spi flash
+  long size = 0;
+  switch (infoFile.source)
+  {
+    case BOARD_SD: // GCode from file on ONBOARD SD
+      size = request_M23(infoFile.title+5);
+
+      //  if( powerFailedCreate(infoFile.title)==false)
+      //  {
+      //
+      //  }    // FIXME: Powerfail resume is not yet supported for ONBOARD_SD. Need more work.
+
+      if(size == 0)
+      {
+        ExitDir();
+        infoMenu.cur--;
+        return;
+      }
+
+      infoPrinting.size  = size;
+
+      //    if(powerFailedExist())
+      //    {
+      request_M24(0);
+      //    }
+      //    else
+      //    {
+      //      request_M24(infoBreakPoint.offset);
+      //    }
+
+      if (infoMachineSettings.autoReportSDStatus == 1)
+        request_M27(infoSettings.m27_refresh_time);                //Check if there is a SD or USB print running.
+      else
+        request_M27(0);
+
+      infoHost.printing = true; // Global lock info on printer is busy in printing.
+
+      break;
+
+    case TFT_UDISK:
+    case TFT_SD: // GCode from file on TFT SD
+      if(f_open(&infoPrinting.file,infoFile.title, FA_OPEN_EXISTING | FA_READ) != FR_OK)
+      {
+        ExitDir();
+        infoMenu.cur--;
+        return ;
+      }
+      if( powerFailedCreate(infoFile.title)==false)
+      {
+
+      }
+      powerFailedlSeek(&infoPrinting.file);
+
+      infoPrinting.size  = f_size(&infoPrinting.file);
+      infoPrinting.cur   = infoPrinting.file.fptr;
+      if(infoSettings.send_start_gcode == 1 && infoPrinting.cur == 0){ // PLR continue printing, CAN NOT use start gcode
+        sendPrintCodes(0);
+      }
+      break;
+  }
+  infoPrinting.printing = true;
+  infoPrinting.time = 0;
+  infoPrinting.remaining_time = 0;
+  infoPrinting.slicer_progress = false;
+
+  if (infoSettings.print_summary)
+  {
+    resetFilamentUsed();
+  }
+  infoMenu.menu[infoMenu.cur] = menuPrinting;
+}
+
+static inline void reValueNozzle(int icon_pos)
+{
+  char tempstr[10];
+  sprintf(tempstr, "%d/%d", heatGetCurrentTemp(currentTool), heatGetTargetTemp(currentTool));
+
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_NOZZLE);
+  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (u8* )heatDisplayID[currentTool]);
+  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reValueBed(int icon_pos)
+{
+  char tempstr[10];
+  sprintf(tempstr, "%d/%d", heatGetCurrentTemp(BED), heatGetTargetTemp(BED));
+
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_BED);
+  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (u8* )heatDisplayID[BED]);
+  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reDrawFan(int icon_pos)
+{
+  char tempstr[10];
+  if (infoSettings.fan_percentage == 1)
+    sprintf(tempstr, "%d%%", fanGetCurPercent(currentFan));
+  else
+    sprintf(tempstr, "%d", fanGetCurSpeed(currentFan));
+
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_FAN);
+  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (u8*)fanID[currentFan]);
+  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reDrawSpeed(int icon_pos)
+{
+  char tempstr[10];
+
+  if(currentSpeedID == 0)
+    ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_SPEED);
+  else
+    ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_FLOW);
+
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  sprintf(tempstr, "%d%%", speedGetPercent(currentSpeedID));
+  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (u8 *)Speed_ID[currentSpeedID]);
+  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reDrawTime(int icon_pos)
+{
+  u8 hour,min,sec;
+
+  if (!infoPrinting.slicer_progress || ( infoPrinting.remaining_time == 0 && infoPrinting.progress < 100 ))
+  {
+    hour = infoPrinting.time/3600;
+    min = infoPrinting.time%3600/60;
+    sec = infoPrinting.time%60;
+  }
+  else
+  {
+      hour = infoPrinting.remaining_time/3600;
+      min = infoPrinting.remaining_time%3600/60;
+      sec = infoPrinting.remaining_time%60;
+  }
+
+  GUI_SetNumMode(GUI_NUMMODE_ZERO);
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  char tempstr[10];
+  sprintf(tempstr, "%02u:%02u:%02u",hour,min,sec);
+  ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_TIMER);
+  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+  GUI_SetNumMode(GUI_NUMMODE_SPACE);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reDrawProgress(int icon_pos)
+{
+  char buf[6];
+  sprintf(buf, "%d%%", infoPrinting.progress);
+  GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+  GUI_DispString(printinfo_points[3].x + PICON_TITLE_X, printinfo_points[3].y + PICON_TITLE_Y, (u8 *)buf);
+  GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
+
+static inline void reDrawLayer(int icon_pos)
+{
+  if (OS_GetTimeMs() > nextDrawTime)
+  {
+    char tempstr[10];
+    sprintf(tempstr, "%.2fmm", (infoFile.source == BOARD_SD) ? coordinateGetAxisActual(Z_AXIS) : coordinateGetAxisTarget(Z_AXIS));
+
+    GUI_SetTextMode(GUI_TEXTMODE_TRANS);
+    ICON_ReadDisplay(printinfo_points[icon_pos].x,printinfo_points[icon_pos].y,ICON_PRINTING_ZLAYER);
+    GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (u8* )LAYER_TITLE);
+    GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (u8 *)tempstr);
+    GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+    nextDrawTime = OS_GetTimeMs() + DRAW_TIME;
+  }
+}
+
+static inline void toggleinfo(void)
+{
+  if (OS_GetTimeMs() > nextToggleTime)
+  {
+    if (infoSettings.hotend_count > 1)
+    {
+      currentTool = (currentTool + 1) % infoSettings.hotend_count;
+      rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling
+      reValueNozzle(EXT_ICON_POS);
+    }
+
+    if ((infoSettings.fan_count + infoSettings.fan_ctrl_count) > 1)
+    {
+      currentFan = (currentFan + 1) % (infoSettings.fan_count + infoSettings.fan_ctrl_count);
+      rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling
+      reDrawFan(FAN_ICON_POS);
+    }
+
+    currentSpeedID = (currentSpeedID + 1) % 2;
+    nextToggleTime = OS_GetTimeMs() + TOGGLE_TIME;
+    rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling
+    reDrawSpeed(SPD_ICON_POS);
+    speedQuery();
+    if (infoFile.source == BOARD_SD) coordinateQuery();
+    if (infoSettings.print_summary)
+    {
+      updateFilamentUsed();
+    }
+  }
+}
+
+static inline void printingDrawPage(void)
+{
+  //  Scroll_CreatePara(&titleScroll, infoFile.title,&titleRect);  //
+  reValueNozzle(EXT_ICON_POS);
+  reValueBed(BED_ICON_POS);
+  reDrawFan(FAN_ICON_POS);
+  reDrawTime(TIM_ICON_POS);
+  reDrawProgress(TIM_ICON_POS);
+  reDrawLayer(Z_ICON_POS);
+  reDrawSpeed(SPD_ICON_POS);
+}
+
+
+void stopConfirm(void)
+{
+  abortPrinting();
+  if (!infoSettings.print_summary)
+  {
+    --infoMenu.cur;
+  }
+}
+
+void menuPrinting(void)
+{
+  //1title, ITEM_PER_PAGE item(icon + label)
+  MENUITEMS printingItems = {
+    // title
+    LABEL_BACKGROUND,
+    // icon                         label
+    {{ICON_BACKGROUND,              LABEL_BACKGROUND},
+     {ICON_BACKGROUND,              LABEL_BACKGROUND},
+     {ICON_BACKGROUND,              LABEL_BACKGROUND},
+     {ICON_BACKGROUND,              LABEL_BACKGROUND},
+     {ICON_BABYSTEP,                LABEL_BABYSTEP},
+     {ICON_PAUSE,                   LABEL_PAUSE},
+     {ICON_MORE,                    LABEL_MORE},
+     {ICON_STOP,                    LABEL_STOP},}
+  };
+
+  uint8_t   nowFan[MAX_FAN_COUNT] = {0};
+  uint16_t  curspeed[2] = {0};
+  uint32_t  time = 0;
+  HEATER    nowHeat;
+  float     curLayer = 0;
+  bool      lastPause = isPause();
+  bool      lastPrinting = isPrinting();
+  memset(&nowHeat, 0, sizeof(HEATER));
+
+  printingItems.title.address = getCurGcodeName(infoFile.title);
+  printingItems.items[KEY_ICON_4].icon = (infoFile.source != BOARD_SD && infoPrinting.model_icon) ? ICON_PREVIEW : ICON_BABYSTEP;
+  printingItems.items[KEY_ICON_5] = itemIsPause[isPause()];
+  printingItems.items[KEY_ICON_7] = itemIsPrinting[lastPrinting];
+  menuDrawPage(&printingItems);
+  printingDrawPage();
+
+
+  while(infoMenu.menu[infoMenu.cur] == menuPrinting)
+  {
+//    Scroll_DispString(&titleScroll, LEFT); //Scroll display file name will take too many CPU cycles
+
+    //check nozzle temp change
+    if (nowHeat.T[currentTool].current != heatGetCurrentTemp(currentTool) || nowHeat.T[currentTool].target != heatGetTargetTemp(currentTool))
+    {
+      nowHeat.T[currentTool].current = heatGetCurrentTemp(currentTool);
+      nowHeat.T[currentTool].target = heatGetTargetTemp(currentTool);
+      rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling
+      reValueNozzle(EXT_ICON_POS);
+    }
+
+    //check bed temp change
+    if (nowHeat.T[BED].current != heatGetCurrentTemp(BED) || nowHeat.T[BED].target != heatGetTargetTemp(BED))
+    {
+      nowHeat.T[BED].current = heatGetCurrentTemp(BED);
+      nowHeat.T[BED].target = heatGetTargetTemp(BED);
+      rapid_serial_loop();   //perform backend printing loop before drawing to avoid printer idling
+      reValueBed(BED_ICON_POS);
+    }
+
+    //check Fan speed change
+    if (nowFan[currentFan] != fanGetCurSpeed(currentFan))
+    {
+      nowFan[currentFan] = fanGetCurSpeed(currentFan);
+      rapid_serial_loop();  //perform backend printing loop before drawing to avoid printer idling
+      reDrawFan(FAN_ICON_POS);
+    }
+
+    //check print time change
+    if( infoPrinting.size != 0)
+    {
+      if(time != infoPrinting.time)
+      {
+        if (!infoPrinting.slicer_progress)
+        {
+            infoPrinting.progress = MIN((uint64_t)infoPrinting.cur*100/infoPrinting.size, 100);
+        }
+        time = infoPrinting.time;
+        rapid_serial_loop();
+        reDrawTime(TIM_ICON_POS);
+        reDrawProgress(TIM_ICON_POS);
+      }
+    }
+    else
+    {
+      if(infoPrinting.progress != 100)
+      {
+        infoPrinting.progress = 100;
+        reDrawTime(TIM_ICON_POS);
+        reDrawProgress(TIM_ICON_POS);
+      }
+    }
+
+    //Z_AXIS coordinate
+    if(curLayer != (infoFile.source == BOARD_SD) ? coordinateGetAxisActual(Z_AXIS) : coordinateGetAxisTarget(Z_AXIS))
+    {
+      curLayer = (infoFile.source == BOARD_SD) ? coordinateGetAxisActual(Z_AXIS) : coordinateGetAxisTarget(Z_AXIS);
+      rapid_serial_loop();  //perform backend printing loop before drawing to avoid printer idling
+      reDrawLayer(Z_ICON_POS);
+    }
+
+    //check change in speed or flow
+    if(curspeed[currentSpeedID] != speedGetPercent(currentSpeedID))
+    {
+      curspeed[currentSpeedID] = speedGetPercent(currentSpeedID);
+      rapid_serial_loop();  //perform backend printing loop before drawing to avoid printer idling
+      reDrawSpeed(SPD_ICON_POS);
+    }
+
+    if (lastPause != isPause())
+    {
+      lastPause = isPause();
+      printingItems.items[KEY_ICON_5] = itemIsPause[lastPause];
+      menuDrawItem(&printingItems.items[KEY_ICON_5], KEY_ICON_5);
+    }
+
+    if (lastPrinting != isPrinting())
+    {
+      lastPrinting = isPrinting();
+      printingItems.items[KEY_ICON_7] = itemIsPrinting[lastPrinting];
+      menuDrawItem(&printingItems.items[KEY_ICON_7], KEY_ICON_7);
+    }
+
+    toggleinfo();
+
+    KEY_VALUES key_num = menuKeyGetValue();
+    switch(key_num)
+    {
+      case KEY_ICON_4:
+        infoMenu.menu[++infoMenu.cur] = menuBabystep;
+        break;
+
+      case KEY_ICON_5:
+        setPrintPause(!isPause(), false);
+        break;
+
+      case KEY_ICON_6:
+        infoMenu.menu[++infoMenu.cur] = menuMore;
+        break;
+
+      case KEY_ICON_7:
+        if(isPrinting())
+        {
+          setDialogText(LABEL_WARNING, LABEL_STOP_PRINT, LABEL_CONFIRM, LABEL_CANCEL);
+          showDialog(DIALOG_TYPE_ALERT, stopConfirm, NULL, NULL);
+        }
+        else
+        {
+          exitPrinting();
+          if (infoSettings.print_summary)
+          {
+            infoMenu.cur = 0;
+          }
+          else
+          {
+            --infoMenu.cur;
+          }
+        }
+        break;
+
+      default:
+        break;
+    }
+    loopProcess();
+  }
+}

--- a/interfaceCmd.c
+++ b/interfaceCmd.c
@@ -1,0 +1,955 @@
+#include "interfaceCmd.h"
+#include "includes.h"
+#include "Printing.h"
+
+
+GCODE_QUEUE infoCmd;       //
+GCODE_QUEUE infoCacheCmd;  // Only when heatHasWaiting() is false the cmd in this cache will move to infoCmd queue.
+
+static u8 cmd_index=0;
+
+static bool ispolling = true;
+
+extern PRINTING infoPrinting;
+
+// Is there a code character in the current gcode command.
+static bool cmd_seen(char code)
+{
+  for(cmd_index = 0; infoCmd.queue[infoCmd.index_r].gcode[cmd_index] != 0 && cmd_index < CMD_MAX_CHAR; cmd_index++)
+  {
+    if(infoCmd.queue[infoCmd.index_r].gcode[cmd_index] == code)
+    {
+      cmd_index += 1;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Get the int after 'code', Call after cmd_seen('code').
+static u32 cmd_value(void)
+{
+  return (strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL, 10));
+}
+
+// Get the float after 'code', Call after cmd_seen('code').
+static float cmd_float(void)
+{
+  return (strtod(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL));
+}
+
+#if defined(SERIAL_PORT_2) || defined(BUZZER_PIN)
+//check if 'string' start with 'search'
+bool static startsWith(TCHAR *search, TCHAR *string)
+{
+  return (strstr(string, search) - string == cmd_index) ? true : false;
+}
+#endif
+
+// Common store cmd
+void commonStoreCmd(GCODE_QUEUE *pQueue, const char* format, va_list va)
+{
+  vsnprintf(pQueue->queue[pQueue->index_w].gcode, CMD_MAX_CHAR, format, va);
+
+  pQueue->queue[pQueue->index_w].src = SERIAL_PORT;
+  pQueue->index_w = (pQueue->index_w + 1) % CMD_MAX_LIST;
+  pQueue->count++;
+}
+
+// Store gcode cmd to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar.
+bool storeCmd(const char * format,...)
+{
+  if (strlen(format) == 0) return false;
+
+  GCODE_QUEUE *pQueue = &infoCmd;
+
+  if (pQueue->count >= CMD_MAX_LIST)
+  {
+    reminderMessage(LABEL_BUSY, STATUS_BUSY);
+    return false;
+  }
+
+  va_list va;
+  va_start(va, format);
+  commonStoreCmd(pQueue, format, va);
+  va_end(va);
+
+  return true;
+}
+
+// Store gcode cmd to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar,  waiting for available queue and store the command.
+void mustStoreCmd(const char * format,...)
+{
+  if (strlen(format) == 0) return;
+
+  GCODE_QUEUE *pQueue = &infoCmd;
+
+  if(pQueue->count >= CMD_MAX_LIST) reminderMessage(LABEL_BUSY, STATUS_BUSY);
+
+  while (pQueue->count >= CMD_MAX_LIST)
+  {
+    loopProcess();
+  }
+
+  va_list va;
+  va_start(va, format);
+  commonStoreCmd(pQueue, format, va);
+  va_end(va);
+}
+
+// Store Script cmd to infoCmd queue
+// For example: "M502\nM500\n" will be split into two commands "M502\n", "M500\n"
+void mustStoreScript(const char * format,...)
+{
+  if (strlen(format) == 0) return;
+
+  char script[256];
+  va_list va;
+  va_start(va, format);
+  vsnprintf(script, 256, format, va);
+  va_end(va);
+
+  char *p = script;
+  uint16_t i = 0;
+  char cmd[CMD_MAX_CHAR];
+  for (;;)
+  {
+    char c = *p++;
+    if (!c) return;
+    cmd[i++] = c;
+
+    if (c == '\n')
+    {
+      cmd[i] = 0;
+      mustStoreCmd("%s", cmd);
+      i = 0;
+    }
+  }
+}
+
+// Store from UART cmd(such as: ESP3D, OctoPrint, else TouchScreen) to infoCmd queue, this cmd will be sent by UART in sendQueueCmd(),
+// If the infoCmd queue is full, reminde in title bar.
+bool storeCmdFromUART(uint8_t port, const char * gcode)
+{
+  if (strlen(gcode) == 0) return false;
+  GCODE_QUEUE *pQueue = &infoCmd;
+
+  if (pQueue->count >= CMD_MAX_LIST)
+  {
+    reminderMessage(LABEL_BUSY, STATUS_BUSY);
+    return false;
+  }
+
+  strncpy(pQueue->queue[pQueue->index_w].gcode, gcode, CMD_MAX_CHAR);
+
+  pQueue->queue[pQueue->index_w].src = port;
+  pQueue->index_w = (pQueue->index_w + 1) % CMD_MAX_LIST;
+  pQueue->count++;
+
+  return true;
+}
+
+// Store gcode cmd to infoCacheCmd queue, this cmd will be move to infoCmd in getGcodeFromFile() -> moveCacheToCmd(),
+// this function is only for restore printing status after power failed.
+void mustStoreCacheCmd(const char * format,...)
+{
+  GCODE_QUEUE *pQueue = &infoCacheCmd;
+
+  if(pQueue->count == CMD_MAX_LIST) reminderMessage(LABEL_BUSY, STATUS_BUSY);
+
+  while (pQueue->count >= CMD_MAX_LIST)
+  {
+    loopProcess();
+  }
+
+  va_list va;
+  va_start(va, format);
+  commonStoreCmd(pQueue, format, va);
+  va_end(va);
+}
+
+// Move gcode cmd from infoCacheCmd to infoCmd queue.
+bool moveCacheToCmd(void)
+{
+  if(infoCmd.count >= CMD_MAX_LIST) return false;
+  if(infoCacheCmd.count == 0) return false;
+
+  storeCmd("%s", infoCacheCmd.queue[infoCacheCmd.index_r].gcode);
+  infoCacheCmd.count--;
+  infoCacheCmd.index_r = (infoCacheCmd.index_r + 1) % CMD_MAX_LIST;
+  return true;
+}
+
+// Clear all gcode cmd in infoCmd queue for abort printing.
+void clearCmdQueue(void)
+{
+  infoCmd.count = infoCmd.index_w = infoCmd.index_r =0;
+  infoCacheCmd.count = infoCacheCmd.index_w = infoCacheCmd.index_r = 0;
+  heatSetUpdateWaiting(false);
+}
+
+//remove last line from cmd queue
+void purgeLastCmd(void)
+{
+  infoCmd.count--;
+  infoCmd.index_r = (infoCmd.index_r + 1) % CMD_MAX_LIST;
+}
+
+// Parse and send gcode cmd in infoCmd.
+void sendQueueCmd(void)
+{
+  if(infoHost.wait == true)    return;
+  if(infoCmd.count == 0)       return;
+
+  bool avoid_terminal = false;
+  u16  cmd=0;
+  cmd_index = 0;
+  //check if cmd is from TFT or other host
+  bool fromTFT = (infoCmd.queue[infoCmd.index_r].src == SERIAL_PORT);
+
+  if (!ispolling && !fromTFT)
+  { //ignore any query from TFT
+    purgeLastCmd();
+    return;
+  }
+
+  // Skip line number from stored gcode for internal parsing purpose
+  if (infoCmd.queue[infoCmd.index_r].gcode[0] == 'N')
+  {
+    cmd_index = strcspn(infoCmd.queue[infoCmd.index_r].gcode, " ") + 1;
+  }
+
+  switch(infoCmd.queue[infoCmd.index_r].gcode[cmd_index])
+  {
+    // parse M-codes
+    case 'M':
+      cmd = strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 1], NULL, 10);
+      switch(cmd)
+      {
+        case 0:
+          if (isPrinting()) {
+            setPrintPause(true,true);
+          }
+          break;
+        case 1:
+          if (isPrinting()) {
+            setPrintPause(true,true);
+          }
+          break;
+        case 18: //M18/M84 disable steppers
+        case 84:
+          if(cmd_seen('S') && !cmd_seen('Y') && !cmd_seen('Z') && !cmd_seen('E'))
+          {
+            // Do not mark coordinate as unknown in this case as this is a M18/M84 S<timeout>
+            // command that doesn't disable the motors right away but will set their idling
+            // timeout.
+          }
+          else
+          {
+            // This is something else than an "M18/M84 S<timeout>", this will disable at least one stepper, set coordinate as unknown
+            coordinateSetKnown(false);
+          }
+          break;
+
+#ifdef SERIAL_PORT_2
+        case 20: //M20
+          if (!fromTFT)
+          {
+            if (startsWith("M20 SD:", infoCmd.queue[infoCmd.index_r].gcode) ||startsWith("M20 U:", infoCmd.queue[infoCmd.index_r].gcode))   {
+            if(startsWith("M20 SD:", infoCmd.queue[infoCmd.index_r].gcode)) infoFile.source = TFT_SD;
+            else infoFile.source = TFT_UDISK;
+            strncpy(infoFile.title, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], MAX_PATH_LEN);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < MAX_PATH_LEN && infoFile.title[i] !=0 ; i++)
+              {
+                if ((infoFile.title[i] == '*') || (infoFile.title[i] == '\n') ||(infoFile.title[i] == '\r'))
+                {
+                  infoFile.title[i] = 0;
+                  break;
+                }
+              }
+            Serial_Puts(SERIAL_PORT_2, "Begin file list\n");
+            if (mountFS() == true && scanPrintFiles() == true){
+              for (uint16_t i = 0; i < infoFile.f_num; i++) {
+                Serial_Puts(SERIAL_PORT_2,infoFile.file[i]);
+                Serial_Puts(SERIAL_PORT_2,"\n");
+              }
+              for (uint16_t i = 0; i < infoFile.F_num; i++) {
+                Serial_Puts(SERIAL_PORT_2,"/");
+                Serial_Puts(SERIAL_PORT_2,infoFile.folder[i]);
+                Serial_Puts(SERIAL_PORT_2,"/\n");
+              }
+            }
+            Serial_Puts(SERIAL_PORT_2, "End file list\nok\n");
+            purgeLastCmd();
+            return;
+            }
+          }
+          break;
+
+        case 23: //M23
+          if (!fromTFT)
+          {
+            if (startsWith("M23 SD:", infoCmd.queue[infoCmd.index_r].gcode) || startsWith("M23 U:", infoCmd.queue[infoCmd.index_r].gcode))
+            {
+              if(startsWith("M23 SD:", infoCmd.queue[infoCmd.index_r].gcode))
+                infoFile.source = TFT_SD;
+              else
+                infoFile.source = TFT_UDISK;
+              resetInfoFile();
+              strncpy(infoFile.title, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], MAX_PATH_LEN);
+              // strip out any checksum that might be in the string
+              for (int i = 0; i < MAX_PATH_LEN && infoFile.title[i] !=0 ; i++)
+                {
+                  if ((infoFile.title[i] == '*') || (infoFile.title[i] == '\n') ||(infoFile.title[i] == '\r'))
+                  {
+                    infoFile.title[i] = 0;
+                    break;
+                  }
+                }
+              Serial_Puts(SERIAL_PORT_2, "echo:Now fresh file: ");
+              Serial_Puts(SERIAL_PORT_2, infoFile.title);
+              Serial_Puts(SERIAL_PORT_2, "\n");
+              FIL tmp;
+              if (mountFS() && (f_open(&tmp, infoFile.title, FA_OPEN_EXISTING | FA_READ) == FR_OK) )
+              {
+                char buf[10];
+                sprintf(buf, "%d", f_size(&tmp));
+                Serial_Puts(SERIAL_PORT_2, "File opened: ");
+                Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                Serial_Puts(SERIAL_PORT_2, " Size: ");
+                Serial_Puts(SERIAL_PORT_2, buf);
+                Serial_Puts(SERIAL_PORT_2, "\nFile selected\n");
+                f_close(&tmp);
+              }
+              else
+              {
+                Serial_Puts(SERIAL_PORT_2, "open failed, File: ");
+                Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                Serial_Puts(SERIAL_PORT_2, "\n");
+              }
+              Serial_Puts(SERIAL_PORT_2, "ok\n");
+              purgeLastCmd();
+              return;
+            }
+          }
+          break;
+
+        case 24: //M24
+          if (!fromTFT)
+          {
+            if ((infoFile.source == TFT_UDISK) || (infoFile.source == TFT_SD))
+            {
+              if (isPause())
+              {
+                setPrintPause(false, false);
+              }
+              else {
+                Serial_Puts(SERIAL_PORT_2, "ok\n");
+                purgeLastCmd();
+                infoMenu.cur = 1;
+                menuBeforePrinting();
+              }
+              return;
+            }
+          }
+          break;
+
+        case 25: //M25
+          if (!fromTFT)
+          {
+            if (isPrinting() && !infoHost.printing)
+            {
+              setPrintPause(true, false);
+              Serial_Puts(SERIAL_PORT_2, "ok\n");
+              purgeLastCmd();
+              return;
+            }
+          }
+          break;
+
+        case 27: //M27
+          if (!fromTFT)
+          {
+            if (isPrinting() && !infoHost.printing)
+            {
+              if (cmd_seen('C')){
+                Serial_Puts(SERIAL_PORT_2, "Current file: ");
+                Serial_Puts(SERIAL_PORT_2, infoFile.title);
+                Serial_Puts(SERIAL_PORT_2, ".\n");
+              }
+                char buf[55];
+                sprintf(buf, "%s printing byte %d/%d\n",(infoFile.source==TFT_SD)?"TFT SD":"TFT USB", getPrintCur(),getPrintSize());
+                Serial_Puts(SERIAL_PORT_2, buf);
+                Serial_Puts(SERIAL_PORT_2, "ok\n");
+                purgeLastCmd();
+                return;
+            }
+          }
+          else
+          {
+            printSetUpdateWaiting(false);
+          }
+          break;
+
+        case 28: //M28
+          if (!fromTFT)
+            ispolling = false;
+          break;
+
+        case 29: //M29
+          if (!fromTFT)
+          {
+            storeCmd("M105\nM114\nM220\nM221\n");
+            ispolling = true;
+          }
+            break;
+
+        case 30: //M30
+          if (!fromTFT)
+          {
+            if (startsWith("M30 SD:", infoCmd.queue[infoCmd.index_r].gcode) || startsWith("M30 U:", infoCmd.queue[infoCmd.index_r].gcode))
+            {
+              if(startsWith("M30 SD:", infoCmd.queue[infoCmd.index_r].gcode)) infoFile.source = TFT_SD;
+              else infoFile.source = TFT_UDISK;
+              TCHAR filepath[MAX_PATH_LEN];
+              strncpy(filepath, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], MAX_PATH_LEN);
+              // strip out any checksum that might be in the string
+              for (int i = 0; i < MAX_PATH_LEN && filepath[i] !=0 ; i++)
+                {
+                  if ((filepath[i] == '*') || (filepath[i] == '\n') ||(filepath[i] == '\r'))
+                  {
+                    filepath[i] = 0;
+                    break;
+                  }
+                }
+              if ((mountFS() == true) && (f_unlink (filepath)== FR_OK))
+              {
+                Serial_Puts(SERIAL_PORT_2, "File deleted: ");
+                Serial_Puts(SERIAL_PORT_2, filepath);
+                Serial_Puts(SERIAL_PORT_2, ".\nok\n");
+              }
+              else
+              {
+                Serial_Puts(SERIAL_PORT_2, "Deletion failed, File: ");
+                Serial_Puts(SERIAL_PORT_2, filepath);
+                Serial_Puts(SERIAL_PORT_2, ".\nok\n");
+              }
+
+              purgeLastCmd();
+              return;
+            }
+          }
+          break;
+
+        case 115: //M115 TFT
+          if (!fromTFT && startsWith("M115 TFT", infoCmd.queue[infoCmd.index_r].gcode))
+            {
+              char buf[50];
+              Serial_Puts(SERIAL_PORT_2, "FIRMWARE_NAME: " FIRMWARE_NAME " SOURCE_CODE_URL:https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware\n");
+              sprintf(buf, "Cap:HOTEND_NUM:%d\n", infoSettings.hotend_count);
+              Serial_Puts(SERIAL_PORT_2, buf);
+              sprintf(buf, "Cap:EXTRUDER_NUM:%d\n", infoSettings.ext_count);
+              Serial_Puts(SERIAL_PORT_2, buf);
+              sprintf(buf, "Cap:FAN_NUM:%d\n", infoSettings.fan_count);
+              Serial_Puts(SERIAL_PORT_2, buf);
+              sprintf(buf, "Cap:FAN_CTRL_NUM:%d\n", infoSettings.fan_ctrl_count);
+              Serial_Puts(SERIAL_PORT_2, buf);
+              Serial_Puts(SERIAL_PORT_2, "ok\n");
+              purgeLastCmd();
+              return;
+            }
+          break;
+
+        case 524: //M524
+          if (!fromTFT && isPrinting() && !infoHost.printing)
+            {
+              abortPrinting();
+              Serial_Puts(SERIAL_PORT_2, "ok\n");
+              purgeLastCmd();
+              return;
+            }
+          break;
+#else
+        case 27: //M27
+            printSetUpdateWaiting(false);
+        break;
+#endif
+
+        case 73:
+          if(cmd_seen('P'))
+          {
+            infoPrinting.progress = cmd_float();
+            infoPrinting.slicer_progress = true;
+
+          }
+          if(cmd_seen('R'))
+          {
+            infoPrinting.remaining_time = cmd_float() * 60;
+            infoPrinting.slicer_progress = true;
+
+          }
+          //we must check if marlin accept M73 before forwarding it ,but how?
+          purgeLastCmd();
+          return;
+
+        case 80: //M80
+          #ifdef PS_ON_PIN
+            PS_ON_On();
+          #endif
+          break;
+
+        case 81: //M81
+          #ifdef PS_ON_PIN
+            PS_ON_Off();
+          #endif
+          break;
+
+        case 82: //M82
+          eSetRelative(false);
+          break;
+
+        case 83: //M83
+          eSetRelative(true);
+          break;
+
+        case 92: //M92 Steps per unit
+          if(cmd_seen('X')) setParameter(P_STEPS_PER_MM, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_STEPS_PER_MM, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_STEPS_PER_MM, Z_AXIS, cmd_float());
+          if(cmd_seen('E')) setParameter(P_STEPS_PER_MM, E_AXIS, cmd_float());
+          break;
+
+        case 105: //M105
+          if (fromTFT)
+          {
+            heatSetUpdateWaiting(false);
+            avoid_terminal = !infoSettings.terminalACK;
+          }
+          break;
+
+        case 155: //M155
+          if (fromTFT)
+          {
+            heatSetUpdateWaiting(false);
+            if(cmd_seen('S'))
+            {
+              heatSyncUpdateSeconds(cmd_value());
+            }
+            else if (!cmd_seen('\n'))
+            {
+              char buf[12];
+              sprintf(buf, "S%u\n", heatGetUpdateSeconds());
+              strcat(infoCmd.queue[infoCmd.index_r].gcode, (const char*)buf);
+            }
+          }
+          break;
+
+        case 106: //M106
+        {
+          uint8_t i = cmd_seen('P') ? cmd_value() : 0;
+          if(cmd_seen('S') && fanIsType(i, FAN_TYPE_F) ) {
+            fanSetCurSpeed(i, cmd_value());
+            fanSetSendWaiting(i, false);
+          }
+          else if (!cmd_seen('\n'))
+          {
+            char buf[12];
+            sprintf(buf, "S%u\n", fanGetCurSpeed(i));
+            strcat(infoCmd.queue[infoCmd.index_r].gcode,(const char*)buf);
+          }
+          break;
+        }
+
+        case 107: //M107
+        {
+          uint8_t i = cmd_seen('P') ? cmd_value() : 0;
+          if (fanIsType(i, FAN_TYPE_F)) fanSetCurSpeed(i, 0);
+          break;
+        }
+
+        case 710: //M710 Controller Fan
+        {
+          u8 i = 0;
+          if(cmd_seen('S')) i = fanGetTypID(i,FAN_TYPE_CTRL_S);
+          if(cmd_seen('I')) i = fanGetTypID(i=0,FAN_TYPE_CTRL_I);
+          fanSetCurSpeed(i, cmd_value());
+          fanSetSendWaiting(i, false);
+          break;
+        }
+
+        case 109: //M109
+          if (fromTFT)
+          {
+            infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 3]='4';  // Avoid send M109 to Marlin
+            uint8_t i = cmd_seen('T') ? cmd_value() : heatGetCurrentHotend();
+            if (cmd_seen('R'))
+            {
+              infoCmd.queue[infoCmd.index_r].gcode[cmd_index-1] = 'S';
+              heatSetIsWaiting(i, WAIT_COOLING_HEATING);
+            }
+            else
+            {
+              heatSetIsWaiting(i, WAIT_HEATING);
+            }
+          }
+        // No break here, The data processing of M109 is the same as that of M104 below
+        case 104: //M104
+          if (fromTFT)
+          {
+            uint8_t i = cmd_seen('T') ? cmd_value() : heatGetCurrentHotend();
+            if(cmd_seen('S'))
+            {
+              heatSyncTargetTemp(i, cmd_value());
+            }
+            else if (!cmd_seen('\n'))
+            {
+              char buf[12];
+              sprintf(buf, "S%u\n", heatGetTargetTemp(i));
+              strcat(infoCmd.queue[infoCmd.index_r].gcode,(const char*)buf);
+              heatSetSendWaiting(i, false);
+            }
+          }
+          break;
+
+        case 114: //M114
+          #ifdef FIL_RUNOUT_PIN
+          if (fromTFT)
+            positionSetUpdateWaiting(false);
+          #endif
+          break;
+
+        case 117: //M117
+          {
+            char message[CMD_MAX_CHAR];
+            strncpy(message, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], CMD_MAX_CHAR);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < CMD_MAX_CHAR && message[i] !=0 ; i++)
+            {
+              if (message[i] == '*')
+              {
+                message[i] = 0;
+                break;
+              }
+            }
+            statusScreen_setMsg((u8 *)"M117", (u8 *)&message);
+            if (infoMenu.menu[infoMenu.cur] != menuStatus)
+            {
+              addToast(DIALOG_TYPE_INFO, message);
+            }
+          }
+          break;
+
+        case 190: //M190
+          if (fromTFT)
+          {
+            infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 2]='4';   // Avoid send M190 to Marlin
+            if (cmd_seen('R'))
+            {
+              infoCmd.queue[infoCmd.index_r].gcode[cmd_index-1] = 'S';
+              heatSetIsWaiting(BED, WAIT_COOLING_HEATING);
+            }
+            else
+            {
+              heatSetIsWaiting(BED, WAIT_HEATING);
+            }
+          }
+        // No break here, The data processing of M190 is the same as that of M140 below
+        case 140: //M140
+          if (fromTFT)
+          {
+            if (cmd_seen('S'))
+            {
+              heatSyncTargetTemp(BED, cmd_value());
+            }
+            else if (!cmd_seen('\n'))
+            {
+              char buf[12];
+              sprintf(buf, "S%u\n", heatGetTargetTemp(BED));
+              strcat(infoCmd.queue[infoCmd.index_r].gcode, (const char *)buf);
+              heatSetSendWaiting(BED, false);
+            }
+          }
+          break;
+
+        case 191: //M191
+          if (fromTFT)
+          {
+            infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 2]='4';   // Avoid send M191 to Marlin
+            if (cmd_seen('R'))
+            {
+              infoCmd.queue[infoCmd.index_r].gcode[cmd_index-1] = 'S';
+              heatSetIsWaiting(CHAMBER, WAIT_COOLING_HEATING);
+            }
+            else
+            {
+              heatSetIsWaiting(CHAMBER, WAIT_HEATING);
+            }
+          }
+        // No break here, The data processing of M191 is the same as that of M141 below
+        case 141: //M141
+          if (fromTFT)
+          {
+            if (cmd_seen('S'))
+            {
+              heatSyncTargetTemp(CHAMBER, cmd_value());
+            }
+            else if (!cmd_seen('\n'))
+            {
+              char buf[12];
+              sprintf(buf, "S%u\n", heatGetTargetTemp(CHAMBER));
+              strcat(infoCmd.queue[infoCmd.index_r].gcode, (const char *)buf);
+              heatSetSendWaiting(CHAMBER, false);
+            }
+          }
+          break;
+        case 201: //M201 Maximum Acceleration (units/s2)
+          if(cmd_seen('X')) setParameter(P_MAX_ACCELERATION, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_MAX_ACCELERATION, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_MAX_ACCELERATION, Z_AXIS, cmd_float());
+          if(cmd_seen('E')) setParameter(P_MAX_ACCELERATION, E_AXIS, cmd_float());
+          break;
+        case 203: //M203 Maximum feedrates (units/s)
+          if(cmd_seen('X')) setParameter(P_MAX_FEED_RATE, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_MAX_FEED_RATE, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_MAX_FEED_RATE, Z_AXIS, cmd_float());
+          if(cmd_seen('E')) setParameter(P_MAX_FEED_RATE, E_AXIS, cmd_float());
+          break;
+        case 204: //M204 Acceleration (units/s2)
+          if(cmd_seen('P')) setParameter(P_ACCELERATION, 0, cmd_float());
+          if(cmd_seen('R')) setParameter(P_ACCELERATION, 1, cmd_float());
+          if(cmd_seen('T')) setParameter(P_ACCELERATION, 2, cmd_float());
+          break;
+        case 205: //M205 - Set Advanced Settings
+          if(cmd_seen('X')) setParameter(P_JERK, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_JERK, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_JERK, Z_AXIS, cmd_float());
+          if(cmd_seen('E')) setParameter(P_JERK, E_AXIS, cmd_float());
+          if(cmd_seen('J')) setParameter(P_JUNCTION_DEVIATION, 0, cmd_float());
+          break;
+        case 206: //M206 Home offset
+          if(cmd_seen('X')) setParameter(P_HOME_OFFSET, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_HOME_OFFSET, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_HOME_OFFSET, Z_AXIS, cmd_float());
+          break;
+        case 207: //M207 FW Retract
+          if(cmd_seen('S')) setParameter(P_FWRETRACT, 0, cmd_float());
+          if(cmd_seen('W')) setParameter(P_FWRETRACT, 1, cmd_float());
+          if(cmd_seen('F')) setParameter(P_FWRETRACT, 2, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_FWRETRACT, 3, cmd_float());
+          break;
+        case 208: //M208 FW Retract recover
+          if(cmd_seen('S')) setParameter(P_FWRECOVER, 0, cmd_float());
+          if(cmd_seen('W')) setParameter(P_FWRECOVER, 1, cmd_float());
+          if(cmd_seen('F')) setParameter(P_FWRECOVER, 2, cmd_float());
+          if(cmd_seen('R')) setParameter(P_FWRECOVER, 3, cmd_float());
+          break;
+        case 220: //M220
+          if(cmd_seen('S'))
+            speedSetPercent(0,cmd_value());
+          break;
+        case 221: //M221
+          if(cmd_seen('S'))
+            speedSetPercent(1,cmd_value());
+          break;
+
+        #ifdef BUZZER_PIN
+          case 300: //M300
+            if (cmd_seen('S'))
+            {
+              uint16_t hz = cmd_value();
+              if (cmd_seen('P'))
+              {
+                uint16_t ms = cmd_value();
+                Buzzer_TurnOn(hz, ms);
+                if (!fromTFT && startsWith("M300 TFT", infoCmd.queue[infoCmd.index_r].gcode))
+                {
+                  purgeLastCmd();
+                  return;
+                }
+              }
+            }
+            break;
+        #endif
+        case 355: //M355
+        {
+          if(cmd_seen('S')) {
+            caseLightSetState(cmd_value() > 0);
+            caseLightSendWaiting(false);
+          }
+          if(cmd_seen('P')){
+            caseLightSetBrightness(cmd_value());
+            caseLightSendWaiting(false);
+          }
+
+          break;
+        }
+        case 420: //M420
+          //ABL state will be set through parsACK.c after receiving confirmation message from the printer
+          // to prevent wrong state in case of error.
+          if(cmd_seen('Z')) setParameter(P_ABL_STATE,1,cmd_float());
+        break;
+
+        #ifdef NOZZLE_PAUSE_M600_M601
+          case 600: //M600/M601 pause print
+          case 601:
+            if (isPrinting())
+            {
+              setPrintPause(true, false);
+              // prevent sending M600/M601 to marlin
+              purgeLastCmd();
+              return;
+            }
+            break;
+        #endif
+
+        #ifdef LOAD_UNLOAD_M701_M702
+          case 701:  // M701 Load filament
+          case 702:  // M702 Unload filament
+            infoHost.wait = true;
+            break;
+        #endif
+
+        case 851: //M851 Z probe offset
+          if(cmd_seen('X')) setParameter(P_PROBE_OFFSET, X_AXIS, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_PROBE_OFFSET, Y_AXIS, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_PROBE_OFFSET, Z_AXIS, cmd_float());
+          break;
+        case 900: //M900 Linear advance
+          if (cmd_seen('K')) setParameter(P_LIN_ADV, 0, cmd_float());
+          break;
+        case 906: //M906 Stepper driver current
+          if(cmd_seen('X')) setParameter(P_CURRENT, X_AXIS, cmd_value());
+          if(cmd_seen('Y')) setParameter(P_CURRENT, Y_AXIS, cmd_value());
+          if(cmd_seen('Z')) setParameter(P_CURRENT, Z_AXIS, cmd_value());
+          if(cmd_seen('E')) setParameter(P_CURRENT, E_AXIS, cmd_value());
+          if(cmd_seen('I'))
+          {
+            if(cmd_seen('X')) setDualStepperStatus(X_STEPPER,true);
+            if(cmd_seen('Y')) setDualStepperStatus(Y_STEPPER,true);
+            if(cmd_seen('Z')) setDualStepperStatus(Z_STEPPER,true);
+          }
+          if(cmd_seen('T') && cmd_value() == 0)
+          {
+            if(cmd_seen('E')) setParameter(P_CURRENT,E_STEPPER,cmd_value());
+          }
+          if(cmd_seen('T') && cmd_value() == 1)
+          {
+            if(cmd_seen('E')) setParameter(P_CURRENT,E2_STEPPER,cmd_value());
+            setDualStepperStatus(E_STEPPER,true);
+          }
+          break;
+        case 914: //parse and store TMC Bump sensitivity values
+          if(cmd_seen('X')) setParameter(P_BUMPSENSITIVITY, X_STEPPER, cmd_float());
+          if(cmd_seen('Y')) setParameter(P_BUMPSENSITIVITY, Y_STEPPER, cmd_float());
+          if(cmd_seen('Z')) setParameter(P_BUMPSENSITIVITY, Z_STEPPER, cmd_float());
+          break;
+        case 913: //M913 Hybrid Threshold Speed
+          if(cmd_seen('X')) setParameter(P_HYBRID_THRESHOLD, X_STEPPER, cmd_value());
+          if(cmd_seen('Y')) setParameter(P_HYBRID_THRESHOLD, Y_STEPPER, cmd_value());
+          if(cmd_seen('Z')) setParameter(P_HYBRID_THRESHOLD, Z_STEPPER, cmd_value());
+          if(cmd_seen('E')) setParameter(P_HYBRID_THRESHOLD, E_STEPPER, cmd_value());
+          break;
+      }
+      break; //end parsing M-codes
+
+    case 'G':
+      cmd=strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 1],NULL,10);
+      switch(cmd)
+      {
+        case 0: //G0
+        case 1: //G1
+        {
+          AXIS i;
+          for(i=X_AXIS;i<TOTAL_AXIS;i++)
+          {
+            if(cmd_seen(axis_id[i]))
+            {
+              coordinateSetAxisTarget(i,cmd_float());
+            }
+          }
+          if(cmd_seen('F'))
+          {
+            coordinateSetFeedRate(cmd_value());
+          }
+          break;
+        }
+
+        case 28: //G28
+          coordinateSetKnown(true);
+          babystepReset();
+          storeCmd("M503 S0\n");
+          break;
+
+        #if ENABLE_BL_VALUE > 0              // if not Disabled
+          case 29: //G29
+            {
+              if(cmd_seen('A'))
+              {
+                setParameter(P_ABL_STATE,0,1);
+                storeCmd("M117 UBL active\n");
+              }
+              if(cmd_seen('D'))
+              {
+                setParameter(P_ABL_STATE,0,0);
+                storeCmd("M117 UBL inactive\n");
+              }
+            }
+            break;
+        #endif
+
+        case 90: //G90
+          coorSetRelative(false);
+          break;
+
+        case 91: //G91
+          coorSetRelative(true);
+          break;
+
+        case 92: //G92
+        {
+          bool coorRelative = coorGetRelative();
+          bool eRelative = eGetRelative();
+          // Set to absolute mode
+          coorSetRelative(false);
+          eSetRelative(false);
+          for(AXIS i = X_AXIS; i < TOTAL_AXIS; i++)
+          {
+            if(cmd_seen(axis_id[i]))
+            {
+              coordinateSetAxisTarget(i, cmd_float());
+              #ifdef FIL_RUNOUT_PIN
+                if (i == E_AXIS)
+                {
+                  // Reset SFS status, Avoid false Filament runout caused by G92 resetting E-axis position
+                  FIL_SFS_SetAlive(true);
+                }
+              #endif
+            }
+          }
+          // Restore mode
+          coorSetRelative(coorRelative);
+          eSetRelative(eRelative);
+          break;
+        }
+      }
+      break; //end parsing G-codes
+
+    case 'T':
+      cmd=strtol(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 1], NULL, 10);
+      heatSetCurrentTool(cmd);
+      break;
+
+  } // end parsing cmd
+
+  setCurrentAckSrc(infoCmd.queue[infoCmd.index_r].src);
+  Serial_Puts(SERIAL_PORT, infoCmd.queue[infoCmd.index_r].gcode);
+  if (avoid_terminal != true){
+    sendGcodeTerminalCache(infoCmd.queue[infoCmd.index_r].gcode, TERMINAL_GCODE);
+  }
+  purgeLastCmd();
+
+  infoHost.wait = infoHost.connected;
+} //sendQueueCmd


### PR DESCRIPTION
### Description
Add M73 support.
Format M73 PXXX RXXX  (P: actual progression of print (%) - R: remaining time (minute)

PrusaSlicer (and probably others but i don't use) can add progress gcode, and at least for PrusaSlicer and my printer, time is very accurate.

When a print start, if a M73 command is see, it will switch to "slicer_progress mode", and don't use internal progress.
if we are in that mode, the printing gui display the remaining time instead of ellapse time (if set)

### Benefits

Get an accurate print time

### Related Issues

I've some questions, 
my merlin didn't accept the M73 command, and i imagine most Printer with this screen has marlin compiled without LCD

In this code, i didn't forward it to Marlin, and i don't know if it make sense to forward it (if two screens on printer?)

But in more general case, is a blacklist of gcode to not send in printer in config.ini a good option?

it could be useful for others commands too.
my slicer add G21 to set in mm.
and marlin is not compiled with  INCH_MODE_SUPPORT, so don't accept the M21 command.
so i've got an warning each time i start a print.

PS.
Sorry, make a mistake with git and commit are not good.
If you are interested with it, il will redo a clean PR