### PR TITLE
TFT35 compatible with both ILI9488 and NT35310

### DIFF
--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -7,31 +7,6 @@ uint16_t backGroundColor = BLACK;
 GUI_TEXT_MODE guiTextMode = GUI_TEXTMODE_NORMAL;
 GUI_NUM_MODE guiNumMode = GUI_NUMMODE_SPACE;
 
-void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
-{
-  #if LCD_DRIVER_IS(ILI9325)
-    LCD_WR_REG(0x50);
-    LCD_WR_DATA(sy);
-    LCD_WR_REG(0x52);
-    LCD_WR_DATA(sx);
-    LCD_WR_REG(0x51);
-    LCD_WR_DATA(ey);
-    LCD_WR_REG(0x53);
-    LCD_WR_DATA(ex);
-    LCD_WR_REG(0x20);
-    LCD_WR_DATA(sy);
-    LCD_WR_REG(0x21);
-    LCD_WR_DATA(sx);
-  #else
-    LCD_WR_REG(0x2A);
-    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
-    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
-    LCD_WR_REG(0x2B);
-    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
-    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
-  #endif
-}
-
 void GUI_SetColor(uint16_t color)
 {
   foreGroundColor = color;
@@ -76,7 +51,6 @@ void GUI_Clear(uint16_t color)
 {
   uint32_t index=0;
   LCD_SetWindow(0, 0, LCD_WIDTH-1, LCD_HEIGHT-1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (index=0; index<LCD_WIDTH*LCD_HEIGHT; index++)
   {
     LCD_WR_16BITS_DATA(color);
@@ -115,14 +89,12 @@ void GUI_DrawPixel(int16_t x, int16_t y, uint16_t color)
     return ;
 
   LCD_SetWindow(x, y, x, y);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   LCD_WR_16BITS_DATA(color);
 }
 
 void GUI_DrawPoint(uint16_t x, uint16_t y)
 {
   LCD_SetWindow(x, y, x, y);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   LCD_WR_16BITS_DATA(foreGroundColor);
 }
 
@@ -136,7 +108,6 @@ void GUI_FillRect(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
 {
   uint16_t i=0, j=0;
   LCD_SetWindow( sx, sy, ex-1, ey-1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -161,7 +132,6 @@ void GUI_ClearRect(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
 {
   uint16_t i=0, j=0;
   LCD_SetWindow( sx, sy, ex-1, ey-1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -187,7 +157,6 @@ void GUI_FillRectColor(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey, uint1
 {
   uint16_t i=0, j=0;
   LCD_SetWindow(sx, sy, ex-1, ey-1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=sx; i<ex; i++)
   {
     for (j=sy; j<ey; j++)
@@ -201,7 +170,6 @@ void GUI_FillRectArry(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey, uint8_
 {
   uint16_t i = 0, j = 0, color;
   LCD_SetWindow(sx, sy, ex - 1, ey - 1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i = sx; i < ex; i++)
   {
     for (j = sy; j < ey; j++)
@@ -291,7 +259,6 @@ void GUI_HLine(uint16_t x1, uint16_t y, uint16_t x2)
 {
   uint16_t i=0;
   LCD_SetWindow(x1, y, x2-1, y);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=x1; i<x2; i++)
   {
     LCD_WR_16BITS_DATA(foreGroundColor);
@@ -307,7 +274,6 @@ void GUI_VLine(uint16_t x, uint16_t y1, uint16_t y2)
 {
   uint16_t i=0;
   LCD_SetWindow(x, y1, x, y2-1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (i=y1; i<y2; i++)
   {
     LCD_WR_16BITS_DATA(foreGroundColor);

--- a/TFT/src/User/API/UI/GUI.h
+++ b/TFT/src/User/API/UI/GUI.h
@@ -44,9 +44,6 @@ typedef struct
   int16_t x0, y0, x1, y1;
 } GUI_RECT;
 
-void LCD_SetCursor(uint16_t Xpos, uint16_t Ypos);
-void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
-
 void GUI_SetColor(uint16_t color);
 uint16_t GUI_GetColor(void);
 void GUI_SetBkColor(uint16_t bkcolor);

--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -14,7 +14,6 @@ void lcd_frame_display(uint16_t sx, uint16_t sy, uint16_t w, uint16_t h, uint32_
   uint32_t address = addr;
 
   LCD_SetWindow(sx, sy, sx + w - 1, sy + h - 1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
 
   W25Qxx_SPI_CS_Set(0);
   W25Qxx_SPI_Read_Write_Byte(CMD_READ_DATA);
@@ -81,7 +80,6 @@ bool model_DirectDisplay(GUI_POINT pos, char *gcode)
   f_lseek(&gcodeFile, gcodeFile.fptr + 3);
 
   LCD_SetWindow(pos.x, pos.y, pos.x + ICON_WIDTH - 1, pos.y + ICON_HEIGHT - 1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
   for (uint16_t y = 0; y < ICON_HEIGHT; y++)
   {
     for (uint16_t x = 0; x < ICON_WIDTH; x++)
@@ -169,7 +167,6 @@ void ICON_PressedDisplay(uint16_t sx, uint16_t sy, uint8_t icon)
   uint32_t address = getBMPsize((uint8_t *)&w, (uint8_t *)&h, ICON_ADDR(icon));
 
   LCD_SetWindow(sx, sy, sx + w - 1, sy + h - 1);
-  LCD_WR_REG(TFTLCD_WRITEMEMORY);
 
   W25Qxx_SPI_CS_Set(0);
   W25Qxx_SPI_Read_Write_Byte(CMD_READ_DATA);

--- a/TFT/src/User/Hal/LCD_Driver/HX8558.c
+++ b/TFT/src/User/Hal/LCD_Driver/HX8558.c
@@ -1,0 +1,140 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(HX8558)
+
+  #include "HX8558.h"
+  // HX8558
+  void HX8558_Init_Sequential(void)
+  {
+    Delay_ms(50);  // delay 50 ms
+
+    LCD_WR_REG(0xFE);
+    LCD_WR_REG(0xEF);
+    LCD_WR_REG(0x3A);
+    LCD_WR_DATA(5);
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(0x64);
+    LCD_WR_REG(0xE8);
+    LCD_WR_DATA(0x12);
+    LCD_WR_DATA(0x22);
+    LCD_WR_REG(0xE3);
+    LCD_WR_DATA(1);
+    LCD_WR_DATA(4);
+    LCD_WR_REG(0xA5);
+    LCD_WR_DATA(0x40);
+    LCD_WR_DATA(0x40);
+    LCD_WR_REG(0xA4);
+    LCD_WR_DATA(0x44);
+    LCD_WR_DATA(0x44);
+    LCD_WR_REG(0xAB);
+    LCD_WR_DATA(8);
+    LCD_WR_REG(0xAA);
+    LCD_WR_DATA(0x88);
+    LCD_WR_DATA(0x88);
+    LCD_WR_REG(0xAE);
+    LCD_WR_DATA(0xB);
+    LCD_WR_REG(0xAC);
+    LCD_WR_DATA(0);
+    LCD_WR_REG(0xAF);
+    LCD_WR_DATA(0x77);
+    LCD_WR_REG(0xAD);
+    LCD_WR_DATA(0x77);
+
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0xEF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(1);
+    LCD_WR_DATA(0x3F);
+
+    LCD_WR_REG(0x2C);
+
+    LCD_WR_REG(0xF0);
+    LCD_WR_DATA(2);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(1);
+    LCD_WR_DATA(1);
+    LCD_WR_DATA(7);
+
+    LCD_WR_REG(0xF1);
+    LCD_WR_DATA(1);
+    LCD_WR_DATA(3);
+    LCD_WR_DATA(0);
+    LCD_WR_DATA(0x36);
+    LCD_WR_DATA(41);
+    LCD_WR_DATA(0x13);
+
+    LCD_WR_REG(0xF2);
+    LCD_WR_DATA(8);
+    LCD_WR_DATA(6);
+    LCD_WR_DATA(0x24);
+    LCD_WR_DATA(3);
+    LCD_WR_DATA(5);
+    LCD_WR_DATA(0x34);
+
+    LCD_WR_REG(0xF3);
+    LCD_WR_DATA(0x16);
+    LCD_WR_DATA(0xC);
+    LCD_WR_DATA(0x5A);
+    LCD_WR_DATA(4);
+    LCD_WR_DATA(3);
+    LCD_WR_DATA(0x69);
+
+    LCD_WR_REG(0xF4);
+    LCD_WR_DATA(0xD);
+    LCD_WR_DATA(0x18);
+    LCD_WR_DATA(0x15);
+    LCD_WR_DATA(5);
+    LCD_WR_DATA(5);
+    LCD_WR_DATA(0);
+
+    LCD_WR_REG(0xF5);
+    LCD_WR_DATA(0xD);
+    LCD_WR_DATA(0x18);
+    LCD_WR_DATA(0x17);
+    LCD_WR_DATA(0x35);
+    LCD_WR_DATA(0x39);
+    LCD_WR_DATA(0);
+    LCD_WR_REG(0x11);
+
+    Delay_ms(150);
+
+    LCD_WR_REG(0x29);
+    LCD_WR_REG(0x2C);
+  }
+
+  void HX8558_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? HX8558_180_DEGREE_REG_VALUE : HX8558_0_DEGREE_REG_VALUE);
+  }
+
+  void HX8558_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t HX8558_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X22);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    GUI_COLOR pix;
+    pix.color = LCD_RD_DATA();
+    return (pix.RGB.r << 19) | (pix.RGB.g << 10) | (pix.RGB.b << 3);
+  }
+
+#endif  // LCD_DRIVER_HAS(HX8558)

--- a/TFT/src/User/Hal/LCD_Driver/HX8558.h
+++ b/TFT/src/User/Hal/LCD_Driver/HX8558.h
@@ -1,0 +1,21 @@
+#ifndef _HX8558_H_
+#define _HX8558_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HX8558_0_DEGREE_REG_VALUE   0xA4
+#define HX8558_180_DEGREE_REG_VALUE 0X64
+
+uint8_t LCD_DriveIsHX8558(void);
+void HX8558_Init_Sequential(void);
+void HX8558_SetDirection(uint8_t rotate);
+void HX8558_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t HX8558_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/ILI9325.c
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9325.c
@@ -1,0 +1,54 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(ILI9325)
+
+  #include "ILI9325.h"
+  // ILI9325
+  void ILI9325_Init_Sequential(void)
+  {
+    uint16_t R01h, R03h, R60h;
+    R01h = (1 << 8) | (0 << 10);                        // SS = 1, SM = 0,  from S720 to S1 (see also  GS bit (R60h))
+    R03h = (1 << 12) | (1 << 5) | (1 << 4) | (1 << 3);  // TRI=0, DFM=0, BGR=1, ORG=0, I/D[1:0]=11, AM=1
+    R60h = (0 << 15) | (0x27 << 8);                     // Gate Scan Control (R60h) GS=0(G1) NL[5:0]=0x27 (320 lines)
+
+    LCD_WR_REG(0x0001); // Driver Output Control Register (R01h)
+    LCD_WR_DATA(R01h);
+    LCD_WR_REG(0x0003); // Entry Mode (R03h)
+    LCD_WR_DATA(R03h);
+    LCD_WR_REG(0x0060); // Driver Output Control (R60h)
+    LCD_WR_DATA(R60h);
+  }
+
+  void ILI9325_SetDirection(uint8_t dir)
+  {
+    uint16_t R01h, R03h, R60h;
+    R01h = (dir ? 0 : 1 << 8) | (0 << 10);     // SS=horizontal flip, SM=0
+    R03h = (1 << 12) | (1 << 5) | (1 << 4) | (1 << 3);            // TRI=0, DFM=0, BGR=1, ORG=0, I/D[1:0]=11, AM=1
+    R60h = (dir ? 1 : 0 << 15) | (0x27 << 8);  // GS=vertical flip, NL[5:0]=0x27 (320 lines)
+
+    LCD_WR_REG(0x0001); // Driver Output Control Register (R01h)
+    LCD_WR_DATA(R01h);
+    LCD_WR_REG(0x0003); // Entry Mode (R03h)
+    LCD_WR_DATA(R03h);
+    LCD_WR_REG(0x0060); // Driver Output Control (R60h)
+    LCD_WR_DATA(R60h);
+  }
+
+  void ILI9325_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x50);
+    LCD_WR_DATA(sy);
+    LCD_WR_REG(0x52);
+    LCD_WR_DATA(sx);
+    LCD_WR_REG(0x51);
+    LCD_WR_DATA(ey);
+    LCD_WR_REG(0x53);
+    LCD_WR_DATA(ex);
+    LCD_WR_REG(0x20);
+    LCD_WR_DATA(sy);
+    LCD_WR_REG(0x21);
+    LCD_WR_DATA(sx);
+    LCD_WR_REG(0x22);  // Ready to write memory
+  }
+
+#endif  // LCD_DRIVER_HAS(ILI9325)

--- a/TFT/src/User/Hal/LCD_Driver/ILI9325.h
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9325.h
@@ -1,0 +1,18 @@
+#ifndef _ILI9325_H_
+#define _ILI9325_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t LCD_DriveIsILI9325(void);
+void ILI9325_Init_Sequential(void);
+void ILI9325_SetDirection(uint8_t rotate);
+void ILI9325_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t ILI9325_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/ILI9341.c
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9341.c
@@ -1,0 +1,156 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(ILI9341)
+
+  #include "ILI9341.h"
+  // ILI9341
+  void ILI9341_Init_Sequential(void)
+  {
+    Delay_ms(50);  // delay 50 ms
+
+    LCD_WR_REG(0xCF);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0xC1);
+    LCD_WR_DATA(0X30);
+
+    LCD_WR_REG(0xED);
+    LCD_WR_DATA(0x64);
+    LCD_WR_DATA(0x03);
+    LCD_WR_DATA(0X12);
+    LCD_WR_DATA(0X81);
+
+    LCD_WR_REG(0xE8);   /// @diff :Driver timing control A
+    LCD_WR_DATA(0x8A);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x78);
+
+    LCD_WR_REG(0xEA);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+
+    LCD_WR_REG(0xCB);
+    LCD_WR_DATA(0x39);
+    LCD_WR_DATA(0x2C);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x34);
+    LCD_WR_DATA(0x02);
+
+    LCD_WR_REG(0xF7);
+    LCD_WR_DATA(0x20);
+
+    LCD_WR_REG(0xC0);   /// @diff Power control
+    LCD_WR_DATA(0x25);  // VRH[5:0]
+
+    LCD_WR_REG(0xC1);   /// @diff control
+    LCD_WR_DATA(0x12);  // SAP[2:0];BT[3:0]
+
+    LCD_WR_REG(0xC5);   /// @diff VCM control
+    LCD_WR_DATA(0x33);
+    LCD_WR_DATA(0x3C);
+
+    LCD_WR_REG(0xC7);   /// @diff VCM control2
+    LCD_WR_DATA(0x9A);
+
+    LCD_WR_REG(0xB1);   /// @diff Frame Rate Control
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x15);
+
+    LCD_WR_REG(0x3A);
+    LCD_WR_DATA(0x55);
+
+    LCD_WR_REG(0x36);   // Memory Access Control
+    LCD_WR_DATA(0x68);
+
+    LCD_WR_REG(0xB6);   // Display Function Control
+    LCD_WR_DATA(0x0A);
+    LCD_WR_DATA(0xA2);
+
+    LCD_WR_REG(0xF2);   // 3Gamma Function Disable
+    LCD_WR_DATA(0x00);
+
+    LCD_WR_REG(0x26);   // Gamma curve selected
+    LCD_WR_DATA(0x01);
+
+    LCD_WR_REG(0xE0);   /// @diff Set Gamma
+    LCD_WR_DATA(0x1F);
+    LCD_WR_DATA(0x1C);
+    LCD_WR_DATA(0x1A);
+    LCD_WR_DATA(0x0B);
+    LCD_WR_DATA(0x0F);
+    LCD_WR_DATA(0x08);
+    LCD_WR_DATA(0x47);
+    LCD_WR_DATA(0xC8);
+    LCD_WR_DATA(0x37);
+    LCD_WR_DATA(0x0B);
+    LCD_WR_DATA(0x14);
+    LCD_WR_DATA(0x05);
+    LCD_WR_DATA(0x0A);
+    LCD_WR_DATA(0x08);
+    LCD_WR_DATA(0x00);
+
+    LCD_WR_REG(0XE1);   /// @diff Set Gamma
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x24);
+    LCD_WR_DATA(0x25);
+    LCD_WR_DATA(0x04);
+    LCD_WR_DATA(0x10);
+    LCD_WR_DATA(0x07);
+    LCD_WR_DATA(0x38);
+    LCD_WR_DATA(0x48);
+    LCD_WR_DATA(0x48);
+    LCD_WR_DATA(0x03);
+    LCD_WR_DATA(0x0B);
+    LCD_WR_DATA(0x0A);
+    LCD_WR_DATA(0x35);
+    LCD_WR_DATA(0x37);
+    LCD_WR_DATA(0x1F);
+
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x01);
+    LCD_WR_DATA(0x3f);
+
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0xef);
+
+    LCD_WR_REG(0x11);   // Exit Sleep
+    Delay_ms(120);
+    LCD_WR_REG(0x29);   // Display on
+  }
+
+  void ILI9341_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? ILI9341_180_DEGREE_REG_VALUE : ILI9341_0_DEGREE_REG_VALUE);
+  }
+
+  void ILI9341_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t ILI9341_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    uint16_t rg, br;
+    rg = LCD_RD_DATA();  // First pixel R:8bit-G:8bit
+    br = LCD_RD_DATA();  // First pixel B:8bit - Second pixel R:8bit
+
+    return ((rg) << 8) | ((br & 0xFF00) >> 8);  // RG-B
+  }
+
+#endif  // LCD_DRIVER_HAS(ILI9341)

--- a/TFT/src/User/Hal/LCD_Driver/ILI9341.h
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9341.h
@@ -1,0 +1,21 @@
+#ifndef _ILI9341_H_
+#define _ILI9341_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ILI9341_0_DEGREE_REG_VALUE   0X68
+#define ILI9341_180_DEGREE_REG_VALUE 0XA8
+
+uint8_t LCD_DriveIsILI9341(void);
+void ILI9341_Init_Sequential(void);
+void ILI9341_SetDirection(uint8_t rotate);
+void ILI9341_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t ILI9341_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/ILI9488.c
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9488.c
@@ -1,0 +1,87 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(ILI9488)
+
+  #include "ILI9488.h"
+  // ILI9488
+  uint8_t LCD_DriveIsILI9488(void)
+  {
+    uint16_t id = 0;
+    LCD_WR_REG(0XD3);
+    id = LCD_RD_DATA();  // dummy read
+    id = LCD_RD_DATA();
+    id = LCD_RD_DATA();
+    id <<= 8;
+
+    id |= LCD_RD_DATA();
+    return (id == 0x9488);
+  }
+
+  void ILI9488_Init_Sequential(void)
+  {
+    LCD_WR_REG(0xC0);
+    LCD_WR_DATA(0x0c);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xC1);
+    LCD_WR_DATA(0x44);
+    LCD_WR_REG(0xC5);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x16);
+    LCD_WR_DATA(0x80);
+    LCD_WR_REG(0x36);
+    LCD_WR_DATA(0x28);
+    LCD_WR_REG(0x3A);   // Interface Mode Control
+    LCD_WR_DATA(0x55);
+    LCD_WR_REG(0XB0);   // Interface Mode Control
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0xB1);   // Frame rate 70HZ
+    LCD_WR_DATA(0xB0);
+    LCD_WR_REG(0xB4);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xB6);   // RGB/MCU Interface Control
+    LCD_WR_DATA(0x02);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xE9);
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0XF7);
+    LCD_WR_DATA(0xA9);
+    LCD_WR_DATA(0x51);
+    LCD_WR_DATA(0x2C);
+    LCD_WR_DATA(0x82);
+    LCD_WR_REG(0x11);
+    Delay_ms(120);
+    LCD_WR_REG(0x29);
+  }
+
+  void ILI9488_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? ILI9488_180_DEGREE_REG_VALUE : ILI9488_0_DEGREE_REG_VALUE);
+  }
+
+  void ILI9488_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t ILI9488_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    uint16_t rg, br;
+    rg = LCD_RD_DATA();  // First pixel R:8bit-G:8bit
+    br = LCD_RD_DATA();  // First pixel B:8bit - Second pixel R:8bit
+
+    return ((rg) << 8) | ((br & 0xFF00) >> 8);  // RG-B
+  }
+
+#endif  // LCD_DRIVER_HAS(ILI9488)

