### PR TITLE
Add M73 support

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -54,6 +54,10 @@ void setPrintingTime(uint32_t RTtime)
     if(isPrinting() && !isPause())
     {
       infoPrinting.time++;
+      if (infoPrinting.remaining_time > 0)
+      {
+        infoPrinting.remaining_time--;
+      }
     }
   }
 }

--- a/TFT/src/User/API/Printing.h
+++ b/TFT/src/User/API/Printing.h
@@ -35,11 +35,15 @@ typedef struct
   uint32_t size; // Gcode file total size
   uint32_t cur;  // Gcode has printed file size
   uint8_t  progress;
+  uint32_t remaining_time; //current remaining time in sec (if set with m73)
+
   bool     printing; // 1 means printing, 0 means idle
   bool     pause;    // 1 means paused
   bool     m0_pause; // pause triggered through M0/M1 gcode
   bool     runout;   // 1: runout in printing, 0: idle
   bool     model_icon; // 1: model preview icon exist, 0: not exist
+  bool     slicer_progress; //0: progress managed by btt, 1: by slicer (autoset if we encounter a M77 command)
+
 }PRINTING;
 
 extern PRINTING infoPrinting;

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -476,6 +476,23 @@ void sendQueueCmd(void)
         break;
 #endif
 
+        case 73:
+          if(cmd_seen('P'))
+          {
+            infoPrinting.progress = cmd_float();
+            infoPrinting.slicer_progress = true;
+
+          }
+          if(cmd_seen('R'))
+          {
+            infoPrinting.remaining_time = cmd_float() * 60;
+            infoPrinting.slicer_progress = true;
+
+          }
+          //forwarding it or not?
+          purgeLastCmd();
+          return;
+
         case 80: //M80
           #ifdef PS_ON_PIN
             PS_ON_On();


### PR DESCRIPTION
Description
Add M73 support.
Format M73 PXXX RXXX (P: actual progression of print (%) - R: remaining time (minute)

PrusaSlicer (and probably others but i don't use) can add progress gcode, and at least for PrusaSlicer and my printer, time is very accurate.

When a print start, if a M73 command is see, it will switch to "slicer_progress mode", and don't use internal progress.
if we are in that mode, the printing gui display the remaining time instead of ellapse time (if set)

Benefits
Get an accurate print time

Related Issues
I've some questions,
my merlin didn't accept the M73 command, and i imagine most Printer with this screen has marlin compiled without LCD

In this code, i didn't forward it to Marlin, and i don't know if it make sense to forward it (if two screens on printer?)

But in more general case, is a blacklist of gcode to not send in printer in config.ini a good option?

it could be useful for others commands too.
my slicer add G21 to set in mm.
and marlin is not compiled with INCH_MODE_SUPPORT, so don't accept the M21 command.
so i've got an warning each time i start a print.
