### PR TITLE
Fix screen rotation not being correctly restored.

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -35,6 +35,7 @@ void infoSettingsReset(void)
   infoSettings.mesh_min_color         = lcd_colors[MESH_MIN_COLOR];
   infoSettings.mesh_max_color         = lcd_colors[MESH_MAX_COLOR];
 
+  infoSettings.rotate_ui              = DISABLED;
   infoSettings.terminalACK            = DISABLED;
   infoSettings.persistent_info        = ENABLED;
   infoSettings.file_listmode          = ENABLED;

--- a/TFT/src/User/API/flashStore.c
+++ b/TFT/src/User/API/flashStore.c
@@ -67,7 +67,7 @@ void readStoredPara(void)
   else
   {
     memcpy(&infoSettings, data + (index += 4), sizeof(SETTINGS));
-    if (sign != TSC_SIGN) infoSettings.rotate_ui = DISABLED;
+    if ((paraStatus & PARA_TSC_EXIST) == 0) infoSettings.rotate_ui = DISABLED;
   }
 }
 


### PR DESCRIPTION
### Description

The screen orientation is not restored correctly at boot time.
The screen is always restored to the original orientation, however the Touch Screen Calibration (TSC) is restored so you end up with a TFT completely messed up.
