### PR TITLE
Bugfix: Wrong character width in Terminal

### DIFF
--- a/TFT/src/User/Menu/SendGcode.c
+++ b/TFT/src/User/Menu/SendGcode.c
@@ -748,10 +748,10 @@ void menuTerminalWindow(void)
       terminalDrawPageNumber();
     }
 
-    getCharacterInfo((uint8_t *)(terminalBuf + lastTerminalIndex), &info);
-
     while (terminalBuf + lastTerminalIndex && (lastTerminalIndex != terminalData->terminalBufTail))
     {
+      getCharacterInfo((uint8_t *)(terminalBuf + lastTerminalIndex), &info);
+
       // Next Line
       if (cursorX + info.pixelWidth > terminalAreaRect[0].x1 ||
           (terminalBuf[lastTerminalIndex] == '\n' && cursorX != CURSOR_START_X))


### PR DESCRIPTION
- Fix: Wrong character width in the Terminal when the first character received has a larger width (originated from #1171). The character info was being fetched only for the first character on a page, this resulted in all the character on the page being rendered with spacing based on the first character's width.