### PR TITLE
Bugfix: prevent switching to touch mode while printing from Marlin mode, Revert #1681 and remove Printing menu handling from ParseACK.c

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -493,7 +493,8 @@ void loopCheckPrinting(void)
     infoPrinting.printing = true;
     if (!hasPrintingMenu())
     {
-      infoMenu.menu[++infoMenu.cur] = menuPrinting;
+      infoMenu.cur = 1;
+      infoMenu.menu[infoMenu.cur] = menuPrinting;
     }
   }
 

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -503,8 +503,6 @@ void parseACK(void)
 
         infoFile.source = BOARD_SD_REMOTE;
         initPrintSummary();
-        if(infoMenu.menu[infoMenu.cur] == menuDialog)
-          infoMenu.cur--;  // remove popup/dialog window if visible.
 
         if (infoMachineSettings.autoReportSDStatus == 1)
         {
@@ -716,7 +714,7 @@ void parseACK(void)
           if (ack_seen("Y")) setParameter(P_CURRENT, Y_STEPPER, ack_value());
           if (ack_seen("Z")) setParameter(P_CURRENT, Z_STEPPER, ack_value());
           setParameter(P_STEALTH_CHOP, X_STEPPER, 0 );  //Sets 0 if StealthChop is off on all axes and the M569 string does not occur.
-          setParameter(P_STEALTH_CHOP, Y_STEPPER, 0 );  //Sets 0 if StealthChop is off on all axes and the M569 string does not occur. 
+          setParameter(P_STEALTH_CHOP, Y_STEPPER, 0 );  //Sets 0 if StealthChop is off on all axes and the M569 string does not occur.
           setParameter(P_STEALTH_CHOP, Z_STEPPER, 0 );  //Sets 0 if StealthChop is off on all axes and the M569 string does not occur.
           setParameter(P_STEALTH_CHOP, E_STEPPER, 0 );  //Sets 0 if StealthChop is off on all axes and the M569 string does not occur.
           setParameter(P_STEALTH_CHOP, E2_STEPPER, 0 ); //Sets 0 if StealthChop is off on all axes and the M569 string does not occur.
@@ -774,15 +772,15 @@ void parseACK(void)
           setParameter(P_STEALTH_CHOP, Y_STEPPER, ack_seen("Y") ? 1 : 0);
           setParameter(P_STEALTH_CHOP, Z_STEPPER, ack_seen("Z") ? 1 : 0);
         }
-        if (ack_seen("S1 T0"))  
+        if (ack_seen("S1 T0"))
         {
           setParameter(P_STEALTH_CHOP, E_STEPPER, 1 );
         }
-        if (ack_seen("S1 T1"))  
+        if (ack_seen("S1 T1"))
         {
            setParameter(P_STEALTH_CHOP, E2_STEPPER, 1 );
-        }  
-      }  
+        }
+      }
     // parse and store ABL type if auto-detect is enabled
     #if ENABLE_BL_VALUE == 1
       else if (ack_seen("Auto Bed Leveling"))

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -503,8 +503,8 @@ void parseACK(void)
 
         infoFile.source = BOARD_SD_REMOTE;
         initPrintSummary();
-        infoMenu.cur = 1;  // take care if popup active or user in other menu than print
-        infoMenu.menu[infoMenu.cur] = menuPrinting;  // switch to printing menu and make it next in line after mainscreen
+        if(infoMenu.menu[infoMenu.cur] == menuDialog)
+          infoMenu.cur--;  // remove popup/dialog window if visible.
 
         if (infoMachineSettings.autoReportSDStatus == 1)
         {


### PR DESCRIPTION
- Reverts commit #1681 and remove printing menu handling from `ParseACK.c`.  
  - Printing menu handling for Onboard SD printing is already handled via `loopCheckPrinting()` in `Printing.c`. 
  - In PR #1526 a duplicate printing menu handling was added in `ParseACK.c` which introduces a bug that causes unintentional switching to the Touch mode without proper hardware initializations when a print is started in Marlin mode, resulting in the buzzer being disabled and a non-functional stop button.