--- a/TFT/src/User/Hal/LCD_Driver/ILI9488.h
+++ b/TFT/src/User/Hal/LCD_Driver/ILI9488.h
@@ -1,0 +1,21 @@
+#ifndef _ILI9488_H_
+#define _ILI9488_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ILI9488_0_DEGREE_REG_VALUE   0X28
+#define ILI9488_180_DEGREE_REG_VALUE 0XE8
+
+uint8_t LCD_DriveIsILI9488(void);
+void ILI9488_Init_Sequential(void);
+void ILI9488_SetDirection(uint8_t rotate);
+void ILI9488_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t ILI9488_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/NT35310.c
+++ b/TFT/src/User/Hal/LCD_Driver/NT35310.c
@@ -1,0 +1,87 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(NT35310)
+
+  #include "NT35310.h"
+  // NT35310
+  uint8_t LCD_DriveIsNT35310(void)
+  {
+    uint16_t id = 0;
+    LCD_WR_REG(0XD4);
+    id = LCD_RD_DATA();  // dummy read
+    id = LCD_RD_DATA();
+    id = LCD_RD_DATA();
+    id <<= 8;
+
+    id |= LCD_RD_DATA();
+    return (id == 0x5310);
+  }
+
+  void NT35310_Init_Sequential(void)
+  {
+    LCD_WR_REG(0xC0);
+    LCD_WR_DATA(0x0c);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xC1);
+    LCD_WR_DATA(0x44);
+    LCD_WR_REG(0xC5);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x16);
+    LCD_WR_DATA(0x80);
+    LCD_WR_REG(0x36);
+    LCD_WR_DATA(0X60);
+    LCD_WR_REG(0x3A);   // Interface Mode Control
+    LCD_WR_DATA(0x55);
+    LCD_WR_REG(0XB0);   // Interface Mode Control
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0xB1);   // Frame rate 70HZ
+    LCD_WR_DATA(0xB0);
+    LCD_WR_REG(0xB4);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xB6);   // RGB/MCU Interface Control
+    LCD_WR_DATA(0x02);
+    LCD_WR_DATA(0x02);
+    LCD_WR_REG(0xE9);
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0XF7);
+    LCD_WR_DATA(0xA9);
+    LCD_WR_DATA(0x51);
+    LCD_WR_DATA(0x2C);
+    LCD_WR_DATA(0x82);
+    LCD_WR_REG(0x11);
+    Delay_ms(120);
+    LCD_WR_REG(0x29);
+  }
+
+  void NT35310_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? NT35310_180_DEGREE_REG_VALUE : NT35310_0_DEGREE_REG_VALUE);
+  }
+
+  void NT35310_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t NT35310_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    uint16_t rg, br;
+    rg = LCD_RD_DATA();  // First pixel R:8bit-G:8bit
+    br = LCD_RD_DATA();  // First pixel B:8bit - Second pixel R:8bit
+
+    return ((rg) << 8) | ((br & 0xFF00) >> 8);  // RG-B
+  }
+
+#endif  // LCD_DRIVER_HAS(NT35310)

