### PR TITLE
Fixed implicit function declaration request_M0() in Printing.c

### DIFF
--- a/TFT/src/User/API/Gcode/gcode.h
+++ b/TFT/src/User/API/Gcode/gcode.h
@@ -33,4 +33,5 @@ bool request_M27(int seconds);
 bool request_M524(void);
 bool request_M24(int pos);
 long request_M23_M36(char *filename);
+bool request_M0(void);
 #endif


### PR DESCRIPTION
### Description

This PR fixes a bug introduced in PR  #1533 
@Thro42

request_M0() is not exported in gcode.h so the compiler can't find the function in Printing.c
which results in a function call of an empty function.

Best regards 
pprugger
