### PR TITLE
Feature delta drop before mesh edit

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -195,7 +195,7 @@
 #define Z_MAX_POS 250
 
 // Is this a Delta printer
-#define IS_DELTA true
+#define IS_DELTA false
 
 // Pause Settings
 #define NOZZLE_PAUSE_RETRACT_LENGTH               15  // (mm)

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -195,7 +195,8 @@
 #define Z_MAX_POS 250
 
 // Is this a Delta printer
-#define IS_DELTA false
+#define IS_DELTA             false
+#define DELTA_MBL_Z_DROP_MM  50 // MBL Drop 50mm first after home avoid crashing into the top of the towers.
 
 // Pause Settings
 #define NOZZLE_PAUSE_RETRACT_LENGTH               15  // (mm)

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -194,6 +194,9 @@
 #define Y_MAX_POS 235
 #define Z_MAX_POS 250
 
+// Is this a Delta printer
+#define IS_DELTA true
+
 // Pause Settings
 #define NOZZLE_PAUSE_RETRACT_LENGTH               15  // (mm)
 #define NOZZLE_RESUME_PURGE_LENGTH                16  // (mm)

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -893,9 +893,9 @@ void menuMeshEditor(void)
             mustStoreCmd("G28\n");                         // only the first time, home the printer
             if (IS_DELTA)
             {
-              mustStoreCmd("G91\n");                         // Set Relative Positioning
-              mustStoreCmd("G1 Z-50 F1500\n");               // Drop by 30mm
-              mustStoreCmd("G90\n");                         // Set Absolute Positioing
+              mustStoreCmd("G91\n");                                  // Set Relative Positioning
+              mustStoreCmd("G1 Z-%.2f F1500\n", DELTA_MBL_Z_DROP_MM); // Drop by "DELTA_MBL_Z_DROP_MM" mm
+              mustStoreCmd("G90\n");                                  // Set Absolute Positioing
             }
           }
 
@@ -926,9 +926,9 @@ void menuMeshEditor(void)
         mustStoreCmd("G28\n");
         if (IS_DELTA)
         {
-          mustStoreCmd("G91\n");                         // Set Relative Positioning
-          mustStoreCmd("G1 Z-50 F1500\n");               // Drop by 30mm
-          mustStoreCmd("G90\n");                         // Set Absolute Positioing
+          mustStoreCmd("G91\n");                                  // Set Relative Positioning
+          mustStoreCmd("G1 Z-%.2f F1500\n", DELTA_MBL_Z_DROP_MM); // Drop by "DELTA_MBL_Z_DROP_MM" mm
+          mustStoreCmd("G90\n");                                  // Set Absolute Positioing
         }                             // force homing (e.g. if steppers are disarmed)
         break;
 

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -923,7 +923,13 @@ void menuMeshEditor(void)
       case ME_KEY_HOME:
         forceHoming = false;
 
-        mustStoreCmd("G28\n");                             // force homing (e.g. if steppers are disarmed)
+        mustStoreCmd("G28\n");
+        if (IS_DELTA)
+        {
+          mustStoreCmd("G91\n");                         // Set Relative Positioning
+          mustStoreCmd("G1 Z-50 F1500\n");               // Drop by 30mm
+          mustStoreCmd("G90\n");                         // Set Absolute Positioing
+        }                             // force homing (e.g. if steppers are disarmed)
         break;
 
       case ME_KEY_SAVE:

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -891,6 +891,12 @@ void menuMeshEditor(void)
             forceHoming = false;
 
             mustStoreCmd("G28\n");                         // only the first time, home the printer
+            if (IS_DELTA)
+            {
+              mustStoreCmd("G91\n");                         // Set Relative Positioning
+              mustStoreCmd("G1 Z-50 F1500\n");               // Drop by 30mm
+              mustStoreCmd("G90\n");                         // Set Absolute Positioing
+            }
           }
 
           curValue = menuMeshTuner(meshGetCol(), meshGetJ(), meshGetValue(meshGetIndex()));

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -9,7 +9,7 @@ static inline void meshInitPoint(uint16_t col, uint16_t row, float value)
 //  probeHeightEnable();                                     // temporary disable software endstops
 
   // Z offset gcode sequence start
-  if (infoMachineSettings.zProbe == ENABLED)
+  if (infoMachineSettings.zProbe == ENABLED && !(IS_DELTA))
     probeHeightStop();                                     // raise nozzle
 
   mustStoreCmd("G42 I%d J%d\n", col, row);                 // move nozzle to X and Y coordinates corresponding


### PR DESCRIPTION
- Add `IS_DELTA` to configuration.h
- Prevent `probeHeightStop()` on Delta printers
- Drop Delta printers by 50mm after homing during a Mesh Edit. This amount **should** be enough on most Delta printers to prevent a tower from crashing if the first point used is directly under a tower.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
This PR adds a Configuration.h setting for whether or not a printer is a Delta printer. If set to true, then when starting a mesh edit, after homing, the hotend will drop 50mm below the homing point to allow the printer to have free motion to move along X/Y without crashing into the top of the towers. This addresses the issue I brought forward in #1670.

[Video of the hotend crashing prior to this PR](https://drive.google.com/file/d/1ytqReGYUiGMMHlO3ekQIlyB_EiudZByH/view?usp=sharing)
[Video of the hotend successfully homing and moving between points after this PR](https://drive.google.com/file/d/1yvXUsVR_KRnNp51VW3JrHbhV5kFRbQRg/view?usp=sharing)

This is my first time coding in this language, so I'd appreciate if someone could make sure this PR doesn't have any unwanted side effects.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Allows a Delta printer to safely home during a Mesh edit, without effecting other printers. Setting defaults to `false` so as to not effect anyone unless they specifically set it to true.

### Related Issues

#1670 
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
