### PR TITLE
friendly z offset icons/labels for inverted Z axis

### DIFF
--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -106,6 +106,8 @@ void menuBabystep(void)
   now_z_offset = z_offset = orig_z_offset = new_z_offset = offsetGetValue();
   force_z_offset = false;
 
+  UPDATE_MENU_IF_INVERTED_Z_AXIS(&babyStepItems);
+
   if (infoMachineSettings.EEPROM == 1)
   {
     babyStepItems.items[KEY_ICON_4].icon = ICON_EEPROM_SAVE;

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -106,7 +106,7 @@ void menuBabystep(void)
   now_z_offset = z_offset = orig_z_offset = new_z_offset = offsetGetValue();
   force_z_offset = false;
 
-  UPDATE_MENU_IF_INVERTED_Z_AXIS(&babyStepItems);
+  INVERT_Z_AXIS_ICONS(&babyStepItems);
 
   if (infoMachineSettings.EEPROM == 1)
   {

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -159,6 +159,7 @@ void menuMBL(void)
 
   now = curValue = coordinateGetAxisActual(Z_AXIS);
 
+  UPDATE_MENU_IF_INVERTED_Z_AXIS(&mblItems);
   mblItems.items[KEY_ICON_4] = itemMoveLen[curUnit_index];
 
   if (mblRunning)

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -159,7 +159,7 @@ void menuMBL(void)
 
   now = curValue = coordinateGetAxisActual(Z_AXIS);
 
-  UPDATE_MENU_IF_INVERTED_Z_AXIS(&mblItems);
+  INVERT_Z_AXIS_ICONS(&mblItems);
   mblItems.items[KEY_ICON_4] = itemMoveLen[curUnit_index];
 
   if (mblRunning)

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -95,6 +95,7 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
 
   now = curValue = coordinateGetAxisActual(Z_AXIS);
 
+  UPDATE_MENU_IF_INVERTED_Z_AXIS(&meshItems);
   meshItems.items[KEY_ICON_4] = itemMoveLen[curUnit_index];
 
   menuDrawPage(&meshItems);

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -95,7 +95,7 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
 
   now = curValue = coordinateGetAxisActual(Z_AXIS);
 
-  UPDATE_MENU_IF_INVERTED_Z_AXIS(&meshItems);
+  INVERT_Z_AXIS_ICONS(&meshItems);
   meshItems.items[KEY_ICON_4] = itemMoveLen[curUnit_index];
 
   menuDrawPage(&meshItems);

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -131,6 +131,7 @@ void menuZOffset(void)
 
   now = z_offset = offsetGetValue();
 
+  UPDATE_MENU_IF_INVERTED_Z_AXIS(&zOffsetItems);
   zOffsetItems.items[KEY_ICON_4].label = itemToggle[offsetGetStatus()];
 
   itemZOffsetSubmenu[0] = itemMoveLen[curUnit_index];

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -131,7 +131,7 @@ void menuZOffset(void)
 
   now = z_offset = offsetGetValue();
 
-  UPDATE_MENU_IF_INVERTED_Z_AXIS(&zOffsetItems);
+  INVERT_Z_AXIS_ICONS(&zOffsetItems);
   zOffsetItems.items[KEY_ICON_4].label = itemToggle[offsetGetStatus()];
 
   itemZOffsetSubmenu[0] = itemMoveLen[curUnit_index];

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -114,6 +114,19 @@ bool nextScreenUpdate(uint32_t duration)
   }
 }
 
+#ifdef FRIENDLY_Z_OFFSET_LANGUAGE
+  void updateMenuIfInvertedZAxis(MENUITEMS * menuItems)
+  {
+    if (infoSettings.invert_axis[Z_AXIS] == 1)
+    {
+      menuItems->items[KEY_ICON_0].icon = ICON_Z_INC;
+      menuItems->items[KEY_ICON_0].label.index = LABEL_UP;
+      menuItems->items[KEY_ICON_3].icon = ICON_Z_DEC;
+      menuItems->items[KEY_ICON_3].label.index = LABEL_DOWN;
+    }
+  }
+#endif
+
 void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance)
 {
   //uint16_t origColor = GUI_GetColor();

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -115,7 +115,7 @@ bool nextScreenUpdate(uint32_t duration)
 }
 
 #ifdef FRIENDLY_Z_OFFSET_LANGUAGE
-  void updateMenuIfInvertedZAxis(MENUITEMS * menuItems)
+  void invertZAxisIcons(MENUITEMS * menuItems)
   {
     if (infoSettings.invert_axis[Z_AXIS] == 1)
     {

--- a/TFT/src/User/Menu/common.h
+++ b/TFT/src/User/Menu/common.h
@@ -52,6 +52,14 @@ extern const uint16_t iconToggle[ITEM_TOGGLE_NUM];
 // Check if next screen update is due
 bool nextScreenUpdate(uint32_t duration);
 
+#ifdef FRIENDLY_Z_OFFSET_LANGUAGE
+  void updateMenuIfInvertedZAxis(MENUITEMS * menuItems);
+
+  #define UPDATE_MENU_IF_INVERTED_Z_AXIS(menuItemsPtr) updateMenuIfInvertedZAxis(menuItemsPtr)
+#else
+  #define UPDATE_MENU_IF_INVERTED_Z_AXIS(menuItemsPtr)
+#endif
+
 void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance);
 
 void drawBackground(const GUI_RECT *rect, uint16_t bgColor, uint16_t edgeDistance);

--- a/TFT/src/User/Menu/common.h
+++ b/TFT/src/User/Menu/common.h
@@ -53,11 +53,11 @@ extern const uint16_t iconToggle[ITEM_TOGGLE_NUM];
 bool nextScreenUpdate(uint32_t duration);
 
 #ifdef FRIENDLY_Z_OFFSET_LANGUAGE
-  void updateMenuIfInvertedZAxis(MENUITEMS * menuItems);
+  void invertZAxisIcons(MENUITEMS * menuItems);
 
-  #define UPDATE_MENU_IF_INVERTED_Z_AXIS(menuItemsPtr) updateMenuIfInvertedZAxis(menuItemsPtr)
+  #define  INVERT_Z_AXIS_ICONS(menuItemsPtr) invertZAxisIcons(menuItemsPtr)
 #else
-  #define UPDATE_MENU_IF_INVERTED_Z_AXIS(menuItemsPtr)
+  #define  INVERT_Z_AXIS_ICONS(menuItemsPtr)
 #endif
 
 void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance);


### PR DESCRIPTION
If FRIENDLY_Z_OFFSET_LANGUAGE is enabled (in Configuration.h) and inverted Z axis is configured (in config.ini), icons "arrow up"/"arrow down" and labels "up/"down" are used in menus Babystep, MBL, Mesh Tuner and Z offset instead of icons "nozzle down"/"nozzle up" and labels "down"/"up".

fixes #1918
fixes #1926

**PR STATE:** ready to merge