### PR TITLE
Added the possibility to change to time the bootscreen logo is shown

### DIFF
--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -29,7 +29,7 @@ typedef enum
 // Config version support
 // change if new elements/keywords are added/removed/changed in the configuration.h Format YYYYMMDD
 // this number should match CONFIG_VERSION in configuration.h
-#define CONFIG_SUPPPORT 20210105
+#define CONFIG_SUPPPORT 20210124
 
 #define FONT_FLASH_SIGN       20200908 //(YYYYMMDD) change if fonts require updating
 #define CONFIG_FLASH_SIGN     20210107 //(YYYYMMDD) change if any keyword(s) in config.ini is added or removed

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1,6 +1,6 @@
 #ifndef _CONFIGURATION_H_
 #define _CONFIGURATION_H_
-#define CONFIG_VERSION 20210105
+#define CONFIG_VERSION 20210124
 
 //===========================================================================
 //============================= General Settings ============================
@@ -303,6 +303,9 @@
 
 // Show bootscreen when starting up
 #define SHOW_BTT_BOOTSCREEN
+
+// Bootscreen logo time in ms
+#define BTT_BOOTSCREEN_TIME 3000
 
 // Enable alternative Move Menu Buttons Layout matching the direction of actual printer axis.
 // update the icons from alternate icon folder

--- a/TFT/src/User/Menu/Selectmode.c
+++ b/TFT/src/User/Menu/Selectmode.c
@@ -229,15 +229,10 @@ void switchMode(void)
           LOGO_ReadDisplay();
           updateNextHeatCheckTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
           #ifdef BTT_BOOTSCREEN_TIME
-          while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
-          {
-            loopProcess();
-          }
-          #else
-          while (OS_GetTimeMs() - startUpTime < 3000)  // Display 3s logo
-          {
-            loopProcess();
-          }
+            while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
+            {
+              loopProcess();
+            }
           #endif
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshBoot = false;

--- a/TFT/src/User/Menu/Selectmode.c
+++ b/TFT/src/User/Menu/Selectmode.c
@@ -228,10 +228,17 @@ void switchMode(void)
           heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
           LOGO_ReadDisplay();
           updateNextHeatCheckTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
+          #ifdef BTT_BOOTSCREEN_TIME
+          while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
+          {
+            loopProcess();
+          }
+          #else
           while (OS_GetTimeMs() - startUpTime < 3000)  // Display 3s logo
           {
             loopProcess();
           }
+          #endif
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshBoot = false;
         }

--- a/TFT/src/User/Menu/Selectmode.c
+++ b/TFT/src/User/Menu/Selectmode.c
@@ -228,12 +228,10 @@ void switchMode(void)
           heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
           LOGO_ReadDisplay();
           updateNextHeatCheckTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
-          #ifdef BTT_BOOTSCREEN_TIME
-            while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
-            {
-              loopProcess();
-            }
-          #endif
+          while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
+          {
+            loopProcess();
+          }
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshBoot = false;
         }


### PR DESCRIPTION
### Description

Hey everyone!
I added a compile time option to change the time the boot screen logo is shown.
The parameter is called #define BTT_BOOTSCREEN_TIME and is defined in Configuration.h.
In Selectmode.c i  added a #ifdef BTT_BOOTSCREEN_TIME to check if the parameter is defined, if not the standard time will
be 3 seconds.
Also i changed the CONFIG_SUPPPORT date in Settings.h

### Benefits

This patch adds the possibility to change the time the boot logo is shown at boot as a configuration option in Configuration.h.
This patch is not based on a feature request from someone else, but a feature i needed and wanted to share with the community.

Best regards
pprugger
