### PR TITLE
Followup to #1677 Delta drop before mesh edit

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -196,7 +196,7 @@
 
 // Is this a Delta printer
 #define IS_DELTA             false
-#define DELTA_MBL_Z_DROP_MM  50 // MBL Drop 50mm first after home avoid crashing into the top of the towers.
+#define DELTA_MBL_Z_DROP_MM  50.0f // MBL Drop 50mm first after home avoid crashing into the top of the towers.
 
 // Pause Settings
 #define NOZZLE_PAUSE_RETRACT_LENGTH               15  // (mm)


### PR DESCRIPTION
DELTA_MBL_Z_DROP_MM *must* be definied as a float instead of an int or double if it's going to be called as a float.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Defining `DELTA_MBL_Z_DROP_MM as an int prevents it from being called since it's being called as a float.

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Allows #1677 to function as expected.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
