### PR TITLE
fix PLR freeze

### DIFF
--- a/TFT/src/User/Menu/PowerFailed.c
+++ b/TFT/src/User/Menu/PowerFailed.c
@@ -199,8 +199,8 @@ void menuPowerOff(void)
 
   if (mountFS() == true && powerFailedExist())
   {
-    char okTxt[50];
-    char cancelTxt[50];
+    char okTxt[MAX_LANG_LABEL_LENGTH];
+    char cancelTxt[MAX_LANG_LABEL_LENGTH];
     loadLabelText((uint8_t*)okTxt, LABEL_CONFIRM);
     loadLabelText((uint8_t*)cancelTxt, LABEL_CANCEL);
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
`loadLabelText((uint8_t*)okTxt, LABEL_CONFIRM);` function will always to modify MAX_LANG_LABEL_LENGTH of RAM, when the array is only 50, this function will access overflow and tamper with some unknown RAM data.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
fix #1720
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
