### PR TITLE
adds keyboard layout for quertz  awerty

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -419,10 +419,21 @@
  */
 #define TERMINAL_KEYBOARD_COLOR_LAYOUT 0  // Default: 0
 
-// QWERTY keyboard layout
-// Enable QWERTY keyboard layout in Terminal menu (Only for TFT70 V3.0)
-#define TERMINAL_KEYBOARD_QWERTY_LAYOUT
+//
+// QWERTY/QWRRTZ keyboard layout
+// 
 
+/**
+ * keyboard layout for Terminal Keyboard
+ * 
+ * Options:  [0: Default, 1: Querty, 2: Quertz, 4: Azerty]
+ * Default: The keyboard has an alphabetically order
+ * Querty: The typically keyboard Layout for english (Only for TFT70 V3.0)
+ * Quertz: The typically keyboard Layout for german (Only for TFT70 V3.0)
+ * Azerty: The typically keyboard Layout for french (Only for TFT70 V3.0)
+ * 
+ */
+#define TERMINAL_KEYBOARD_LAYOUT 1  // Default: 0
 
 //===========================================================================
 //=========================== Other Settings ================================

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -255,11 +255,11 @@
 #define ENABLE_BL_VALUE 1 // Default: 1
 
 /** TouchMI settings (on ABL menu)
- * 
+ *
  * Enable this option for settings TouchMI sensor on ABL Menu (Init, Z Offset, Save, Test).
- * 
+ *
  * Options: [enable:1, disable:0]
- * 
+ *
  */
 #define TOUCHMI_SENSOR_VALUE 0 // Default: 0
 
@@ -420,18 +420,18 @@
 #define TERMINAL_KEYBOARD_COLOR_LAYOUT 0  // Default: 0
 
 //
-// QWERTY/QWRRTZ keyboard layout
-// 
+// QWERTY/QWERTZ keyboard layout
+//
 
 /**
  * keyboard layout for Terminal Keyboard
- * 
- * Options:  [0: Default, 1: Querty, 2: Quertz, 4: Azerty]
+ *
+ * Options:  [0: Default, 1: Qwerty, 2: Qwertz, 4: Azerty]
  * Default: The keyboard has an alphabetically order
- * Querty: The typically keyboard Layout for english (Only for TFT70 V3.0)
- * Quertz: The typically keyboard Layout for german (Only for TFT70 V3.0)
+ * Qwerty: The typically keyboard Layout for english (Only for TFT70 V3.0)
+ * Qwertz: The typically keyboard Layout for german (Only for TFT70 V3.0)
  * Azerty: The typically keyboard Layout for french (Only for TFT70 V3.0)
- * 
+ *
  */
 #define TERMINAL_KEYBOARD_LAYOUT 1  // Default: 0
 

--- a/TFT/src/User/Menu/SendGcode.c
+++ b/TFT/src/User/Menu/SendGcode.c
@@ -66,8 +66,8 @@ typedef struct
   #define GKEY_ROW_NUM LAYOUT_3_ROW_NUM
 #endif
 
-#define LAYOUT_QUERTY 1
-#define LAYOUT_QUERTZ 2
+#define LAYOUT_QWERTY 1
+#define LAYOUT_QWERTZ 2
 #define LAYOUT_AZERTY 3
 
 #define GKEY_WIDTH  (LCD_WIDTH / GKEY_COL_NUM)
@@ -319,22 +319,22 @@ const char * const gcodeKey[][GKEY_KEY_NUM] = {
     "7", "8", "9", "E", "F", "R", "Q",
     ".", "0", "-", "~", "I", "J", "P",
 #else
-  #if TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QUERTY
+  #if TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QWERTY
     "\\","|", "!", "\"","$", "%", "&", "/", "=", "?",
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
     "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P",
     "A", "S", "D", "F", "G", "H", "J", "K", "L", "'",
     "Z", "X", "C", "V", "B", "N", "M", ",", ".", ";",
     ":", "_", "@", "#", "~", "-", "+", "*", "(", ")",
-  #elif TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QUERTZ
+  #elif TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QWERTZ
     "!", "\"", "$", "%", "&", "/", "(", ")", "=", "?",
     "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
     "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P",
-    "A", "S", "D", "F", "G", "H", "J", "K", "L", "@", 
+    "A", "S", "D", "F", "G", "H", "J", "K", "L", "@",
     "Y", "X", "C", "V", "B", "N", "M", ",", ".", "-",
     "|", ";", ":", "_", "#", "~", "+", "*", "'", "\\",
   #elif TERMINAL_KEYBOARD_LAYOUT == LAYOUT_AZERTY
-    "#", "@", "~", "&", "(", ")", "_", "'", "\"", "%", 
+    "#", "@", "~", "&", "(", ")", "_", "'", "\"", "%",
     "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
     "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P",
     "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M",

--- a/TFT/src/User/Menu/SendGcode.c
+++ b/TFT/src/User/Menu/SendGcode.c
@@ -66,6 +66,10 @@ typedef struct
   #define GKEY_ROW_NUM LAYOUT_3_ROW_NUM
 #endif
 
+#define LAYOUT_QUERTY 1
+#define LAYOUT_QUERTZ 2
+#define LAYOUT_AZERTY 3
+
 #define GKEY_WIDTH  (LCD_WIDTH / GKEY_COL_NUM)
 #define GKEY_HEIGHT (LCD_HEIGHT / GKEY_ROW_NUM)
 
@@ -315,13 +319,27 @@ const char * const gcodeKey[][GKEY_KEY_NUM] = {
     "7", "8", "9", "E", "F", "R", "Q",
     ".", "0", "-", "~", "I", "J", "P",
 #else
-  #ifdef TERMINAL_KEYBOARD_QWERTY_LAYOUT
+  #if TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QUERTY
     "\\","|", "!", "\"","$", "%", "&", "/", "=", "?",
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
     "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P",
     "A", "S", "D", "F", "G", "H", "J", "K", "L", "'",
     "Z", "X", "C", "V", "B", "N", "M", ",", ".", ";",
     ":", "_", "@", "#", "~", "-", "+", "*", "(", ")",
+  #elif TERMINAL_KEYBOARD_LAYOUT == LAYOUT_QUERTZ
+    "!", "\"", "$", "%", "&", "/", "(", ")", "=", "?",
+    "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
+    "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P",
+    "A", "S", "D", "F", "G", "H", "J", "K", "L", "@", 
+    "Y", "X", "C", "V", "B", "N", "M", ",", ".", "-",
+    "|", ";", ":", "_", "#", "~", "+", "*", "'", "\\",
+  #elif TERMINAL_KEYBOARD_LAYOUT == LAYOUT_AZERTY
+    "#", "@", "~", "&", "(", ")", "_", "'", "\"", "%", 
+    "1", "2", "3", "4", "5", "6", "7", "8", "9", "0",
+    "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P",
+    "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M",
+    "W", "X", "C", "V", "B", "N", ".", ",", ":", ";",
+    "-", "+", "*", "\\", "|", "/", "?","!", "$", "=",
   #else
     "1", "2", "3", "A", "B", "C", "D", "E", "F", "G",
     "4", "5", "6", "H", "I", "J", "K", "L", "M", "N",


### PR DESCRIPTION
### Description
This change adds two commonly used keyboards for central europe layout for the tft7.0 v3 display
QWERTZ (german speaking countries)
AWERTY (french speaking countries) 

### Benefits

Enhanced usability for users of those countries 

### Related Issues

No issue is related, just enhancement of useability
