### PR TITLE
improved robustness of Printing menu during a dialog with Marlin

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -23,8 +23,8 @@
 # Supported Marlin Firmware Versions
 #--------------------------------------------------------------------
 #
-# Minimum Marlin firmware version: 2.0.5.4
-# Distribution date: 2020-05-12
+# Minimum Marlin firmware version: 2.0.8.1
+# Distribution date: 2021-05-15
 # Firmware source: https://github.com/MarlinFirmware/Marlin/releases
 #
 # In order the TFT firmware is able to provide all of its functionalities/features,

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -23,8 +23,8 @@
 # Supported Marlin Firmware Versions
 #--------------------------------------------------------------------
 #
-# Minimum Marlin firmware version: 2.0.5.4
-# Distribution date: 2020-05-12
+# Minimum Marlin firmware version: 2.0.8.1
+# Distribution date: 2021-05-15
 # Firmware source: https://github.com/MarlinFirmware/Marlin/releases
 #
 # In order the TFT firmware is able to provide all of its functionalities/features,

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -12,6 +12,7 @@ static const char messagemagic[] = "message";                      // RRF messag
 static const char errorZProbe[] = "ZProbe triggered before move";  // smoothieware message
 
 bool portSeen[_UART_CNT] = {false, false, false, false, false, false};
+bool hostDialog = false;
 
 struct HOST_ACTION
 {
@@ -258,6 +259,11 @@ void hostActionCommands(void)
   }
   else if (ack_seen(":paused") || ack_seen(":pause"))
   {
+    if (ack_seen(":paused"))  // if paused with ADVANCED_PAUSE_FEATURE enabled in Marlin (:paused),
+      hostDialog = true;      // disable Resume/Pause button in the Printing menu
+    //else                      // otherwise, if ADVANCED_PAUSE_FEATURE is disabled in Marlin (:pause),
+    //  hostDialog = false;     // enable Resume/Pause button in the Printing menu
+
     // pass value "false" to let Marlin report when the host is not
     // printing (when notification ack "Not SD printing" is caught)
     setPrintPause(false, PAUSE_EXTERNAL);
@@ -269,6 +275,8 @@ void hostActionCommands(void)
   }
   else if (ack_seen(":resumed") || ack_seen(":resume"))
   {
+    hostDialog = false;  // enable Resume/Pause button in the Printing menu
+
     // pass value "true" to report the host is printing without waiting
     // from Marlin (when notification ack "SD printing byte" is caught)
     setPrintResume(true);

--- a/TFT/src/User/API/parseACK.h
+++ b/TFT/src/User/API/parseACK.h
@@ -10,6 +10,8 @@ extern "C" {
 
 #define ACK_MAX_SIZE 512
 
+extern bool hostDialog;
+
 typedef enum  // append at the end of this list the id of any new echo message for
 {             // which a specific popup message type must be used to notify the user
   ECHO_ID_BUSY_PAUSE = 0,
@@ -37,6 +39,7 @@ void setCurrentAckSrc(uint8_t src);
 void parseACK(void);
 void parseRcvGcode(void);
 
+inline bool isHostDialog() {return hostDialog;}
 void setIgnoreEcho(ECHO_ID msgId, bool state);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -488,7 +488,10 @@ void menuPrinting(void)
       case KEY_ICON_4:
         if (isPrinting())
         {
-          printPause(!isPaused(), PAUSE_NORMAL);
+          if (!isHostDialog())
+            printPause(!isPaused(), PAUSE_NORMAL);
+          else
+            addToast(DIALOG_TYPE_ERROR, (char *)textSelect(LABEL_BUSY));
         }
         #ifndef TFT70_V3_0
           else

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -23,8 +23,8 @@
 # Supported Marlin Firmware Versions
 #--------------------------------------------------------------------
 #
-# Minimum Marlin firmware version: 2.0.5.4
-# Distribution date: 2020-05-12
+# Minimum Marlin firmware version: 2.0.8.1
+# Distribution date: 2021-05-15
 # Firmware source: https://github.com/MarlinFirmware/Marlin/releases
 #
 # In order the TFT firmware is able to provide all of its functionalities/features,


### PR DESCRIPTION
**IMPROVEMENTS:**
* improved robustness of Printing menu during a dialog with Marlin (e.g. printing from onboard SD). Now when a dialog with Marlin is ongoing (e.g. M600) pressing on the "Resume" button will be simply ignored and an error message "busy processing, please wait..." is displayed on the notification bar just to inform the user that a dialog with Marlin is ongoing and it must be first completed.
* config.ini has been updated reporting Marlin 2.0.8.1 as the suggested minimum version fully compliant with TFT fw

**PR STATUS:** ready to merge

**NOTE:**
1)  bug https://github.com/MarlinFirmware/Marlin/issues/21813 needs to be fixed in order to cover all the possible Marlin settings
2) PR https://github.com/MarlinFirmware/Marlin/pull/21828 fixing the above bug on Marlin must be merged on Marlin

**EDIT 2021-05-16:**
* Marlin PR #21828 is present in the new official Marlin 2.0.8.1 so this PR is ready to be merged now
* config.ini has been updated reporting Marlin 2.0.8.1 as the suggested minimum version fully compliant with TFT fw