--- a/TFT/src/User/Hal/LCD_Driver/NT35310.h
+++ b/TFT/src/User/Hal/LCD_Driver/NT35310.h
@@ -1,0 +1,21 @@
+#ifndef _NT35310_H_
+#define _NT35310_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NT35310_0_DEGREE_REG_VALUE   0X60
+#define NT35310_180_DEGREE_REG_VALUE 0XA0
+
+uint8_t LCD_DriveIsNT35310(void);
+void NT35310_Init_Sequential(void);
+void NT35310_SetDirection(uint8_t rotate);
+void NT35310_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t NT35310_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/RM68042.c
+++ b/TFT/src/User/Hal/LCD_Driver/RM68042.c
@@ -1,0 +1,88 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(RM68042)
+
+  #include "RM68042.h"
+  // RM68042
+  void RM68042_Init_Sequential(void)
+  {
+    LCD_WR_REG(0X11);
+    Delay_ms(20);
+    LCD_WR_REG(0XD0);   // VCI1  VCL  VGH  VGL DDVDH VREG1OUT power amplitude setting
+    LCD_WR_DATA(0X07);
+    LCD_WR_DATA(0X42);
+    LCD_WR_DATA(0X1C);
+    LCD_WR_REG(0XD1);   // VCOMH VCOM_AC amplitude setting
+    LCD_WR_DATA(0X00);
+    LCD_WR_DATA(0X19);
+    LCD_WR_DATA(0X16);
+    LCD_WR_REG(0XD2);   // Operational Amplifier Circuit Constant Current Adjust , charge pump frequency setting
+    LCD_WR_DATA(0X01);
+    LCD_WR_DATA(0X11);
+    LCD_WR_REG(0XE4);
+    LCD_WR_DATA(0X00A0);
+    LCD_WR_REG(0XF3);
+    LCD_WR_DATA(0X0000);
+    LCD_WR_DATA(0X002A);
+    LCD_WR_REG(0XC0);   // REV SM GS
+    LCD_WR_DATA(0X10);
+    LCD_WR_DATA(0X3B);
+    LCD_WR_DATA(0X00);
+    LCD_WR_DATA(0X02);
+    LCD_WR_DATA(0X11);
+    LCD_WR_REG(0XC5);   // Frame rate setting = 72HZ  when setting 0x03
+    LCD_WR_DATA(0X03);
+    LCD_WR_REG(0XC8);   // Gamma setting
+    LCD_WR_DATA(0X00);
+    LCD_WR_DATA(0X35);
+    LCD_WR_DATA(0X23);
+    LCD_WR_DATA(0X07);
+    LCD_WR_DATA(0X00);
+    LCD_WR_DATA(0X04);
+    LCD_WR_DATA(0X45);
+    LCD_WR_DATA(0X53);
+    LCD_WR_DATA(0X77);
+    LCD_WR_DATA(0X70);
+    LCD_WR_DATA(0X00);
+    LCD_WR_DATA(0X04);
+    LCD_WR_REG(0X20);   // Exit invert mode
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(0X28);
+    LCD_WR_REG(0X3A);
+    LCD_WR_DATA(0X55);  // 16λģʽ
+    Delay_ms(120);
+    LCD_WR_REG(0X29);
+  }
+
+  void RM68042_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? RM68042_180_DEGREE_REG_VALUE : RM68042_0_DEGREE_REG_VALUE);
+  }
+
+  void RM68042_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t RM68042_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    uint16_t rg, br;
+    rg = LCD_RD_DATA();  // First pixel R:8bit-G:8bit
+    br = LCD_RD_DATA();  // First pixel B:8bit - Second pixel R:8bit
+
+    return ((rg) << 8) | ((br & 0xFF00) >> 8);  // RG-B
+  }
+
+#endif  // LCD_DRIVER_HAS(RM68042)

