### PR TITLE
Bugfix delta min pos limit

### DIFF
--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -772,12 +772,12 @@ void parseConfigKey(uint16_t index)
       break;
 
     case C_INDEX_PAUSE_POS:
-      if (key_seen("X")) SET_VALID_FLOAT_VALUE(infoSettings.pause_pos[X_AXIS], MIN_POS_LIMIT, MAX_SIZE_LIMIT);
-      if (key_seen("Y")) SET_VALID_FLOAT_VALUE(infoSettings.pause_pos[Y_AXIS], MIN_POS_LIMIT, MAX_SIZE_LIMIT);
+      if (key_seen("X")) SET_VALID_FLOAT_VALUE(infoSettings.pause_pos[X_AXIS], MIN_XY_POS_LIMIT, MAX_SIZE_LIMIT);
+      if (key_seen("Y")) SET_VALID_FLOAT_VALUE(infoSettings.pause_pos[Y_AXIS], MIN_XY_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_PAUSE_Z_RAISE:
-      SET_VALID_FLOAT_VALUE(infoSettings.pause_z_raise, MIN_POS_LIMIT, MAX_SIZE_LIMIT);
+      SET_VALID_FLOAT_VALUE(infoSettings.pause_z_raise, MIN_Z_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_PAUSE_FEEDRATE:
@@ -787,15 +787,15 @@ void parseConfigKey(uint16_t index)
       break;
 
     case C_INDEX_LEVEL_EDGE:
-      SET_VALID_INT_VALUE(infoSettings.level_edge, MIN_POS_LIMIT, MAX_SIZE_LIMIT);
+      SET_VALID_INT_VALUE(infoSettings.level_edge, MIN_XY_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_LEVEL_Z_POS:
-      SET_VALID_FLOAT_VALUE(infoSettings.level_z_pos, MIN_POS_LIMIT, MAX_SIZE_LIMIT);
+      SET_VALID_FLOAT_VALUE(infoSettings.level_z_pos, MIN_Z_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_LEVEL_Z_RAISE:
-      SET_VALID_FLOAT_VALUE(infoSettings.level_z_raise, MIN_POS_LIMIT, MAX_SIZE_LIMIT);
+      SET_VALID_FLOAT_VALUE(infoSettings.level_z_raise, MIN_Z_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_LEVEL_FEEDRATE:
@@ -807,7 +807,7 @@ void parseConfigKey(uint16_t index)
       infoSettings.xy_offset_probing = getOnOff();
       break;
 
-   case C_INDEX_Z_STEPPERS_ALIGNMENT:
+    case C_INDEX_Z_STEPPERS_ALIGNMENT:
       infoSettings.z_steppers_alignment = getOnOff();
       break;
 

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -787,7 +787,7 @@ void parseConfigKey(uint16_t index)
       break;
 
     case C_INDEX_LEVEL_EDGE:
-      SET_VALID_INT_VALUE(infoSettings.level_edge, MIN_XY_POS_LIMIT, MAX_SIZE_LIMIT);
+      SET_VALID_INT_VALUE(infoSettings.level_edge, MIN_Z_POS_LIMIT, MAX_SIZE_LIMIT);
       break;
 
     case C_INDEX_LEVEL_Z_POS:

--- a/TFT/src/User/API/config.h
+++ b/TFT/src/User/API/config.h
@@ -170,7 +170,12 @@ extern "C" {
 #define MIN_SIZE_LIMIT            -2000     // machine size less than this will not be parsed.
 #define NAME_MIN_LENGTH           3         // minimum name length
 #define GCODE_MIN_LENGTH          3         // gcode length less than this will not pe parsed.
-#define MIN_POS_LIMIT             0         // position value less than this will not be parsed.
+#if (IS_DELTA)
+  #define MIN_XY_POS_LIMIT        -2000     // Set a negative minimum position for Deltas
+#else
+  #define MIN_XY_POS_LIMIT        0         // position value less than this will not be parsed.
+#endif
+#define MIN_Z_POS_LIMIT           0
 #define MIN_TOOL_TEMP             20        // extruder temp less than this will not pe parsed.
 #define MIN_BED_TEMP              20        // bed temp less than this will not pe parsed.
 #define MIN_CHAMBER_TEMP          20        // chamber temp less than this will not pe parsed.


### PR DESCRIPTION
- Break MIN_POS_LIMIT into MIN_XY_POS_LIMIT and MIN_Z_POS_LIMIT
- If not a Delta, nothing will change
- If a Delta, set the MIN_XY_POS_LIMIT to -2000 since the center is 0,0
- Fix indent on `case C_INDEX_Z_STEPPERS_ALIGHNMENT`

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Delta Printers have their 0,0 coordinates at the center of the bed. `MIN_POS_LIMIT` is hardcoded to `0`, which restricts Deltas to only be able to use 1/4 of the bed for the Pause Position. I propose splitting this into 2 separate values: `MIN_XY_POS_LIMIT` and `MIN_Z_POS_LIMIT`. `MIN_Z_POS_LIMIT` will remain at `0`, whereas `MIN_XY_POS_LIMIT` will be `0` for Cartesian printers, and `-2000` for Deltas.

### Benefits

Allows Deltas to use the entire bed for their Pause Position.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
