### PR TITLE
fix small font in numpad

### DIFF
--- a/TFT/src/User/API/UI/Numpad.c
+++ b/TFT/src/User/API/UI/Numpad.c
@@ -125,6 +125,8 @@ void Draw_keyboard(uint8_t * title, bool NumberOnly, bool negative)
     GUI_SetColor(infoSettings.font_color);
     GUI_HLine(rect_of_numkey[0].x0,rect_of_numkey[0].y0,rect_of_numkey[3].x1);
 
+    setLargeFont(true);
+
     for (uint8_t i = 0; i < KEY_NUM ;i++)
     {
       if (!(i == NUM_KEY_DEC || i == NUM_KEY_MINUS || (i % 4) == 3))  // || i == NUM_KEY_DEL || i == NUM_KEY_EXIT || i == NUM_KEY_RESET) )
@@ -136,11 +138,12 @@ void Draw_keyboard(uint8_t * title, bool NumberOnly, bool negative)
     if (negative)
       GUI_DispStringInPrect(&rect_of_numkey[NUM_KEY_MINUS],(u8*)numPadKeyChar[NUM_KEY_MINUS]);
 
+    setLargeFont(true);
+
     DrawCharIcon(&rect_of_numkey[NUM_KEY_OK], MIDDLE, ICONCHAR_OK, false, 0);
     DrawCharIcon(&rect_of_numkey[NUM_KEY_DEL], MIDDLE, ICONCHAR_POINT_LEFT, false, 0);
     DrawCharIcon(&rect_of_numkey[NUM_KEY_EXIT], MIDDLE, ICONCHAR_CANCEL, false, 0);
     DrawCharIcon(&rect_of_numkey[NUM_KEY_RESET], MIDDLE, ICONCHAR_RESET, false, 0);
-
   #endif // KEYBOARD_MATERIAL_THEME
 
     GUI_DispStringInPrect(&arrowRect,(uint8_t *)"\u089A");


### PR DESCRIPTION
- Fix small font in Numpad when the material theme is diabled. (https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/1846#issuecomment-822658704)