### PR TITLE
Update language_es.ini

### DIFF
--- a/Copy to SD Card root directory to update/Language Packs/language_es.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_es.ini
@@ -32,7 +32,7 @@ label_ps_on:Apag. aut.
 label_ps_on_active_high:Power Supply Active HIGH
 label_fil_runout:Filament sensor
 label_fil_runout_inverting:Inverted Filament Runout Logic
-label_plrecovery_en:Power loss recovery
+label_pl_recovery_en:Power loss recovery
 label_pl_recovery_home:Power Loss Recovery Homing
 label_btt_mini_ups:BTT UPS Support
 label_touch_sound:Touch sounds


### PR DESCRIPTION
Bad label name: "label_plrecovery_en" to "label_pl_recovery_en"

### Requirements

Error when update the firmware to es languaje, error ir label

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
