### PR TITLE
Fix filenames to work on TFT24 to reset settings after firmware was updated

### DIFF
--- a/TFT/src/User/API/boot.h
+++ b/TFT/src/User/API/boot.h
@@ -45,12 +45,12 @@ extern "C" {
 #define FLASH_USED              (INFOBOX_ADDR + INFOBOX_MAX_SIZE)   //currently small icons are not used
 
 
-#define ADMIN_MODE_FILE "0:admin.txt"
+#define ADMIN_MODE_FILE "admin.txt"
 #define FIRMWARE_NAME STRINGIFY(HARDWARE) "." STRINGIFY(SOFTWARE_VERSION)
 #define FIRMWARE_NAME_SHORT STRINGIFY(HARDWARE_SHORT) STRINGIFY(SOFTWARE_VERSION_SHORT)
 #define BMP_ROOT_DIR "0:" ROOT_DIR "/bmp"
 #define FONT_ROOT_DIR "0:" ROOT_DIR "/font"
-#define TFT_RESET_FILE "0:reset.txt"
+#define TFT_RESET_FILE "reset.txt"
 
 //This List is Auto-Generated. Please add new icons in icon_list.inc only
 enum


### PR DESCRIPTION
### Description

Fix filenames to work on TFT24 to reset settings after firmware was updated. Otherwise it is not possible to reset touch calibration on TFT24 (no touch working)

### Benefits

It is possible to reset touch configuration on TFT24

### Related Issues
#1498 