--- a/TFT/src/User/Hal/LCD_Driver/RM68042.h
+++ b/TFT/src/User/Hal/LCD_Driver/RM68042.h
@@ -1,0 +1,21 @@
+#ifndef _RM68042_H_
+#define _RM68042_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RM68042_0_DEGREE_REG_VALUE   0X28
+#define RM68042_180_DEGREE_REG_VALUE 0X2B
+
+uint8_t LCD_DriveIsRM68042(void);
+void RM68042_Init_Sequential(void);
+void RM68042_SetDirection(uint8_t rotate);
+void RM68042_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t RM68042_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/SSD1963.c
+++ b/TFT/src/User/Hal/LCD_Driver/SSD1963.c
@@ -1,0 +1,101 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(SSD1963)
+
+  #include "SSD1963.h"
+  // SSD1963  resolution max:864*480
+  #define SSD_HOR_RESOLUTION LCD_WIDTH   // LCD width pixel
+  #define SSD_VER_RESOLUTION LCD_HEIGHT  // LCD height pixel
+
+  #define SSD_HT  (SSD_HOR_RESOLUTION+SSD_HOR_BACK_PORCH+SSD_HOR_FRONT_PORCH)
+  #define SSD_HPS (SSD_HOR_BACK_PORCH)
+  #define SSD_VT  (SSD_VER_RESOLUTION+SSD_VER_BACK_PORCH+SSD_VER_FRONT_PORCH)
+  #define SSD_VPS (SSD_VER_BACK_PORCH)
+
+  void SSD1963_Init_Sequential(void)
+  {
+    uint32_t LCDC_FPR;
+    LCD_WR_REG(0xE2);   // Set PLL with OSC = 25MHz (hardware), 250Mhz < VC0 < 800Mhz
+    LCD_WR_DATA(0x17);  // M = 0x17 = 23, VCO = 25Mhz * (M + 1) = 25 * 24 = 600Mhz
+    LCD_WR_DATA(0x04);  // N = 0x04 = 4, PLL = VCO / (N + 1) = 600 / 5 = 120Mhz
+    LCD_WR_DATA(0x54);  // C[2] = 1, Effectuate the multiplier and divider value
+    LCD_WR_REG(0xE0);   // Start PLL command
+    LCD_WR_DATA(0x01);  // enable PLL
+    Delay_ms(10);
+    LCD_WR_REG(0xE0);   // Start PLL command again
+    LCD_WR_DATA(0x03);  // now, use PLL output as system clock
+    Delay_ms(10);
+    LCD_WR_REG(0x01);   // Soft reset
+    Delay_ms(100);
+    LCDC_FPR = (SSD_DCLK_FREQUENCY * 1048576) / 120 -1;  // DCLK Frequency = PLL * (LCDC_FPR + 1)/1048576, LCDC_FPR = (DCLK Frequency * 1048576) / PLL - 1
+    LCD_WR_REG(0xE6);   // 12Mhz = 120Mhz * (LCDC_FPR + 1)/1048576, LCDC_FPR = 104856.6 = 0x019998
+    LCD_WR_DATA((LCDC_FPR >> 16) & 0xFF);
+    LCD_WR_DATA((LCDC_FPR >> 8) & 0xFF);
+    LCD_WR_DATA(LCDC_FPR & 0xFF);
+    LCD_WR_REG(0xB0);   // Set LCD mode
+    LCD_WR_DATA(0x00);  // 0x00: 16bits data, 0x20: 24bits data
+    LCD_WR_DATA(0x00);  // 0x00: TFT Mode
+    LCD_WR_DATA((SSD_HOR_RESOLUTION - 1) >> 8);  // LCD width pixel
+    LCD_WR_DATA((SSD_HOR_RESOLUTION - 1) & 0xFF);
+    LCD_WR_DATA((SSD_VER_RESOLUTION - 1) >> 8);  // LCD height pixel
+    LCD_WR_DATA((SSD_VER_RESOLUTION - 1) & 0xFF);
+    LCD_WR_DATA(0x00);  // RGB format
+    LCD_WR_REG(0xB4);   // Set horizontal period
+    LCD_WR_DATA((SSD_HT - 1) >> 8);  // Horizontal total period (display + non-display) in pixel clock
+    LCD_WR_DATA(SSD_HT - 1);
+    LCD_WR_DATA(SSD_HPS >> 8);  // Non-display period between the start of the horizontal sync (LLINE) signal and the first display data
+    LCD_WR_DATA(SSD_HPS);
+    LCD_WR_DATA(SSD_HOR_PULSE_WIDTH - 1);  // horizontal sync pulse width (LLINE) in pixel clock
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0xB6);   // Set vertical period
+    LCD_WR_DATA((SSD_VT - 1) >> 8);
+    LCD_WR_DATA(SSD_VT - 1);
+    LCD_WR_DATA(SSD_VPS >> 8);
+    LCD_WR_DATA(SSD_VPS);
+    LCD_WR_DATA(SSD_VER_FRONT_PORCH - 1);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x00);
+    LCD_WR_REG(0xF0);   // Set pixel data interface format
+    LCD_WR_DATA(0x03);  // 16-bit(565 format) data for 16bpp
+    LCD_WR_REG(0xBC);   // postprocessor for contrast/brightness/saturation.
+    LCD_WR_DATA(0x34);  // Contrast value (0-127). Set to 52 to reduce banding/flickering.
+    LCD_WR_DATA(0x77);  // Brightness value (0-127). Set to 119 to reduce banding/flickering.
+    LCD_WR_DATA(0x48);  // Saturation value (0-127).
+    LCD_WR_DATA(0x01);  // Enable/disable the postprocessor for contrast/brightness/saturation (1-0).
+    LCD_WR_REG(0x29);   // Set display on
+
+    LCD_WR_REG(0x36);   // Set address mode
+    LCD_WR_DATA(0x00);
+  }
+
+  void SSD1963_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? SSD1963_180_DEGREE_REG_VALUE : SSD1963_0_DEGREE_REG_VALUE);
+  }
+
+  void SSD1963_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t SSD1963_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+
+    GUI_COLOR pix;
+    pix.color = LCD_RD_DATA();
+    return (pix.RGB.r << 19) | (pix.RGB.g << 10) | (pix.RGB.b << 3);
+  }
+
+#endif  // LCD_DRIVER_HAS(SSD1963)

