### PR TITLE
Update Hungarian language (text too long)

### DIFF
--- a/TFT/src/User/API/Language/language_hu.h
+++ b/TFT/src/User/API/Language/language_hu.h
@@ -186,7 +186,7 @@
     #define STRING_TOUCH_TO_EXIT          "Érintsd meg a kilépéshez."
     #define STRING_MAINMENU               "Főmenü"
     #define STRING_WAIT_TEMP_SHUT_DOWN    "Várd meg a fej\nvisszahűlését.%d℃"
-    #define STRING_FORCE_SHUT_DOWN        "Kényszerítés"
+    #define STRING_FORCE_SHUT_DOWN        "Kényszerít"
     #define STRING_SHUTTING_DOWN          "Leállítás..."
     #define STRING_PARAMETER_SETTING      "Tényezők"
     #define STRING_ON                     "BE"


### PR DESCRIPTION
The text was too long and occupied two lines.

![image](https://user-images.githubusercontent.com/3252103/102700667-c7fc9180-424f-11eb-8fba-a7d56c8dc2e6.png)
