### PR TITLE
Add support for MKS TFT32 1.3, TFT28 V3.0

### DIFF
--- a/TFT/src/Libraries/cmsis/stm32f10x/system_stm32f10x.c
+++ b/TFT/src/Libraries/cmsis/stm32f10x/system_stm32f10x.c
@@ -106,7 +106,7 @@
 #if defined (STM32F10X_LD_VL) || defined (STM32F10X_MD_VL) || defined (STM32F10X_HD_VL)
 /* #define SYSCLK_FREQ_HSE    HSE_VALUE */
  #define SYSCLK_FREQ_24MHz  24000000
-#elif defined (MKS_32_V1_4) || defined (MKS_28_V1_0)
+#elif defined (MKS_32_V1_3) || defined (MKS_32_V1_4) || defined (MKS_28_V1_0)
  #define SYSCLK_FREQ_48MHz  48000000
 #else
 /* #define SYSCLK_FREQ_HSE    HSE_VALUE */

--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -6,6 +6,23 @@ uint16_t backGroundColor = BLACK;
 GUI_TEXT_MODE guiTextMode = GUI_TEXTMODE_NORMAL;
 GUI_NUM_MODE guiNumMode = GUI_NUMMODE_SPACE;
 
+#if LCD_DRIVER_IS(ILI9325)
+void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+{
+    LCD_WR_REG(0x50);
+    LCD_WR_DATA(sy);
+	  LCD_WR_REG(0x52);
+    LCD_WR_DATA(sx);
+	  LCD_WR_REG(0x51);
+    LCD_WR_DATA(ey);
+	  LCD_WR_REG(0x53);
+    LCD_WR_DATA(ex);
+	  LCD_WR_REG(0x20);
+    LCD_WR_DATA(sy);
+	  LCD_WR_REG(0x21);
+    LCD_WR_DATA(sx);
+}
+#else
 void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
 {
   LCD_WR_REG(0x2A);
@@ -15,6 +32,7 @@ void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
   LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
   LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
 }