--- a/TFT/src/User/Hal/LCD_Driver/SSD1963.h
+++ b/TFT/src/User/Hal/LCD_Driver/SSD1963.h
@@ -1,0 +1,21 @@
+#ifndef _SSD1963_H_
+#define _SSD1963_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SSD1963_0_DEGREE_REG_VALUE   0x00
+#define SSD1963_180_DEGREE_REG_VALUE 0x03
+
+uint8_t LCD_DriveIsSSD1963(void);
+void SSD1963_Init_Sequential(void);
+void SSD1963_SetDirection(uint8_t rotate);
+void SSD1963_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t SSD1963_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Driver/ST7789.c
+++ b/TFT/src/User/Hal/LCD_Driver/ST7789.c
@@ -1,0 +1,106 @@
+#include "includes.h"
+
+#if LCD_DRIVER_HAS(ST7789)
+
+  #include "ST7789.h"
+  // ST7789
+  void ST7789_Init_Sequential(void)
+  {
+    LCD_WR_REG(0x11);
+    Delay_ms(120);  // Delay 120ms
+    //------------------------------display and color format setting------------------------------//
+    LCD_WR_REG(0x36);
+    LCD_WR_DATA(0x68);
+    LCD_WR_REG(0x3a);
+    LCD_WR_DATA(0x05);
+    //--------------------------------ST7789V Frame rate setting----------------------------------//
+    LCD_WR_REG(0xb2);
+    LCD_WR_DATA(0x0c);
+    LCD_WR_DATA(0x0c);
+    LCD_WR_DATA(0x00);
+    LCD_WR_DATA(0x33);
+    LCD_WR_DATA(0x33);
+    LCD_WR_REG(0xb7);
+    LCD_WR_DATA(0x35);
+    //---------------------------------ST7789V Power setting--------------------------------------//
+    LCD_WR_REG(0xbb);
+    LCD_WR_DATA(0x28);
+    LCD_WR_REG(0xc0);
+    LCD_WR_DATA(0x2c);
+    LCD_WR_REG(0xc2);
+    LCD_WR_DATA(0x01);
+    LCD_WR_REG(0xc3);
+    LCD_WR_DATA(0x0b);
+    LCD_WR_REG(0xc4);
+    LCD_WR_DATA(0x20);
+    LCD_WR_REG(0xc6);
+    LCD_WR_DATA(0x0f);
+    LCD_WR_REG(0xd0);
+    LCD_WR_DATA(0xa4);
+    LCD_WR_DATA(0xa1);
+    //--------------------------------ST7789V gamma setting---------------------------------------//
+    LCD_WR_REG(0xe0);
+    LCD_WR_DATA(0xd0);
+    LCD_WR_DATA(0x01);
+    LCD_WR_DATA(0x08);
+    LCD_WR_DATA(0x0f);
+    LCD_WR_DATA(0x11);
+    LCD_WR_DATA(0x2a);
+    LCD_WR_DATA(0x36);
+    LCD_WR_DATA(0x55);
+    LCD_WR_DATA(0x44);
+    LCD_WR_DATA(0x3a);
+    LCD_WR_DATA(0x0b);
+    LCD_WR_DATA(0x06);
+    LCD_WR_DATA(0x11);
+    LCD_WR_DATA(0x20);
+    LCD_WR_REG(0xe1);
+    LCD_WR_DATA(0xd0);
+    LCD_WR_DATA(0x02);
+    LCD_WR_DATA(0x07);
+    LCD_WR_DATA(0x0a);
+    LCD_WR_DATA(0x0b);
+    LCD_WR_DATA(0x18);
+    LCD_WR_DATA(0x34);
+    LCD_WR_DATA(0x43);
+    LCD_WR_DATA(0x4a);
+    LCD_WR_DATA(0x2b);
+    LCD_WR_DATA(0x1b);
+    LCD_WR_DATA(0x1c);
+    LCD_WR_DATA(0x22);
+    LCD_WR_DATA(0x1f);
+    LCD_WR_REG(0x29);
+  }
+
+  void ST7789_SetDirection(uint8_t rotate)
+  {
+    LCD_WR_REG(0X36);
+    LCD_WR_DATA(rotate ? ST7789_180_DEGREE_REG_VALUE : ST7789_0_DEGREE_REG_VALUE);
+  }
+
+  void ST7789_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey)
+  {
+    LCD_WR_REG(0x2A);
+    LCD_WR_DATA(sx>>8);LCD_WR_DATA(sx&0xFF);
+    LCD_WR_DATA(ex>>8);LCD_WR_DATA(ex&0xFF);
+    LCD_WR_REG(0x2B);
+    LCD_WR_DATA(sy>>8);LCD_WR_DATA(sy&0xFF);
+    LCD_WR_DATA(ey>>8);LCD_WR_DATA(ey&0xFF);
+    LCD_WR_REG(0x2C);  // Ready to write memory
+  }
+
+  uint32_t ST7789_ReadPixel_24Bit(int16_t x, int16_t y)
+  {
+    LCD_SetWindow(x, y, x, y);
+    LCD_WR_REG(0X2E);
+    Delay_us(1);
+    LCD_RD_DATA();  // Dummy read
+
+    uint16_t rg, br;
+    rg = LCD_RD_DATA();  // First pixel R:8bit-G:8bit
+    br = LCD_RD_DATA();  // First pixel B:8bit - Second pixel R:8bit
+
+    return ((rg) << 8) | ((br & 0xFF00) >> 8);  // RG-B
+  }
+
+#endif  // LCD_DRIVER_HAS(ST7789)

