### PR TITLE
fix BOARD_SD_REMOTE flag

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -481,15 +481,6 @@ void resumeAndContinue(void)
   Serial_Puts(SERIAL_PORT, "M876 S1\n");
 }
 
-bool hasPrintingMenu(void)
-{
-  for (uint8_t i = 0; i <= infoMenu.cur; i++)
-  {
-    if (infoMenu.menu[i] == menuPrinting) return true;
-  }
-  return false;
-}
-
 void loopCheckPrinting(void)
 {
   #ifdef HAS_EMULATOR
@@ -499,11 +490,10 @@ void loopCheckPrinting(void)
   if (infoHost.printing && !infoPrinting.printing)
   {
     infoPrinting.printing = true;
-    if (!hasPrintingMenu())
-    {
-      infoMenu.cur = 1;
-      infoMenu.menu[infoMenu.cur] = menuPrinting;
-    }
+    infoFile.source = BOARD_SD_REMOTE;  // Avoid BOARD_SD be parsed as BOARD_SD_REMOTE in parseACK.c
+
+    infoMenu.cur = 1;  // Clear menu buffer when printing menu is active by remote
+    infoMenu.menu[infoMenu.cur] = menuPrinting;
   }
 
   if (infoFile.source < BOARD_SD) return;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -553,7 +553,7 @@ void parseACK(void)
         {
           // RRF
           // {"key":"job.file.fileName","flags": "","result":"0:/gcodes/pig-4H.gcode"}
-          ack_seen("result\":\"");
+          ack_seen("result\":\"0:/gcodes/");
           fileEndString = "\"";
         }
         uint16_t start_index = ack_index;
@@ -569,7 +569,6 @@ void parseACK(void)
         infoPrinting.cur = 0;
         infoPrinting.size = 1; // Should be different with .cur to avoid 100% progress on TFT, Get the correct value by M27
 
-        infoFile.source = BOARD_SD_REMOTE;
         initPrintSummary();
 
         if (infoMachineSettings.autoReportSDStatus == 1)


### PR DESCRIPTION
### Requirements

### Description
* Avoid BOARD_SD be parsed as BOARD_SD_REMOTE in parseACK.c
* Always clear menu buffer when printing menu is active by remote
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
