### PR TITLE
Fix corrupt settings after #1864 & reduce memory usage

### DIFF
--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -32,7 +32,7 @@ typedef enum
 #define CONFIG_SUPPPORT 20210321
 
 #define FONT_FLASH_SIGN       20200908  //(YYYYMMDD) change if fonts require updating
-#define CONFIG_FLASH_SIGN     20210421  //(YYYYMMDD) change if any keyword(s) in config.ini is added or removed
+#define CONFIG_FLASH_SIGN     20210422  //(YYYYMMDD) change if any keyword(s) in config.ini is added or removed
 #define LANGUAGE_FLASH_SIGN   20210417  //(YYYYMMDD) change if any keyword(s) in language pack is added or removed
 #define ICON_FLASH_SIGN       20210217  //(YYYYMMDD) change if any icon(s) is added or removed
 

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -57,7 +57,7 @@ bool getConfigFromFile(void)
   char cur_line_buffer[LINE_MAX_CHAR];
   cur_line = cur_line_buffer;
 
-  drawProgressPage((u8*)"Updating Configuration...");
+  drawProgressPage((uint8_t*)"Updating Configuration...");
 
   if (readConfigFile(CONFIG_FILE_PATH, parseConfigLine, LINE_MAX_CHAR))
   {
@@ -101,7 +101,7 @@ bool getLangFromFile(void)
   char cur_line_buffer[MAX_LANG_LABEL_LENGTH + 100];
   cur_line = cur_line_buffer;
 
-  drawProgressPage((u8*)f.fname);
+  drawProgressPage((uint8_t*)f.fname);
 
   // erase part of flash to be rewritten
   for (int i = 0; i < (LANGUAGE_SIZE / W25QXX_SECTOR_SIZE);i++)
@@ -650,7 +650,7 @@ void parseConfigKey(uint16_t index)
       case C_INDEX_MARLIN_TITLE:
       {
         char * pchr = strrchr(cur_line, ':') + 1;
-        int utf8len = getUTF8Length((u8*)pchr);
+        int utf8len = getUTF8Length((uint8_t*)pchr);
         int bytelen = strlen(pchr) + 1;
         if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_STRING_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
           strcpy(configStringsStore->marlin_title, pchr);
@@ -986,7 +986,7 @@ void parseConfigKey(uint16_t index)
     {
       char pchr[LINE_MAX_CHAR];
       strcpy(pchr, strrchr(cur_line, ':') + 1);
-      int utf8len = getUTF8Length((u8 *)pchr);
+      int utf8len = getUTF8Length((uint8_t*)pchr);
       int bytelen = strlen(pchr) + 1;
       if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_GCODE_NAME_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
       {

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -945,7 +945,7 @@ void parseConfigKey(uint16_t index)
       #endif
 
       case C_INDEX_NEOPIXEL_PIXELS:
-        SET_VALID_INT_VALUE(infoSettings.knob_led_idle, 0, MAX_NEOPIXEL_PIXELS);
+        SET_VALID_INT_VALUE(infoSettings.neopixel_pixels, 0, MAX_NEOPIXEL_PIXELS);
         infoSettings.neopixel_pixels = (infoSettings.neopixel_pixels == 0) ? NEOPIXEL_PIXELS : infoSettings.neopixel_pixels;
         break;
     #endif

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -945,8 +945,8 @@ void parseConfigKey(uint16_t index)
       #endif
 
       case C_INDEX_NEOPIXEL_PIXELS:
-          SET_VALID_INT_VALUE(infoSettings.knob_led_idle, 0, MAX_NEOPIXEL_PIXELS);
-        infoSettings.neopixel_pixels = (infoSettings.neopixel_pixels == 0) ? NEOPIXEL_PIXELS: infoSettings.neopixel_pixels;
+        SET_VALID_INT_VALUE(infoSettings.knob_led_idle, 0, MAX_NEOPIXEL_PIXELS);
+        infoSettings.neopixel_pixels = (infoSettings.neopixel_pixels == 0) ? NEOPIXEL_PIXELS : infoSettings.neopixel_pixels;
         break;
     #endif
 

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -17,25 +17,27 @@ const GUI_RECT  recterrortxt      = {BYTE_WIDTH/2,    BYTE_HEIGHT*2+4,    LCD_WI
 const GUI_RECT  rectProgressframe = {BYTE_WIDTH/2-2, LCD_HEIGHT-(BYTE_HEIGHT*2+BYTE_HEIGHT/2), LCD_WIDTH-BYTE_WIDTH/2+2,LCD_HEIGHT-BYTE_HEIGHT/2};
 const GUI_POINT pointProgressText = {BYTE_WIDTH/2-2, LCD_HEIGHT-(BYTE_HEIGHT*4)};
 
-uint16_t foundkeys = 0;
-
-CONFIGFILE * CurConfigFile;
-char * cur_line = NULL;
-static uint16_t c_index = 0;
-
-uint8_t customcode_index = 0;
-uint8_t customcode_good[CUSTOM_GCODES_COUNT];
-bool scheduleRotate = false;
-
-static CUSTOM_GCODES* configCustomGcodes = NULL;
-PRINT_GCODES* configPrintGcodes = NULL;
-STRINGS_STORE* configStringsStore = NULL;
-
 const char * const config_keywords[CONFIG_COUNT] = {
 #define X_CONFIG(NAME) CONFIG_##NAME,
   #include "config.inc"
 #undef X_CONFIG
 };
+
+const char * const cgList[] = CUSTOM_GCODE_LIST;
+const char * const cgNames[] = CUSTOM_GCODE_LABELS;
+const char * const preheatNames[] = PREHEAT_LABELS;
+
+CONFIGFILE* CurConfigFile;
+CUSTOM_GCODES* configCustomGcodes = NULL;
+PRINT_GCODES* configPrintGcodes = NULL;
+STRINGS_STORE* configStringsStore = NULL;
+
+char * cur_line = NULL;
+uint16_t c_index = 0;
+uint16_t foundkeys = 0;
+uint8_t customcode_index = 0;
+uint8_t customcode_good[CUSTOM_GCODES_COUNT];
+bool scheduleRotate = false;
 
 bool getConfigFromFile(void)
 {
@@ -59,7 +61,7 @@ bool getConfigFromFile(void)
 
   if (readConfigFile(CONFIG_FILE_PATH, parseConfigLine, LINE_MAX_CHAR))
   {
-    //store custom codes count
+    // store custom codes count
     configCustomGcodes->count = customcode_index;
 
     PRINTDEBUG("\nCustom gcode stored at 1:");
@@ -101,7 +103,7 @@ bool getLangFromFile(void)
 
   drawProgressPage((u8*)f.fname);
 
-  //erase part of flash to be rewritten
+  // erase part of flash to be rewritten
   for (int i = 0; i < (LANGUAGE_SIZE / W25QXX_SECTOR_SIZE);i++)
   {
     W25Qxx_EraseSector(LANGUAGE_ADDR + (i * W25QXX_SECTOR_SIZE));
@@ -110,13 +112,13 @@ bool getLangFromFile(void)
   if (foundkeys != LABEL_NUM)
     success = false;
   else
-  { //rename file if update was successful
+  {  // rename file if update was successful
     if (!f_file_exists(ADMIN_MODE_FILE) && f_file_exists(langpath))
-    { // language exists
+    {  // language exists
       char newlangpath[256];
       sprintf(newlangpath, "0:%s.CUR", f.fname);
       if (f_file_exists(newlangpath))
-      { // old language also exists
+      {  // old language also exists
         f_unlink(newlangpath);
       }
       f_rename(langpath, newlangpath);
@@ -171,19 +173,18 @@ bool readConfigFile(const char * path, void (*lineParser)(), uint16_t maxLineLen
 
       if (cur_char == '\n')  // start parsing line after new line.
       {
-        comment_mode = false;  //for new command
+        comment_mode = false;  // for new command
         comment_space = true;
         if (count != 0)
         {
-          //cur_line[count++] = '\n';
           cur_line[count++] = '\0';
-          cur_line[count] = 0;  //terminate string
+          cur_line[count] = 0;  // terminate string
           lineParser();
           drawProgress();
 
           PRINTDEBUG("\n");
           PRINTDEBUG(cur_line);
-          count = 0;  //clear buffer
+          count = 0;  // clear buffer
         }
       }
       else if (count < maxLineLen - 2)
@@ -192,11 +193,11 @@ bool readConfigFile(const char * path, void (*lineParser)(), uint16_t maxLineLen
           comment_mode = true;
         else
         {
-          if (comment_space && cur_char != ' ')  //ignore ' ' space bytes
+          if (comment_space && cur_char != ' ')  // ignore ' ' space bytes
             comment_space = false;
-          if (!comment_mode && !comment_space && cur_char != '\r')  //normal code
+          if (!comment_mode && !comment_space && cur_char != '\r')  // normal code
           {
-            if (cur_char == 'n' && last_char == '\\')  //replace "\n" with new line char('\n')
+            if (cur_char == 'n' && last_char == '\\')  // replace "\n" with new line char('\n')
             {
               cur_char = '\n';
               count--;
@@ -207,9 +208,9 @@ bool readConfigFile(const char * path, void (*lineParser)(), uint16_t maxLineLen
             if (configFile.cur == configFile.size)
             {
               cur_line[count++] = '\0';
-              cur_line[count] = 0;  //terminate string
+              cur_line[count] = 0;  // terminate string
               PRINTDEBUG("line read\n");
-              lineParser();  //start parsing at the end of the file.
+              lineParser();  // start parsing at the end of the file.
               drawProgress();
             }
           }
@@ -223,7 +224,7 @@ bool readConfigFile(const char * path, void (*lineParser)(), uint16_t maxLineLen
   }
 }
 
-//check if the value is within min and max limits
+// check if the value is within min and max limits
 bool inLimit(int val, int min, int max)
 {
   if (val < min || val > max)
@@ -237,7 +238,7 @@ bool inLimit(int val, int min, int max)
   }
 }
 
-//check if config keyword exits in the buffer line
+// check if config keyword exits in the buffer line
 bool key_seen(const char * keyStr)
 {
   uint16_t i;
@@ -293,7 +294,7 @@ static float valid_floatValue(float min, float max, float defaultVal)
     return defaultVal;
 }
 
-//check if value is hex format
+// check if value is hex format
 static inline bool config_is_hex(void)
 {
   return (strstr(&cur_line[c_index], "0x") != NULL);
@@ -305,7 +306,7 @@ static inline uint32_t config_hex(void)
   return (strtol(&cur_line[c_index], NULL, 16));
 }
 
-// Get the hex after config keyword.
+// convert RGB888 to RGB565
 static inline uint16_t RGB888_to_RGB565(uint32_t rgb888)
 {
   uint8_t r = ((rgb888 >> 16) & 0xFF) >> 3;  // R5
@@ -326,7 +327,7 @@ static inline void config_set_color(uint16_t *color_src)
   }
 }
 
-//check keywords in the config line in buffer
+// check keywords in the config line in buffer
 void parseConfigLine(void)
 {
   for (uint16_t i = 0; i < CONFIG_COUNT; i++)
@@ -343,7 +344,7 @@ void parseConfigLine(void)
   showError(CSTAT_UNKNOWN_KEYWORD);
 }
 
-//parse keywords from line read from language file
+// parse keywords from line read from language file
 void parseLangLine(void)
 {
   for (int i = 0; i < LABEL_NUM; i++)
@@ -394,7 +395,7 @@ void saveConfig(void)
 
 void writeConfig(uint8_t * dataBytes, uint16_t numBytes, uint32_t addr, uint32_t maxSize)
 {
-  //do not proceed if data size is larger than reserved max size.
+  // do not proceed if data size is larger than reserved max size.
   if (numBytes > maxSize)
   {
     PRINTDEBUG("\nwrite error\n");
@@ -403,49 +404,45 @@ void writeConfig(uint8_t * dataBytes, uint16_t numBytes, uint32_t addr, uint32_t
   }
   int sectorCount = maxSize / W25QXX_SECTOR_SIZE;
 
-  //erase part of flash to be rewritten
+  // erase part of flash to be rewritten
   for (int i = 0; i < sectorCount; i++)
   {
     W25Qxx_EraseSector(addr + (i * W25QXX_SECTOR_SIZE));
   }
-  Delay_ms(100);  //give time for spi flash to settle
-  W25Qxx_WriteBuffer(dataBytes, addr, numBytes);  //write data to spi flash
-  Delay_ms(100);  //give time for spi flash to settle
+  Delay_ms(100);  // give time for spi flash to settle
+  W25Qxx_WriteBuffer(dataBytes, addr, numBytes);  // write data to spi flash
+  Delay_ms(100);  // give time for spi flash to settle
 }
 
-//Reset & store config settings
+// Reset & store config settings
 void resetConfig(void)
 {
-  const char cg_list[][MAX_GCODE_LENGTH] = CUSTOM_GCODE_LIST;
-  const char cg_names[][MAX_GCODE_LENGTH] = CUSTOM_GCODE_LABELS;
-  const char cg_preheatnames[][MAX_GCODE_LENGTH] = PREHEAT_LABELS;
-
   CUSTOM_GCODES tempCG;
   STRINGS_STORE tempST;
   PRINT_GCODES tempPC;
 
-  //restore custom gcode presets
+  // restore custom gcode presets
   int n = 0;
   for (int i = 0; i < CUSTOM_GCODES_COUNT; i++)
   {
     if (default_custom_enabled[i] == 1)
     {
-      strcpy(tempCG.gcode[n],cg_list[i]);
-      strcpy(tempCG.name[n],cg_names[i]);
+      strcpy(tempCG.gcode[n],cgList[i]);
+      strcpy(tempCG.name[n],cgNames[i]);
       n++;
     }
   }
   tempCG.count = n;
 
-  //restore strings store
+  // restore strings store
   strcpy(tempST.marlin_title, MARLIN_BANNER_TEXT);
 
-  for (int i = 0; i < PREHEAT_COUNT;i++)
+  for (int i = 0; i < PREHEAT_COUNT; i++)
   {
-    strcpy(tempST.preheat_name[i],cg_preheatnames[i]);
+    strcpy(tempST.preheat_name[i],preheatNames[i]);
   }
 
-  //restore print gcodes
+  // restore print gcodes
   strcpy(tempPC.start_gcode, PRINT_START_GCODE);
   strcpy(tempPC.end_gcode, PRINT_END_GCODE);
   strcpy(tempPC.cancel_gcode, PRINT_CANCEL_GCODE);
@@ -461,7 +458,6 @@ void drawProgressPage(uint8_t * title)
   GUI_Clear(BLACK);
   GUI_DispString(2, 2, title);
   GUI_FillRectColor(rectTitleline.x0, rectTitleline.y0, rectTitleline.x1, rectTitleline.y1, BLUE);
-  //GUI_DrawPrect(&recterror);
   GUI_DrawPrect(&rectProgressframe);
 }
 
@@ -506,8 +502,7 @@ void showError(CONFIG_STATS stat)
 
     case CSTAT_STORAGE_LOW:
       ttl = "Write Error:";
-      sprintf(tempstr, "Config size is larger than allocated size", CONFIG_FILE_PATH);
-      txt = tempstr;
+      txt = "Config size is larger than allocated size";
       break;
 
     case CSTAT_FILE_INVALID:
@@ -516,8 +511,8 @@ void showError(CONFIG_STATS stat)
       txt = "Invalid config File";
       break;
   }
-  GUI_DispString(recterrortxt.x0, recterrortxt.y0, (u8*)ttl);
-  GUI_DispStringInRect(recterrortxt.x0, recterrortxt.y0 + (BYTE_HEIGHT * 2), recterrortxt.x1, recterrortxt.y1, (u8*)txt);
+  GUI_DispString(recterrortxt.x0, recterrortxt.y0, (uint8_t*)ttl);
+  GUI_DispStringInRect(recterrortxt.x0, recterrortxt.y0 + (BYTE_HEIGHT * 2), recterrortxt.x1, recterrortxt.y1, (uint8_t*)txt);
   GUI_SetColor(WHITE);
   Delay_ms(5000);
 }
@@ -654,8 +649,7 @@ void parseConfigKey(uint16_t index)
 
       case C_INDEX_MARLIN_TITLE:
       {
-        char * pchr;
-        pchr = strrchr(cur_line, ':') + 1;
+        char * pchr = strrchr(cur_line, ':') + 1;
         int utf8len = getUTF8Length((u8*)pchr);
         int bytelen = strlen(pchr) + 1;
         if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_STRING_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
@@ -667,7 +661,7 @@ void parseConfigKey(uint16_t index)
         SET_VALID_INT_VALUE(infoSettings.marlin_type, 0, MODE_COUNT - 1);
         break;
 
-    #endif // ST7920_EMULATOR || LCD2004_EMULATOR
+    #endif  // ST7920_EMULATOR || LCD2004_EMULATOR
 
     //----------------------------RRF Mode Settings
     case C_INDEX_RRF_MACROS_ON:
@@ -951,21 +945,16 @@ void parseConfigKey(uint16_t index)
       #endif
 
       case C_INDEX_NEOPIXEL_PIXELS:
-      {
-        uint16_t pixels = config_int();
-        if (inLimit(pixels, 0, MAX_NEOPIXEL_PIXELS))
-        {
-          infoSettings.neopixel_pixels = pixels ? pixels : NEOPIXEL_PIXELS;
-        }
+          SET_VALID_INT_VALUE(infoSettings.knob_led_idle, 0, MAX_NEOPIXEL_PIXELS);
+        infoSettings.neopixel_pixels = (infoSettings.neopixel_pixels == 0) ? NEOPIXEL_PIXELS: infoSettings.neopixel_pixels;
         break;
-      }
     #endif
 
     #ifdef LCD_LED_PWM_CHANNEL
       case C_INDEX_BRIGHTNESS:
         SET_VALID_INT_VALUE(infoSettings.lcd_brightness, 0, ITEM_BRIGHTNESS_NUM - 1);
         if (infoSettings.lcd_brightness == 0)
-          infoSettings.lcd_brightness = 1; //If someone set it to 0 set it to 1
+          infoSettings.lcd_brightness = 1; // If someone set it to 0 set it to 1
         break;
 
       case C_INDEX_BRIGHTNESS_IDLE:
@@ -996,17 +985,17 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_CUSTOM_LABEL_15:
     {
       char pchr[LINE_MAX_CHAR];
-      strcpy(pchr,strrchr(cur_line, ':') + 1);
-      int utf8len = getUTF8Length((u8*)pchr);
+      strcpy(pchr, strrchr(cur_line, ':') + 1);
+      int utf8len = getUTF8Length((u8 *)pchr);
       int bytelen = strlen(pchr) + 1;
       if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_GCODE_NAME_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
         strcpy(configCustomGcodes->name[customcode_index++], pchr);
-        customcode_good[index - C_INDEX_CUSTOM_LABEL_1] = 1;  //set name was found ok
+        customcode_good[index - C_INDEX_CUSTOM_LABEL_1] = 1;  // set name was found ok
       }
       else
       {
-        customcode_good[index - C_INDEX_CUSTOM_LABEL_1] = 0;  //set name was not ok
+        customcode_good[index - C_INDEX_CUSTOM_LABEL_1] = 0;  // set name was not ok
       }
       break;
     }
@@ -1026,14 +1015,14 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_CUSTOM_GCODE_14:
     case C_INDEX_CUSTOM_GCODE_15:
     {
-      int fileindex = index - C_INDEX_CUSTOM_GCODE_1;  //actual gcode index in config file
+      int lineIndex = index - C_INDEX_CUSTOM_GCODE_1;  // actual gcode index in config file
       char pchr[LINE_MAX_CHAR];
-      strcpy(pchr,strrchr(cur_line, ':') + 1);
+      strcpy(pchr, strrchr(cur_line, ':') + 1);
       int len = strlen(pchr) + 1;
-      //check if gcode length is ok and the name was ok
-      if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH) && (customcode_good[fileindex] == 1))
+      // check if gcode length is ok and the name was ok
+      if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH) && (customcode_good[lineIndex] == 1))
         strcpy(configCustomGcodes->gcode[customcode_index - 1], pchr);
-      else if (customcode_good[fileindex] == 1)  //if name was ok but gcode is not ok then reduce count
+      else if (customcode_good[lineIndex] == 1)  // if name was ok but gcode is not ok then reduce count
         customcode_index--;
       break;
     }
@@ -1054,8 +1043,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_START_GCODE:
     {
-      char * pchr;
-      pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strrchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
@@ -1072,8 +1060,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_END_GCODE:
     {
-      char * pchr;
-      pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strrchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
@@ -1090,8 +1077,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_CANCEL_GCODE:
     {
-      char * pchr;
-      pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strrchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {


### PR DESCRIPTION
- Update config sign after new setting added in #1864 causing invalid settings reading.
- Clean up and reduce memory usage.

Build report:

Device | Old RAM Usage | New RAM usage | RAM Reduced | Old Flash Size | New Flash Size | Flash Size Reduced
-- | -- | -- | -- | -- | -- | --
TFT35 V1.0 | 17544 | 17544 | 0 | 150692 | 148188 | -2504
TFT35 V1.1 | 17544 | 17544 | 0 | 150692 | 148188 | -2504
TFT35 V1.2 | 17544 | 17544 | 0 | 150572 | 148068 | -2504
TFT35 V2 | 18288 | 18288 | 0 | 159984 | 157472 | -2512
TFT35 V3.0 | 18712 | 18712 | 0 | 178244 | 175740 | -2504
TFT35 E3 V3.0 | 18716 | 18716 | 0 | 178924 | 176420 | -2504
TFT35 B1 V3.0 | 18716 | 18716 | 0 | 178924 | 176420 | -2504
TFT43 V3.0 | 18716 | 18716 | 0 | 178936 | 176424 | -2512
TFT50 V3.0 | 18716 | 18716 | 0 | 178936 | 176424 | -2512
TFT70 V3.0 | 18844 | 18844 | 0 | 180092 | 177580 | -2512
TFT28 V1.0 | 17544 | 17544 | 0 | 150740 | 148228 | -2512
TFT28 V3.0 | 18716 | 18716 | 0 | 178764 | 176252 | -2512
TFT24 V1.1 | 18688 | 18688 | 0 | 174220 | 171716 | -2504
MKS TFT32 V1.3 | 18624 | 18624 | 0 | 173792 | 171280 | -2512
MKS TFT32 V1.4 | 18624 | 18624 | 0 | 174240 | 171728 | -2512

