### PR TITLE
fix screen freeze when get onboard SD gcodes

### DIFF
--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -202,6 +202,10 @@ void menuPrintFromSource(void)
 
   if (mountFS() == true && scanPrintFiles() == true)
   {
+    if (infoMenu.menu[infoMenu.cur] != menuPrintFromSource) // Menu index be modify when "scanPrintFilesGcodeFs". (echo,error,warngin popup windows)
+    {
+      return;
+    }
     if (list_mode != true)
     {
       menuDrawPage(&_printIconItems);

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -202,7 +202,7 @@ void menuPrintFromSource(void)
 
   if (mountFS() == true && scanPrintFiles() == true)
   {
-    if (infoMenu.menu[infoMenu.cur] != menuPrintFromSource) // Menu index be modify when "scanPrintFilesGcodeFs". (echo,error,warngin popup windows)
+    if (infoMenu.menu[infoMenu.cur] != menuPrintFromSource) // Menu index be modify when "scanPrintFilesGcodeFs". (echo,error,warning popup windows)
     {
       return;
     }


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
In fact, it is not freeze, the interface is covered by pop-up feedback(echo,error,warning popup windows). The menu index is pop-up, but the interface is gcodes
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
