### PR TITLE
"°" not displayed correctly in german language on TFT70

### DIFF
--- a/Copy to SD Card root directory to update/Language Packs/language_de.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_de.ini
@@ -1,5 +1,5 @@
 #### Language Code:DE
-## Language Version:20210528
+## Language Version:20210522
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\n'
 

--- a/TFT/src/User/API/Language/language_de.h
+++ b/TFT/src/User/API/Language/language_de.h
@@ -145,7 +145,7 @@
     #define STRING_TIMEOUT_REACHED        "Zeit überschritten!"
     #define STRING_DISCONNECT_INFO        "Verbindung getrennt!"
     #define STRING_SHUTTING_DOWN          "Fahre herunter..."
-    #define STRING_WAIT_TEMP_SHUT_DOWN    "Warte bis Düsen-\ntemperatur unter\n%d℃ fällt." // Wait for the temperature of hotend to be lower than 50℃
+    #define STRING_WAIT_TEMP_SHUT_DOWN    "Warte bis Düsen-\ntemperatur unter\n%d°C fällt." // Wait for the temperature of hotend to be lower than 50°C
     #define STRING_POWER_FAILED           "Druck fortsetzen?" //Question Sign
     #define STRING_PROCESS_RUNNING        "Prozess läuft bereits!"
     #define STRING_PROCESS_COMPLETED      "Prozess fertiggestellt!"
@@ -188,9 +188,9 @@
     #define STRING_TOUCHMI                "TouchMi"
 
     // Values
-    #define STRING_1_DEGREE               "1℃"
-    #define STRING_5_DEGREE               "5℃"
-    #define STRING_10_DEGREE              "10℃"
+    #define STRING_1_DEGREE               "1°C"
+    #define STRING_5_DEGREE               "5°C"
+    #define STRING_10_DEGREE              "10°C"
 
     #define STRING_001_MM                 "0.01mm"
     #define STRING_01_MM                  "0.1mm"
@@ -318,7 +318,7 @@
     #define STRING_TUNE_EXTRUDER          "Schritte"
     #define STRING_TUNE_EXT_EXTRUDE_100   "100mm ext."
     #define STRING_TUNE_EXT_TEMP          "Düsentemperatur"
-    #define STRING_TUNE_EXT_TEMPLOW       "Temparatur zu niedrig!\nMinimale Temparatur: %d℃"
+    #define STRING_TUNE_EXT_TEMPLOW       "Temparatur zu niedrig!\nMinimale Temparatur: %d°C"
     #define STRING_TUNE_EXT_DESIREDVAL    "Temparatur hat gewünschten Wert noch nicht erreicht!"
     #define STRING_TUNE_EXT_MARK120MM     "Filament 120 mm über Einlass markieren,\ndann '%s' drücken & nach Extrusion\nerneut messen."
     #define STRING_TUNE_EXT_HEATOFF       "Heizung abschalten?"
@@ -344,8 +344,8 @@
     #define STRING_FILAMENT_COST          "Filament Kosten: %1.2f\n"
     #define STRING_NO_FILAMENT_STATS      "Filament Daten nicht verfügbar."
     #define STRING_CLICK_FOR_MORE         "Klick für Statistik"
-    #define STRING_EXT_TEMPLOW            "Temperatur der Düse liegt\nunter dem Minimum (%d℃)."
-    #define STRING_HEAT_HOTEND            "Heize Düse auf %d℃?"
+    #define STRING_EXT_TEMPLOW            "Temperatur der Düse liegt\nunter dem Minimum (%d°C)."
+    #define STRING_HEAT_HOTEND            "Heize Düse auf %d°C?"
     #define STRING_Z_ALIGN                "Z ausr."
     #define STRING_MACROS                 "Macros"
     #define STRING_MESH_VALID             "Mesh Validation"


### PR DESCRIPTION
### Requirements

UTF-8 Character "°" to be displayed correctly in german language on TFT70, in order to display unit "°C" of temperatures correctly.

### Description

A mistake in the encoding of the previous version of language_de.ini prevents the Character "°" from being fisplayed correctlyl. This regularly happens with "wrong" encoding settings, especially across plattforms.
This change contains correct encoding created on Windows 10 with VIM (Vim Settings :se enc=utf-8 :se fenc=utf-8 :se ff=unix)
 
### Benefits

Character "°" gets recognized and displayed correctly by utf-8 able IDEs / editors and by the TFT70 display.

### Related Issues

This issue may occure also:
- other displays
- other languages
