### PR TITLE
Fix Default Mode Typo

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -18,7 +18,7 @@
  *
  * Options:
  * MODE_MARLIN // Marlin Mode
- * MDOE SERIAL_TSC // Touch Mode
+ * MODE_SERIAL_TSC // Touch Mode
  */
 #define DEFAULT_LCD_MODE MODE_SERIAL_TSC
 


### PR DESCRIPTION
### Description

`MDOE SERIAL_TSC` => `MODE_SERIAL_TSC`

### Benefits

Correct documentation.

### Related Issues

None. Found while rebasing my config to the latest version.