--- a/TFT/src/User/Hal/LCD_Driver/ST7789.h
+++ b/TFT/src/User/Hal/LCD_Driver/ST7789.h
@@ -1,0 +1,21 @@
+#ifndef _ST7789_H_
+#define _ST7789_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ST7789_0_DEGREE_REG_VALUE   0X60
+#define ST7789_180_DEGREE_REG_VALUE 0XA0
+
+uint8_t LCD_DriveIsST7789(void);
+void ST7789_Init_Sequential(void);
+void ST7789_SetDirection(uint8_t rotate);
+void ST7789_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
+uint32_t ST7789_ReadPixel_24Bit(int16_t x, int16_t y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/TFT/src/User/Hal/LCD_Init.h
+++ b/TFT/src/User/Hal/LCD_Init.h
@@ -69,6 +69,7 @@ extern "C" {
 
 uint32_t LCD_ReadPixel_24Bit(int16_t x, int16_t y);
 void LCD_RefreshDirection(void);
+void LCD_SetWindow(uint16_t sx, uint16_t sy, uint16_t ex, uint16_t ey);
 void LCD_Init(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Hal/stm32f10x/lcd_dma.c
+++ b/TFT/src/User/Hal/stm32f10x/lcd_dma.c
@@ -1,7 +1,7 @@
 #include "lcd_dma.h"
 #include "variants.h"
 #include "lcd.h"
-#include "GUI.h"
+#include "LCD_Init.h"
 #include "delay.h"
 #include "w25qxx.h"
 
@@ -86,7 +86,6 @@ void lcd_frame_display(u16 sx,u16 sy,u16 w,u16 h, u32 addr)
   u32 totalSize = w*h*(2-LCD_DATA_16BIT);
 
   LCD_SetWindow(sx,sy,sx+w-1,sy+h-1);
-  LCD_WR_REG(0x2C);
 
   for(cur = 0; cur < totalSize; cur += LCD_DMA_MAX_TRANS)
   {

--- a/TFT/src/User/Hal/stm32f2_f4xx/lcd_dma.c
+++ b/TFT/src/User/Hal/stm32f2_f4xx/lcd_dma.c
@@ -1,7 +1,7 @@
 #include "lcd_dma.h"
 #include "variants.h"
 #include "lcd.h"
-#include "GUI.h"
+#include "LCD_Init.h"
 #include "delay.h"
 #include "w25qxx.h"
 
@@ -93,7 +93,6 @@ void lcd_frame_display(u16 sx,u16 sy,u16 w,u16 h, u32 addr)
   u32 totalSize = w*h*(2-LCD_DATA_16BIT);
 
   LCD_SetWindow(sx,sy,sx+w-1,sy+h-1);
-  LCD_WR_REG(0x2C);
 
   for(cur = 0; cur < totalSize; cur += LCD_DMA_MAX_TRANS)
   {

--- a/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
@@ -22,8 +22,6 @@
 // LCD interface
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               HX8558  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558].
-  #define TFTLCD_0_DEGREE_REG_VALUE   0xA4
-  #define TFTLCD_180_DEGREE_REG_VALUE 0X64
 #endif
 //#define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT24_V1_1.h
+++ b/TFT/src/User/Variants/pin_TFT24_V1_1.h
@@ -23,8 +23,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X68
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XA8
 #endif
 //#define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT28_V1_0.h
+++ b/TFT/src/User/Variants/pin_TFT28_V1_0.h
@@ -20,8 +20,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X68
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XA8
 #endif
 #ifndef LCD_DATA_16BIT
   #define LCD_DATA_16BIT 1  // LCD data 16bit or 8bit

--- a/TFT/src/User/Variants/pin_TFT28_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT28_V3_0.h
@@ -20,8 +20,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               ST7789  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x05
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X60
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XA0
 #endif
 
 #include "pin_TFT35_E3_V3_0.h"

--- a/TFT/src/User/Variants/pin_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V1_0.h
@@ -23,8 +23,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X28
-  #define TFTLCD_180_DEGREE_REG_VALUE 0X2B
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT35_V1_2.h
+++ b/TFT/src/User/Variants/pin_TFT35_V1_2.h
@@ -10,8 +10,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               ILI9488  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X28
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XE8
 #endif
 #ifndef LCD_DATA_16BIT
   #define LCD_DATA_16BIT 1  // LCD data 16bit or 8bit

--- a/TFT/src/User/Variants/pin_TFT35_V2_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V2_0.h
@@ -21,10 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ILI9488  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER               (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X28
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XE8
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT35_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V3_0.h
@@ -21,10 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ILI9488  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER               (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X28
-  #define TFTLCD_180_DEGREE_REG_VALUE 0XE8
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT43_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT43_V3_0.h
@@ -19,8 +19,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
   #define TFTLCD_DRIVER_SPEED         0x10     // SSD1963 needs slower speed
-  #define TFTLCD_0_DEGREE_REG_VALUE   0x00
-  #define TFTLCD_180_DEGREE_REG_VALUE 0x03
 #endif
 
 #ifndef SSD1963_LCD_PARA

--- a/TFT/src/User/Variants/pin_TFT70_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT70_V3_0.h
@@ -23,8 +23,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
   #define TFTLCD_DRIVER_SPEED         0x10     // SSD1963 needs slower speed
-  #define TFTLCD_0_DEGREE_REG_VALUE   0x00
-  #define TFTLCD_180_DEGREE_REG_VALUE 0x03
 #endif
 
 #ifndef SSD1963_LCD_PARA

--- a/TFT/src/User/Variants/pin_Template.h
+++ b/TFT/src/User/Variants/pin_Template.h
@@ -23,8 +23,6 @@
 #ifndef TFTLCD_DRIVER
   #define TFTLCD_DRIVER               RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
   #define TFTLCD_DRIVER_SPEED         0x03
-  #define TFTLCD_0_DEGREE_REG_VALUE   0X28
-  #define TFTLCD_180_DEGREE_REG_VALUE 0X2B
 #endif
 
 //#ifndef SSD1963_LCD_PARA  // Only for TFTLCD_DRIVER is SSD1963

--- a/TFT/src/User/Variants/variants.h
+++ b/TFT/src/User/Variants/variants.h
@@ -11,13 +11,14 @@
 */
 
 // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558, SSD1963].
-#define RM68042 0
-#define ILI9488 1
-#define ILI9341 2
-#define ST7789  3
-#define HX8558  4
-#define SSD1963 5
-#define ILI9325 6
+#define RM68042 (1 << 0)
+#define ILI9488 (1 << 1)
+#define ILI9341 (1 << 2)
+#define ST7789  (1 << 3)
+#define HX8558  (1 << 4)
+#define SSD1963 (1 << 5)
+#define ILI9325 (1 << 6)
+#define NT35310 (1 << 7)
 
 #if defined(TFT24_V1_1)
   #include "pin_TFT24_V1_1.h"
@@ -58,12 +59,7 @@
 #define LCD_ENCODER_SUPPORT (defined(LCD_ENCA_PIN) && defined(LCD_ENCB_PIN) && defined(LCD_BTN_PIN))
 #define ENC_ACTIVE_SIGNAL (defined(LCD_ENC_EN_PIN) && defined(ST7920_EMULATOR) && defined(LCD_ENCODER_SUPPORT))
 
-#define LCD_DRIVER_IS(n) (TFTLCD_DRIVER == n)
-
-#if LCD_DRIVER_IS(ILI9325)
-  #define TFTLCD_WRITEMEMORY 0x22
-#else
-  #define TFTLCD_WRITEMEMORY 0x2C
-#endif
+#define LCD_DRIVER_IS(n)  ((TFTLCD_DRIVER) == (n))
+#define LCD_DRIVER_HAS(n) (((TFTLCD_DRIVER) & (n)) == (n))
 
 #endif


### PR DESCRIPTION

### Description
 * Restructure LCD driver type code, The source code structure is easier to understand, add the new driver is more convenient.
 * Automatically identify the driver type and call the API of the corresponding driver. The same hardware can be compatible with a variety of different driver TFTs
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
