### PR TITLE
Improve "Build Binaries" and "Build Test" GitHub Actions

### DIFF
--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
+    - .devcontainer/**
+    - .github/**
     - Bootloader/**
+    - images/**
     - readme/**
     - '**/*.md'
 

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Copy Files
         run: find .pio/build/ -name '*.bin' -exec cp -vf '{}' "./Copy to SD Card root directory to update/" ";"
       - name: Stage Changes
-        run: git config user.email "actions@example.com" && git config user.name "Github Actions" && find "Copy to SD Card root directory to update/" -name '*.bin' -exec git add {} \;
+        run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && git config user.name "${GITHUB_ACTOR}" && find "Copy to SD Card root directory to update/" -name '*.bin' -exec git add {} \;
       - name: Push
         uses: actions-x/commit@v2
         with:

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -13,7 +13,8 @@ on:
 
 jobs:
   main:
-    name: Main
+    name: Build Binaries
+    if: github.repository == 'bigtreetech/BIGTREETECH-TouchScreenFirmware'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -6,6 +6,7 @@ on:
     - .devcontainer/**
     - .github/**
     - Bootloader/**
+    - Copy to SD Card root directory to update/**
     - images/**
     - readme/**
     - '**/*.md'

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -2,6 +2,11 @@ name: Build Binaries
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+    - Bootloader/**
+    - readme/**
+    - '**/*.md'
+
 jobs:
   main:
     name: Main

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -10,7 +10,6 @@ on:
     - images/**
     - readme/**
     - '**/*.md'
-    - '**/*.ini'
 
 jobs:
   main:

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -10,6 +10,7 @@ on:
     - images/**
     - readme/**
     - '**/*.md'
+    - '**/*.ini'
 
 jobs:
   main:

--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -58,14 +58,20 @@ jobs:
         run: platformio run --environment MKS_32_V1_4_NOBL
       - name: Build MKS TFT28 V1.0
         run: platformio run --environment MKS_28_V1_0
-      - name: Clean Up Folder
+      - name: Remove Old Binaries
         run: find "Copy to SD Card root directory to update/" -name '*.bin' -print -delete
-      - name: Copy Files
+      - name: Remove Old Config
+        run: find "Copy to SD Card root directory to update/" -name 'config.ini' -print -delete
+      - name: Copy New Binaries
         run: find .pio/build/ -name '*.bin' -exec cp -vf '{}' "./Copy to SD Card root directory to update/" ";"
-      - name: Stage Changes
+      - name: Copy New Config
+        run: find TFT/src/User/ -name 'config.ini' -exec cp -vf '{}' "./Copy to SD Card root directory to update/" ";"
+      - name: Stage New Binaries
         run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && git config user.name "${GITHUB_ACTOR}" && find "Copy to SD Card root directory to update/" -name '*.bin' -exec git add {} \;
+      - name: Stage New Config
+        run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && git config user.name "${GITHUB_ACTOR}" && find "Copy to SD Card root directory to update/" -name 'config.ini' -exec git add {} \;
       - name: Push
         uses: actions-x/commit@v2
         with:
-          message: Update prebuilt binaries
+          message: Update prebuilt binaries and config
           token: ${{ secrets.MY_SECRET_TOKEN }}

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -3,15 +3,17 @@ on:
   pull_request:
     paths-ignore:
     - Bootloader/**
-    - readme/**
+    - Copy to SD Card root directory to update/**
     - images/**
+    - readme/**
     - '**/*.md'
 
   push:
     paths-ignore:
     - Bootloader/**
-    - readme/**
+    - Copy to SD Card root directory to update/**
     - images/**
+    - readme/**
     - '**/*.md'
 
 jobs:

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -4,12 +4,14 @@ on:
     paths-ignore:
     - Bootloader/**
     - readme/**
+    - images/**
     - '**/*.md'
 
   push:
     paths-ignore:
     - Bootloader/**
     - readme/**
+    - images/**
     - '**/*.md'
 
 jobs:

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   main:
-    name: Main
+    name: Build Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -1,5 +1,16 @@
 name: Build Test
-on: [pull_request, push]
+on:
+  pull_request:
+    paths-ignore:
+    - Bootloader/**
+    - readme/**
+    - '**/*.md'
+
+  push:
+    paths-ignore:
+    - Bootloader/**
+    - readme/**
+    - '**/*.md'
 
 jobs:
   main:


### PR DESCRIPTION
### Description

1. Copy `config.ini` when building binaries so the version located in `Copy to SD Card root directory to update/` won't have to be updated each time the main version in `TFT/src/User/` is updated.

2. Ignore changes to the following files/folders for automatic binary/config uploads:

    - .devcontainer/
    - .github/
    - Bootloader/
    - Copy to SD Card root directory to update/
    - images/
    - readme/
    - *.md

3. Ignore changes to the following files/folders for build tests:

    - Bootloader/
    - Copy to SD Card root directory to update/
    - images/
    - readme/
    - *.md

Tagging @Codel1417 as they introduced automatic binary uploads in #1450

### Benefits

Automate updating `config.ini` in the "Copy to SD Card" folder and only run CI when needed & don't upload new binaries when readmes/non-code changes are committed.

### Related Issues

None.