+#endif
 
 void GUI_SetColor(uint16_t color)
 {
@@ -59,7 +77,7 @@ void GUI_Clear(uint16_t color)
 {
   uint32_t index=0;
   LCD_SetWindow(0, 0, LCD_WIDTH-1, LCD_HEIGHT-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (index=0; index<LCD_WIDTH*LCD_HEIGHT; index++)
   {
     LCD_WR_16BITS_DATA(color);
@@ -93,14 +111,14 @@ void GUI_DrawPixel(int16_t x, int16_t y, uint16_t color)
     return ;
 
   LCD_SetWindow(x, y, x, y);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   LCD_WR_16BITS_DATA(color);
 }
 
 void GUI_DrawPoint(uint16_t x, uint16_t y)
 {
   LCD_SetWindow(x, y, x, y);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   LCD_WR_16BITS_DATA(foreGroundColor);
 }
 
@@ -108,7 +126,7 @@ void GUI_FillRect(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
 {
   uint16_t i=0, j=0;
   LCD_SetWindow( sx, sy, ex-1, ey-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -127,7 +145,7 @@ void GUI_ClearRect(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
 {
   uint16_t i=0, j=0;
   LCD_SetWindow( sx, sy, ex-1, ey-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -146,7 +164,7 @@ void GUI_FillRectColor(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey, uint1
 {
   uint16_t i=0, j=0;
   LCD_SetWindow(sx, sy, ex-1, ey-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -159,7 +177,7 @@ void GUI_FillRectArry(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey, uint8_
 {
   uint16_t i=0, j=0, color;
   LCD_SetWindow(sx, sy, ex-1, ey-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -235,7 +253,7 @@ void GUI_HLine(uint16_t x1, uint16_t y, uint16_t x2)
 {
   uint16_t i=0;
   LCD_SetWindow(x1, y, x2-1, y);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=x1; i<x2; i++)
   {
     LCD_WR_16BITS_DATA(foreGroundColor);
@@ -245,7 +263,7 @@ void GUI_VLine(uint16_t x, uint16_t y1, uint16_t y2)
 {
   uint16_t i=0;
   LCD_SetWindow(x, y1, x, y2-1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=y1; i<y2; i++)
   {
     LCD_WR_16BITS_DATA(foreGroundColor);

--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -14,7 +14,7 @@ void lcd_frame_display(uint16_t sx, uint16_t sy, uint16_t w, uint16_t h, u32 add
   u32 address = addr;
 
   LCD_SetWindow(sx, sy, sx + w - 1, sy + h - 1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
 
   W25Qxx_SPI_CS_Set(0);
   W25Qxx_SPI_Read_Write_Byte(CMD_READ_DATA);
@@ -81,7 +81,7 @@ bool model_DirectDisplay(GUI_POINT pos, char *gcode)
   f_lseek(&gcodeFile, gcodeFile.fptr + 3);
 
   LCD_SetWindow(pos.x, pos.y, pos.x + ICON_WIDTH - 1, pos.y + ICON_HEIGHT - 1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (uint16_t y = 0; y < ICON_HEIGHT; y++)
   {
     for (uint16_t x = 0; x < ICON_WIDTH; x++)
@@ -169,7 +169,7 @@ void ICON_PressedDisplay(uint16_t sx, uint16_t sy, uint8_t icon)
   u32 address = getBMPsize((uint8_t *)&w, (uint8_t *)&h, ICON_ADDR(icon));
 
   LCD_SetWindow(sx, sy, sx + w - 1, sy + h - 1);
-  LCD_WR_REG(0x2C);
+  LCD_WR_REG(TFTLCD_WRITEMEMORY);
 
   W25Qxx_SPI_CS_Set(0);
   W25Qxx_SPI_Read_Write_Byte(CMD_READ_DATA);

--- a/TFT/src/User/Hal/LCD_Init.c
+++ b/TFT/src/User/Hal/LCD_Init.c
@@ -675,6 +675,21 @@ uint32_t LCD_ReadPixel_24Bit(int16_t x, int16_t y)
   return (pix.RGB.r << 19) | (pix.RGB.g << 10) | (pix.RGB.b << 3);
 }
 
+#elif LCD_DRIVER_IS(ILI9325)
+void LCD_init_RGB(void) 
+{	
+  uint16_t R01h, R03h, R60h;
+  R01h = (1 << 8) | (0 << 10);                        // SS = 1, SM = 0,  from S720 to S1 (see also  GS bit (R60h))
+  R03h = (1 << 12) | (1 << 5) | (1 << 4) | (1 << 3);  // TRI=0, DFM=0, BGR=1, ORG=0, I/D[1:0]=11, AM=1
+  R60h = (0 << 15) | (0x27 << 8);                     // Gate Scan Control (R60h) GS=0(G1) NL[5:0]=0x27 (320 lines)
+
+  LCD_WR_REG(0x0001); // Driver Output Control Register (R01h)	
+  LCD_WR_DATA(R01h);
+  LCD_WR_REG(0x0003); // Entry Mode (R03h)
+  LCD_WR_DATA(R03h);
+  LCD_WR_REG(0x0060); // Driver Output Control (R60h) 
+  LCD_WR_DATA(R60h);
+}
 #endif
 
 uint16_t LCD_ReadID(void)
@@ -690,11 +705,28 @@ uint16_t LCD_ReadID(void)
   return id;
 }
 
+#if LCD_DRIVER_IS(ILI9325)
+void LCD_RefreshDirection(void)
+{
+  uint16_t R01h, R03h, R60h;
+  R01h = (infoSettings.rotate_ui ? 0 : 1 << 8) | (0 << 10);     // SS=horizontal flip, SM=0
+  R03h = (1 << 12) | (1 << 5) | (1 << 4) | (1 << 3);            // TRI=0, DFM=0, BGR=1, ORG=0, I/D[1:0]=11, AM=1
+  R60h = (infoSettings.rotate_ui ? 1 : 0 << 15) | (0x27 << 8);  // GS=vertical flip, NL[5:0]=0x27 (320 lines)
+
+  LCD_WR_REG(0x0001); // Driver Output Control Register (R01h)	
+  LCD_WR_DATA(R01h);
+  LCD_WR_REG(0x0003); // Entry Mode (R03h)
+  LCD_WR_DATA(R03h);
+  LCD_WR_REG(0x0060); // Driver Output Control (R60h) 
+  LCD_WR_DATA(R60h);    
+}
+#else
 void LCD_RefreshDirection(void)
 {
   LCD_WR_REG(0X36);
   LCD_WR_DATA(infoSettings.rotate_ui ? TFTLCD_180_DEGREE_REG_VALUE : TFTLCD_0_DEGREE_REG_VALUE);
 }
+#endif
 
 void LCD_Init(void)
 {

--- a/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usb_bsp.c
+++ b/TFT/src/User/Hal/STM32_USB_HOST_Library/Usr/src/usb_bsp.c
@@ -42,7 +42,7 @@ void USB_OTG_BSP_Init(USB_OTG_CORE_HANDLE * pdev)
   // EXTI_InitTypeDef EXTI_InitStructure;
 #ifdef STM32F10X_CL
 
-#if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+#if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
   RCC_OTGFSCLKConfig(RCC_OTGFSCLKSource_PLLVCO_Div2);
 #else
   RCC_OTGFSCLKConfig(RCC_OTGFSCLKSource_PLLVCO_Div3);

--- a/TFT/src/User/Hal/stm32f10x/lcd.c
+++ b/TFT/src/User/Hal/stm32f10x/lcd.c
@@ -127,7 +127,7 @@ void LCD_WR_DATA(uint16_t data)
 
 uint16_t LCD_RD_DATA(void)
 {
-  #if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+  #if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
     #define LCD_DATA_PORT GPIOE
   #else
     #define LCD_DATA_PORT GPIOC
@@ -155,7 +155,7 @@ uint16_t LCD_RD_DATA(void)
 void LCD_GPIO_Config(void)
 {
 
- #if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+ #if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
 
  GPIO_InitTypeDef GPIO_InitStructure;
   /* GPIO Ports Clock Enable */

--- a/TFT/src/User/Hal/stm32f10x/lcd.h
+++ b/TFT/src/User/Hal/stm32f10x/lcd.h
@@ -19,7 +19,7 @@
   #define LCD_WR_DATA(data)  do{ LCD->LCD_RAM = data; }while(0)
 
 #else
-  #if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+  #if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
   /*
   #define LCD_WR PB14
   #define LCD_RS PD13

--- a/TFT/src/User/Hal/stm32f10x/spi_slave.c
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave.c
@@ -6,7 +6,7 @@
 #include "Settings.h"
 #include "HD44780.h"
 
-#if !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)
+#if !defined(MKS_32_V1_3) && !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)
 
 #if defined(ST7920_EMULATOR)
 //TODO:
@@ -169,4 +169,4 @@ void EXTI15_10_IRQHandler(void)
 }
 #endif
 
-#endif             // endif for #if !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)
+#endif             // endif for #if !defined(MKS_32_V1_3) && !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)

--- a/TFT/src/User/Hal/stm32f10x/spi_slave_mks.c
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave_mks.c
@@ -4,7 +4,7 @@
 #include "stdlib.h"
 #include "stm32f10x_conf.h"
 
-#if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+#if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
 
 #if defined(ST7920_EMULATOR)
 //TODO:
@@ -159,4 +159,4 @@ void EXTI1_IRQHandler(void)
 }
 #endif             // endif for #if defined(ST7920_EMULATOR)
 
-#endif             // endif for #if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+#endif             // endif for #if defined(MKS_32_V1_3) || defined(MKS_32_V1_4) || defined (MKS_28_V1_0)

--- a/TFT/src/User/Menu/Selectmode.c
+++ b/TFT/src/User/Menu/Selectmode.c
@@ -198,7 +198,7 @@ static inline void setupModeHardware(uint8_t mode)
       setEncActiveSignal(1);
     #endif
 
-    #if !defined(MKS_32_V1_4) && !defined(MKS_28_V1_0)
+    #if !defined(MKS_32_V1_3) && !defined(MKS_32_V1_4) && !defined(MKS_28_V1_0)
       //causes hang if we deinit spi1
       SD_DeInit();
     #endif

--- a/TFT/src/User/Variants/pin_MKS_TFT32_V1_3.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT32_V1_3.h
@@ -1,0 +1,217 @@
+#ifndef _PIN_MKS_TFT32_V1_4_H_ // modify to actual filename !!!
+#define _PIN_MKS_TFT32_V1_4_H_ // modify to actual filename !!!
+
+// MCU type (STM32F10x, STM32F2xx)
+#include "stm32f10x.h"
+
+// LCD resolution, font and icon size
+#ifndef TFT_RESOLUTION
+  #define TFT_RESOLUTION
+  #include "./Resolution/TFT_320X240.h"
+#endif
+
+#ifndef ROOT_DIR
+  #define ROOT_DIR "MKS"
+#endif
+
+// Hardware version config
+#ifndef HARDWARE_VERSION
+  #define HARDWARE_VERSION "TFT32_V3.0"
+#endif
+
+// LCD interface
+#ifndef TFTLCD_DRIVER
+  #define TFTLCD_DRIVER               ILI9325  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558].
+#endif
+//#define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
+#ifndef LCD_DATA_16BIT
+  #define LCD_DATA_16BIT 1  // LCD data 16bit or 8bit
+#endif
+
+// Debug disable, free pins for other function
+//#define DISABLE_JTAG   // free JTAG(PB3/PB4) for SPI3
+//#define DISABLE_DEBUG  // free all pins
+
+// LCD Backlight pin (PWM can adjust brightness)
+//#define LCD_LED_PIN           PD14
+//#define LCD_LED_PIN_ALTERNATE 0
+//#define LCD_LED_PWM_CHANNEL   _TIM4_CH3
+
+// SERIAL_PORT: communicating with host(Marlin, smoothieware, etc...)
+// SERIAL_PORT_X: communicating with other controller(Octoprint, ESP3D, other UART Touch Screen, etc...)
+#define SERIAL_PORT   _USART2  // default usart port
+#define SERIAL_PORT_2 _USART1
+#define SERIAL_PORT_3 _USART3
+#define USART2_TX_PIN PD5
+#define USART2_RX_PIN PD6
+#define USART3_TX_PIN PD8
+#define USART3_RX_PIN PD9
+//#define SERIAL_PORT_4 _UART4
+
+// XPT2046 Software SPI Pins (touch screen ic)
+// need CS/SCK/MISO/MOSI for Software SPI, and TPEN for pen interrupt
+#define XPT2046_CS   PC9
+#define XPT2046_SCK  PC10
+#define XPT2046_MISO PC11
+#define XPT2046_MOSI PC12
+#define XPT2046_TPEN PC5
+
+// SD Card SPI pins
+#define SD_SPI_SUPPORT
+//#define SD_SDIO_SUPPORT
+#ifdef SD_SPI_SUPPORT
+  #define SD_LOW_SPEED  7      // 2^(SPEED+1) = 256 frequency division
+  #define SD_HIGH_SPEED 1      // 2 frequency division
+  #define SD_SPI        _SPI1
+  #define SD_CS_PIN     PD11
+#endif
+
+// SD Card CD detect pin
+#define SD_CD_PIN PB15
+
+// W25Qxx SPI pins
+#define W25Qxx_SPEED  1
+#define W25Qxx_SPI    _SPI1
+#define W25Qxx_CS_PIN PB9
+
+//
+//----------------------------------------------------------------------------
+// How to setup Marlin mode (LCD12864 Emulator) on MKS Gen L V1.0 or SKR V1.3
+//----------------------------------------------------------------------------
+//
+// In order to use Marlin mode (12864 emulation mode), you need to make changes on both the HW and FW of the MKS TFT board
+// and the FW of the Marlin board.
+//
+// The following sections provide the full setup procedure to allow Marlin mode for the Marlin boards reported below:
+//  1) MKS Gen L V1.0
+//  2) SKR V1.3
+//
+//
+// ------------------------------------
+// MKS TFT HW changes:
+// ------------------------------------
+//
+// On the MKS TFT, the SPI3 is used for Marlin mode. PB3 pin on the SPI3 (pin number 89 on the TFT's STM32 chip) is also needed
+// but that pin is not exposed to any pin header on the TFT board. This means that PB3 pin must be wired from the TFT's STM32 chip
+// to a free pin header (e.g. the NC pin on the WiFi connector) on the TFT board.
+//
+// NOTES:
+//  1) Wiring PB3 pin to a free pin header on the TFT board requires good soldering skill.
+//     If you don't have good soldering skill, DO NOT try to make any change. Otherwise, you will probably damage the TFT board.
+//  2) By default, SPI3_PIN_SMART_USAGE is enabled. When enabled, pin PB0 and PB1 are not needed for Marlin mode.
+//     These pins are normally used for the Power Off and Filament Runout features, so they will continue be available in Marlin mode.
+//     If SPI3_PIN_SMART_USAGE is disabled, the Power Off and Filament Runout features will be no more available in Marlin mode.
+//  3) To reduce the effect of EMI, it is strongly suggested to use single cables (possibly shielded) for all the SPI pins
+//     (SPI3_SCK, SPI3_MOSI_PIN and SPI3_CS_PIN). For the encoder pins, a flat cable can be used.
+//  4) In case LCD Encoder's sliding buttons (pin LCD_ENCA_PIN and LCD_ENCB_PIN) don't produce any movement on menu,
+//     try to increase the delay LCD_ENCODER_DELAY in Configuration.h (e.g. 64).
+//
+//
+// ------------------------------------
+// FW and HW connection schema:
+// ------------------------------------
+//
+// MKS TFT FW pins   MKS TFT HW pins / board pins         MKS Gen L V1.0 HW pins   SKR V1.3 HW pins   Marlin FW pins
+// ---------------   -----------------------------        ----------------------   ----------------   ---------------
+// LCD_ENCA_PIN      PA13 / JTAG DIO                 =>   EXP2 D31                 EXPA2_08_PIN       BTN_EN1
+// LCD_ENCB_PIN      PA14 / JTAG CLK                 =>   EXP2 D33                 EXPA2_06_PIN       BTN_EN2
+// LCD_BTN_PIN       PB0  / PB0                      =>   EXP1 D35                 EXPA2_07_PIN       BTN_ENC
+// SPI3_CS_PIN       PB1  / PB1                      =>   EXP1 D16                 EXPA2_04_PIN       LCD_PINS_RS
+// SPI3_SCK_PIN      PB3  / NC WiFi (wired to PB3)   =>   EXP1 D23                 EXPA2_09_PIN       LCD_PINS_D4
+// SPI3_MOSI_PIN     PB5  / PB5                      =>   EXP1 D17                 EXPA2_05_PIN       LCD_PINS_ENABLE
+//
+//
+// ------------------------------------
+// MKS Gen L V1.0 pinout schema:
+// ------------------------------------
+//                       ______                                              ______
+//                  D50 | 1  2 | D52                      (BEEPER_PIN)  D37 | 1  2 | D35  (BTN_ENC)
+//       (BTN_EN1)  D31 | 3  4 | D53  (SDSS)         (LCD_PINS_ENABLE)  D17 | 3  4 | D16  (LCD_PINS_RS)
+//       (BTN_EN2)  D33 | 5  6   D51                     (LCD_PINS_D4)  D23 | 5  6   D25  (LCD_PINS_D5)
+// (SD_DETECT_PIN)  D49 | 7  8 | RST                     (LCD_PINS_D6)  D27 | 7  8 | D29  (LCD_PINS_D7)
+//                  GND | 9 10 | D41  (KILL_PIN)                        GND | 9 10 | 5V
+//                       ------                                              ------
+//                        EXP2                                                EXP1
+//
+//
+// ------------------------------------
+// MKS Gen L V1.0 FW (Marlin) changes:
+// ------------------------------------
+//
+// In the Configuration.h file uncomment and set the following existing parameters as reported below:
+//
+// #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+//
+// #define ENCODER_PULSES_PER_STEP 4
+//
+//
+// ------------------------------------
+// SKR V1.3 FW (Marlin) changes:
+// ------------------------------------
+//
+// In the Configuration.h file uncomment and set the following existing parameters as reported below:
+//
+// #define CR10_STOCKDISPLAY
+//
+// #define ENCODER_PULSES_PER_STEP 4
+//
+//
+// In the pins_BTT_SKR_V1_3.h file define pins as reported below:
+//
+// #elif ENABLED(CR10_STOCKDISPLAY)
+//
+//   #define LCD_PINS_RS             EXPA2_04_PIN  // CS
+//   #define BTN_EN1                 EXPA2_08_PIN
+//   #define BTN_EN2                 EXPA2_06_PIN
+//   #define BTN_ENC                 EXPA2_07_PIN  // (58) open-drain  EXPA1_09_PIN
+//   #define LCD_PINS_ENABLE         EXPA2_05_PIN  // EXPA1_03_PIN  //MOSI
+//   #define LCD_PINS_D4             EXPA2_09_PIN  // EXPA1_05_PIN  //CLK
+//
+
+// ST7920 Emulator SPI pins
+#define ST7920_EMULATOR  // uncomment to enable Marlin mode
+#ifdef ST7920_EMULATOR
+  #define ST7920_SPI _SPI3
+#endif
+
+#if defined(ST7920_EMULATOR) || defined(LCD2004_EMULATOR)
+  #define HAS_EMULATOR
+#endif
+
+// Buzzer support
+#define BUZZER_PIN PA2
+
+// Marlin mode + LCD Encoder support
+#ifdef ST7920_EMULATOR
+  #define DISABLE_DEBUG         // free JTAG(PB3/PB4) for SPI3 and free SWDIO PA13 PA14 for encoder pins
+  #define LCD_ENCA_PIN  PA13    // map ENCA pin to JTAG DIO pin
+  #define LCD_ENCB_PIN  PA14    // map ENCB pin to JTAG CLK pin
+
+  #define SPI3_PIN_SMART_USAGE  // if enabled, it avoids any SPI3 CS pin usage and free the MISO (PB4 pin) for encoder pins
+  #ifdef SPI3_PIN_SMART_USAGE
+    #define LCD_BTN_PIN PB4     // map BTN pin to PB4 pin
+  #else
+    #define LCD_BTN_PIN PB0     // map BTN pin to PB0 pin
+
+    #define SPI3_CS_PIN PB1     // CS pin used for SPI3 slave mode mapped to PB1 pin
+  #endif
+#endif
+
+// U disk support
+#define U_DISK_SUPPORT
+#define USE_USB_OTG_FS
+
+// Extend function(PS_ON, filament_detect)
+#if !defined(ST7920_EMULATOR) || defined(SPI3_PIN_SMART_USAGE)
+  #ifndef PS_ON_PIN
+    #define PS_ON_PIN PB0
+  #endif
+
+  #ifndef FIL_RUNOUT_PIN
+    #define FIL_RUNOUT_PIN PB1
+  #endif
+#endif
+
+//#define LED_COLOR_PIN PC7
+
+#endif

--- a/TFT/src/User/Variants/variants.h
+++ b/TFT/src/User/Variants/variants.h
@@ -45,6 +45,8 @@
   #include "pin_TFT35_E3_V3_0.h"
 #elif defined(TFT35_B1_V3_0)
   #include "pin_TFT35_B1_V3_0.h"
+#elif defined(MKS_32_V1_3)
+  #include "pin_MKS_TFT32_V1_3.h"
 #elif defined(MKS_32_V1_4)
   #include "pin_MKS_TFT32_V1_4.h"
 #elif defined(MKS_28_V1_0)

--- a/TFT/src/User/Variants/variants.h
+++ b/TFT/src/User/Variants/variants.h
@@ -10,13 +10,14 @@
 * TIM7 for OS Timer
 */
 
-// Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
+// Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558, SSD1963].
 #define RM68042 0
 #define ILI9488 1
 #define ILI9341 2
 #define ST7789  3
 #define HX8558  4
 #define SSD1963 5
+#define ILI9325 6
 
 #if defined(TFT24_V1_1)
   #include "pin_TFT24_V1_1.h"
@@ -54,5 +55,11 @@
 #define ENC_ACTIVE_SIGNAL (defined(LCD_ENC_EN_PIN) && defined(ST7920_EMULATOR) && defined(LCD_ENCODER_SUPPORT))
 
 #define LCD_DRIVER_IS(n) (TFTLCD_DRIVER == n)
+
+#if LCD_DRIVER_IS(ILI9325)
+  #define TFTLCD_WRITEMEMORY 0x22
+#else
+  #define TFTLCD_WRITEMEMORY 0x2C
+#endif
 
 #endif

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -34,7 +34,7 @@ void Hardware_GenericInit(void)
     GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);  //disable JTAG & SWD
   #endif
 
-  #if defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
+  #if defined(MKS_32_V1_3) ||defined(MKS_32_V1_4) || defined (MKS_28_V1_0)
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
     GPIO_PinRemapConfig(GPIO_Remap_USART2, ENABLE);
   #endif
@@ -57,7 +57,7 @@ void Hardware_GenericInit(void)
     Buzzer_Config();
   #endif
 
-  #if !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)
+  #if !defined(MKS_32_V1_3) && !defined(MKS_32_V1_4) && !defined (MKS_28_V1_0)
     //causes hang if we deinit spi1
     SD_DeInit();
   #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@
 ;BIGTREE_TFT28_V1_0
 ;BIGTREE_TFT28_V3_0
 ;BIGTREE_TFT24_V1_1
+;MKS_32_V1_3
 ;MKS_32_V1_4
 ;MKS_32_V1_4_NOBL
 ;MKS_28_V1_0
@@ -350,6 +351,27 @@ build_flags   = ${stm32f10x.build_flags}
   -DHARDWARE="BIGTREE_TFT24_V1.1"
   -DHARDWARE_SHORT="B24V11"
   -DTFT24_V1_1=
+
+#
+# MKS TFT32 V1.3
+#
+[env:MKS_32_V1_3]
+platform      = ststm32@9.0.0
+framework     = cmsis
+board         = STM32F107VC_0x7000
+upload_protocol = stlink
+debug_tool = stlink
+src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
+extra_scripts = ${common.extra_scripts}
+                buildroot/scripts/stm32f107xC_0x7000_iap.py
+build_flags   = ${stm32f10x.build_flags}
+  -DSTM32F10X_CL=
+  -DHSE_VALUE=25000000ul
+  -DVECT_TAB_FLASH=0x08007000
+  -DRAM_SIZE=64  ; Available RAM size in kbytes
+  -DHARDWARE="MKS_32_V1_3"
+  -DHARDWARE_SHORT="M32V13"
+  -DMKS_32_V1_3=
 
 #
 # MKS TFT32 V1.4


### PR DESCRIPTION
### Description

This PR adds support for the [ILI9325 LCD](https://cdn-shop.adafruit.com/datasheets/ILI9325.pdf), used by MKS TFT32 1.3 (equivalent to MKS TFT28 V3.0) board. Proposed changes are based on the fork by @Uz45 (https://github.com/Uz45/BIGTREETECH-TouchScreenFirmware)

### Benefits

- Support for ILI9325 LCD
- Support for MKS TFT32 1.3 and MKS TFT28 V3.0 touch controllers (probably older versions too, but can't check those)

### Related Issues

- #1792
- #676
- #617
