### PR TITLE
Added M73 and M117 support for remaining print time

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -81,8 +81,8 @@ baudrate:5
 
 #### Enable Multi-Serials
 # Multi-Serials connected to ESP3D, OctoPrint, Other TFT, etc...
-# Disable the serial port when it is not in use and floating
-# Avoid the serial port to receive the wrong data because of electromagnetic interference
+# Disable the serial port when it is not in use and floating.
+# Avoid the serial port to receive the wrong data because of electromagnetic interference.
 #   Options: [0: Disable all multi-serials,
 #             1: Enable SERIAL_PORT_2 alone,
 #             2: Enable SERIAL_PORT_3 alone,

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -81,8 +81,8 @@ baudrate:4
 
 #### Enable Multi-Serials
 # Multi-Serials connected to ESP3D, OctoPrint, Other TFT, etc...
-# Disable the serial port when it is not in use and floating
-# Avoid the serial port to receive the wrong data because of electromagnetic interference
+# Disable the serial port when it is not in use and floating.
+# Avoid the serial port to receive the wrong data because of electromagnetic interference.
 #   Options: [0: Disable all multi-serials,
 #             1: Enable SERIAL_PORT_2 alone,
 #             2: Enable SERIAL_PORT_3 alone,

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -4,14 +4,17 @@
 typedef struct
 {
   FIL        file;
-  uint32_t   time;        // Printed time in sec
-  uint32_t   size;        // Gcode file total size
-  uint32_t   cur;         // Gcode has printed file size
+  uint32_t   time;                // current elapsed time in sec
+  uint32_t   remainingTime;       // current remaining time in sec (if set with M73 or M117)
+  uint32_t   size;                // Gcode file total size
+  uint32_t   cur;                 // Gcode has printed file size
+  uint8_t    prevProgress;
   uint8_t    progress;
-  bool       runout;      // 1: runout in printing, 0: idle
-  bool       printing;    // 1: means printing, 0: means idle
-  bool       pause;       // 1: means paused
-  PAUSE_TYPE pauseType;   // pause type trigged by different sources and gcodes like M0 & M600
+  bool       progressFromSlicer;  // 1: progress controlled by Slicer (if set with M73)
+  bool       runout;              // 1: runout in printing, 0: idle
+  bool       printing;            // 1: means printing, 0: means idle
+  bool       pause;               // 1: means paused
+  PAUSE_TYPE pauseType;           // pause type trigged by different sources and gcodes like M0 & M600
 } PRINTING;
 
 PRINTING infoPrinting;
@@ -57,13 +60,16 @@ void resumeAndContinue(void)
   Serial_Puts(SERIAL_PORT, "M876 S1\n");
 }
 
-void setPrintTime(uint32_t RTtime)
+void setPrintTime(uint32_t elapsedTime)
 {
-  if (RTtime % 1000 == 0)
+  if (elapsedTime % 1000 == 0)
   {
     if (infoPrinting.printing && !infoPrinting.pause)
     {
       infoPrinting.time++;
+
+      if (infoPrinting.remainingTime > 0  && !heatHasWaiting())
+        infoPrinting.remainingTime--;
     }
   }
 }
@@ -78,6 +84,39 @@ void getPrintTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec)
   *hour = infoPrinting.time / 3600;
   *min = infoPrinting.time % 3600 / 60;
   *sec = infoPrinting.time % 60;
+}
+
+void setPrintRemainingTime(int32_t remainingTime)
+{
+  float speedFactor = (float) (speedGetCurPercent(0)) / 100;  // speed (feed rate) factor (e.g. 50% -> 0.5)
+
+  // Cura Slicer put a negative value at the end instead of zero
+  if (remainingTime < 0 || speedFactor <= 0.0f)
+    remainingTime = 0;
+  else
+    remainingTime = remainingTime / speedFactor;  // remaining time = slicer remaining time / speed factor
+
+  infoPrinting.remainingTime = remainingTime;
+}
+
+void parsePrintRemainingTime(char * buffer)
+{
+  int hour, min, sec;
+
+  sscanf(buffer, "%dh%dm%ds", &hour, &min, &sec);
+  setPrintRemainingTime(((int32_t) (hour) * 3600) + ((int32_t) (min) * 60) + (int32_t) (sec));
+}
+
+uint32_t getPrintRemainingTime()
+{
+  return infoPrinting.remainingTime;
+}
+
+void getPrintRemainingTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec)
+{
+  *hour = infoPrinting.remainingTime / 3600;
+  *min = infoPrinting.remainingTime % 3600 / 60;
+  *sec = infoPrinting.remainingTime % 60;
 }
 
 uint32_t getPrintSize(void)
@@ -96,18 +135,31 @@ void setPrintProgress(float cur, float size)
   infoPrinting.size = size;
 }
 
+void setPrintProgressPercentage(uint8_t percentage)
+{
+  infoPrinting.progressFromSlicer = true;  // set to true to force a progress controlled by slicer
+  infoPrinting.progress = percentage;
+}
+
 bool updatePrintProgress(void)
 {
-  uint8_t curProgress = infoPrinting.progress;
+  uint8_t prevProgress = infoPrinting.prevProgress;
 
-  // in case not printing or a wrong size was set, we consider progress as 100%
-  if (infoPrinting.size == 0)  // avoid a division for 0 (a crash) and set progress to 100%
-    infoPrinting.progress = 100;
-  else
-    infoPrinting.progress = MIN((uint64_t)infoPrinting.cur * 100 / infoPrinting.size, 100);
+  if (!infoPrinting.progressFromSlicer)  // avoid to update progress if it is controlled by slicer
+  {
+    // in case not printing or a wrong size was set, we consider progress as 100%
+    if (infoPrinting.size == 0)  // avoid a division for 0 (a crash) and set progress to 100%
+      infoPrinting.progress = 100;
+    else
+      infoPrinting.progress = MIN((uint64_t)infoPrinting.cur * 100 / infoPrinting.size, 100);
+  }
 
-  if (infoPrinting.progress != curProgress)
+  if (infoPrinting.progress != prevProgress)
+  {
+    infoPrinting.prevProgress = infoPrinting.progress;
+
     return true;
+  }
 
   return false;
 }
@@ -328,7 +380,7 @@ void printEnd(void)
   powerFailedClose();
   powerFailedDelete();
 
-  infoPrinting.cur = infoPrinting.size;  // always update the print progress to 100% even if the print was abaorted
+  infoPrinting.cur = infoPrinting.size;  // always update the print progress to 100% even if the print terminated
   infoPrinting.printing = infoPrinting.pause = false;
   preparePrintSummary();  // update print summary. infoPrinting are used
 
@@ -557,7 +609,7 @@ void setPrintAbort(void)
     coordinateQuery(0);
   }
 
-  infoPrinting.cur = infoPrinting.size;
+  infoPrinting.cur = infoPrinting.size;  // always update the print progress to 100% even if the print was abaorted
   infoPrinting.printing = infoPrinting.pause = false;
 }
 

--- a/TFT/src/User/API/Printing.h
+++ b/TFT/src/User/API/Printing.h
@@ -54,14 +54,20 @@ void breakAndContinue(void);
 void resumeAndPurge(void);
 void resumeAndContinue(void);
 
-void setPrintTime(uint32_t RTtime);
+void setPrintTime(uint32_t elapsedTime);
 uint32_t getPrintTime(void);
 void getPrintTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec);
+
+void setPrintRemainingTime(int32_t remainingTime);  // used for M73 Rxx and M117 Time Left xx
+void parsePrintRemainingTime(char * buffer);        // used for M117 Time Left xx
+uint32_t getPrintRemainingTime();
+void getPrintRemainingTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec);
 
 uint32_t getPrintSize(void);
 uint32_t getPrintCur(void);
 
 void setPrintProgress(float cur, float size);
+void setPrintProgressPercentage(uint8_t percentage);  // used by M73 Pxx
 bool updatePrintProgress(void);
 uint8_t getPrintProgress(void);
 

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -191,6 +191,7 @@ void initMachineSetting(void)
   infoMachineSettings.autoReportSDStatus      = DISABLED;
   infoMachineSettings.long_filename_support   = DISABLED;
   infoMachineSettings.babyStepping            = DISABLED;
+  infoMachineSettings.buildPercent            = DISABLED;
   infoMachineSettings.softwareEndstops        = ENABLED;
 }
 

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -267,6 +267,7 @@ typedef struct
   uint8_t autoReportSDStatus;
   uint8_t long_filename_support;
   uint8_t babyStepping;
+  uint8_t buildPercent;
   uint8_t softwareEndstops;
 } MACHINESETTINGS;
 

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -1,7 +1,7 @@
 #include "SpeedControl.h"
 #include "includes.h"
 
-const char *const speedCmd[SPEED_NUM] = {"M220","M221"};
+const char *const speedCmd[SPEED_NUM] = {"M220", "M221"};
 
 static uint16_t setPercent[SPEED_NUM] = {100, 100};
 static uint16_t lastSetPercent[SPEED_NUM] = {100, 100};
@@ -24,7 +24,7 @@ uint16_t speedGetCurPercent(uint8_t tool)
 
 void speedSetPercent(uint8_t tool, uint16_t per)
 {
-  setPercent[tool]=NOBEYOND(SPEED_MIN, per, SPEED_MAX);
+  setPercent[tool] = NOBEYOND(SPEED_MIN, per, SPEED_MAX);
 }
 
 uint16_t speedGetSetPercent(uint8_t tool)
@@ -36,9 +36,9 @@ void loopSpeed(void)
 {
   for (uint8_t i = 0; i < SPEED_NUM; i++)
   {
-    if (lastSetPercent[i] != setPercent[i]  && (OS_GetTimeMs() > nextSpeedTime))
+    if (lastSetPercent[i] != setPercent[i] && (OS_GetTimeMs() > nextSpeedTime))
     {
-      if (storeCmd("%s S%d D%d\n",speedCmd[i], setPercent[i], heatGetCurrentTool()))
+      if (storeCmd("%s S%d D%d\n", speedCmd[i], setPercent[i], heatGetCurrentTool()))
         lastSetPercent[i] = setPercent[i];
       nextSpeedTime = OS_GetTimeMs() + NEXT_SPEED_WAIT;  // avoid rapid fire, clogging the queue
     }

--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -713,7 +713,7 @@ void _GUI_DispStringInRect(int16_t sx, int16_t sy, int16_t ex, int16_t ey, const
 
 void _GUI_DispStringInPrect(const GUI_RECT *rect, const uint8_t *p)
 {
-  _GUI_DispStringInRect(rect->x0, rect->y0, rect->x1, rect->y1,p);
+  _GUI_DispStringInRect(rect->x0, rect->y0, rect->x1, rect->y1, p);
 }
 
 static GUI_POINT GUI_DisplayWordInPrect(const GUI_RECT *rect, GUI_POINT cursor, uint8_t *str)

--- a/TFT/src/User/API/UI/HD44780_Emulator.c
+++ b/TFT/src/User/API/UI/HD44780_Emulator.c
@@ -162,7 +162,7 @@ void HD44780_DispDDRAM(uint8_t data)
     uint16_t x = 0,
              y = 0,
              j = 0;
-    uint16_t bitMapSize =(info.pixelHeight * info.pixelWidth / 8);
+    uint16_t bitMapSize = (info.pixelHeight * info.pixelWidth / 8);
     uint8_t  font[bitMapSize];
     uint32_t temp = 0;
 

--- a/TFT/src/User/API/UI/Numpad.c
+++ b/TFT/src/User/API/UI/Numpad.c
@@ -28,7 +28,7 @@ typedef enum
   NUM_KEY_RESET,
 
   NUM_KEY_IDLE = IDLE_TOUCH,
-}NUM_KEY_VALUES;
+} NUM_KEY_VALUES;
 
 const GUI_RECT rect_of_numkey[KEY_COUNT] = {
   {0 * SKEYWIDTH, ICON_START_Y + 0 * SKEYHEIGHT, 1 * SKEYWIDTH, ICON_START_Y + 1 * SKEYHEIGHT},  // 1
@@ -63,7 +63,7 @@ const char * const numPadKeyChar[KEY_COUNT] = {
   ".", "0", "-", "\u08A5"
 };
 
-uint8_t numpadType = 0; //numpad type identifier
+uint8_t numpadType = 0;  // numpad type identifier
 
 void drawKeypadButton(uint8_t index, uint8_t isPressed)
 {
@@ -119,7 +119,7 @@ void drawKeypadButton(uint8_t index, uint8_t isPressed)
     GUI_DrawRect(rect_of_numkey[index].x0 + 2, rect_of_numkey[index].y0 + 2, rect_of_numkey[index].x1-2, rect_of_numkey[index].y1 - 2);
     GUI_SetColor(infoSettings.font_color);
 
-    #endif // KEYBOARD_MATERIAL_THEME
+    #endif  // KEYBOARD_MATERIAL_THEME
 }
 
 void Draw_keyboard(uint8_t * title, bool numberOnly, bool negative)
@@ -147,7 +147,7 @@ void Draw_keyboard(uint8_t * title, bool numberOnly, bool negative)
     GUI_ClearRect(0, 0, LCD_WIDTH, rect_of_numkey[0].y0);
     GUI_ClearRect(0, rect_of_numkey[0].y0, LCD_WIDTH, LCD_HEIGHT);
 
-    //draw button borders
+    // draw button borders
     GUI_SetColor(infoSettings.list_border_color);
     for (int i = 0; i < 3; i++)
     {
@@ -163,7 +163,7 @@ void Draw_keyboard(uint8_t * title, bool numberOnly, bool negative)
 
     for (uint8_t i = 0; i < KEY_COUNT ;i++)
     {
-      if (!(i == NUM_KEY_DEC || i == NUM_KEY_MINUS || (i % 4) == 3))  // || i == NUM_KEY_DEL || i == NUM_KEY_EXIT || i == NUM_KEY_RESET) )
+      if (!(i == NUM_KEY_DEC || i == NUM_KEY_MINUS || (i % 4) == 3))  // || i == NUM_KEY_DEL || i == NUM_KEY_EXIT || i == NUM_KEY_RESET))
         GUI_DispStringInPrect(&rect_of_numkey[i], (uint8_t *)numPadKeyChar[i]);
     }
 
@@ -179,7 +179,7 @@ void Draw_keyboard(uint8_t * title, bool numberOnly, bool negative)
     drawCharIcon(&rect_of_numkey[NUM_KEY_EXIT], CENTER, CHARICON_CANCEL, false, 0);
     drawCharIcon(&rect_of_numkey[NUM_KEY_RESET], CENTER, CHARICON_RESET, false, 0);
 
-  #endif // KEYBOARD_MATERIAL_THEME
+  #endif  // KEYBOARD_MATERIAL_THEME
 
   GUI_DispStringInPrect(&arrowRect,(uint8_t *)"\u089A");
 
@@ -204,7 +204,7 @@ static inline void drawValue(char * str)
   setFontSize(FONT_SIZE_NORMAL);
 }
 
-//Numpad for decimal numbers
+// Numpad for decimal numbers
 double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negative)
 {
   //bool exit = false;
@@ -301,7 +301,7 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
         if (!strchr((const char *)ParameterBuf, numPadKeyChar[key_num][0]) && nowIndex < (FLOAT_BUF_LENGTH - 1))
         {
           if (nowIndex == 0 || (nowIndex == 1 && strchr((const char *)ParameterBuf, '-')))  // check if no number exits or only minus exists
-            ParameterBuf[nowIndex++] = '0';                                                 //add zero before decimal sign if it is the first character
+            ParameterBuf[nowIndex++] = '0';                                                 // add zero before decimal sign if it is the first character
           ParameterBuf[nowIndex++] = numPadKeyChar[key_num][0];
           ParameterBuf[nowIndex] = 0;
           BUZZER_PLAY(sound_keypress);
@@ -360,7 +360,7 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
   }
 }
 
-//Numpad for integer numbers
+// Numpad for integer numbers
 int32_t numPadInt(uint8_t* title, int32_t old_val, int32_t reset_val, bool negative)
 {
   NUM_KEY_VALUES key_num = NUM_KEY_IDLE;

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -32,13 +32,11 @@ static float cmd_float(void)
   return (strtod(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index], NULL));
 }
 
-#if defined(SERIAL_PORT_2) || defined(BUZZER_PIN)
 // check if 'string' start with 'search'
-bool static startsWith(TCHAR *search, TCHAR *string)
+static bool startsWith(TCHAR *search, TCHAR *string)
 {
   return (strstr(string, search) - string == cmd_index) ? true : false;
 }
-#endif
 
 // Common store cmd
 void commonStoreCmd(GCODE_QUEUE *pQueue, const char* format, va_list va)
@@ -541,6 +539,20 @@ void sendQueueCmd(void)
             break;
         #endif  // not SERIAL_PORT_2
 
+        case 73:
+          if (cmd_seen('P'))
+            setPrintProgressPercentage(cmd_value());
+
+          if (cmd_seen('R'))
+            setPrintRemainingTime((int32_t) (cmd_float() * 60));
+
+          if (!infoMachineSettings.buildPercent)  // if M73 is not supported by Marlin, skip it
+          {
+            purgeLastCmd(true, avoid_terminal);
+            return;
+          }
+          break;
+
         case 80:  // M80
           #ifdef PS_ON_PIN
             PS_ON_On();
@@ -653,25 +665,33 @@ void sendQueueCmd(void)
           break;
 
         case 117:  // M117
-        {
-          char message[CMD_MAX_CHAR];
-          strncpy(message, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], CMD_MAX_CHAR);
-          // strip out any checksum that might be in the string
-          for (int i = 0; i < CMD_MAX_CHAR && message[i] != 0 ; i++)
+          if (startsWith("Time Left", &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 5]))
           {
-            if (message[i] == '*')
+            parsePrintRemainingTime(&infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 14]);
+          }
+          else
+          {
+            char message[CMD_MAX_CHAR];
+
+            strncpy(message, &infoCmd.queue[infoCmd.index_r].gcode[cmd_index + 4], CMD_MAX_CHAR);
+            // strip out any checksum that might be in the string
+            for (int i = 0; i < CMD_MAX_CHAR && message[i] != 0; i++)
             {
-              message[i] = 0;
-              break;
+              if (message[i] == '*')
+              {
+                message[i] = 0;
+                break;
+              }
+            }
+
+            statusScreen_setMsg((uint8_t *)"M117", (uint8_t *)&message);
+
+            if (infoMenu.menu[infoMenu.cur] != menuStatus)
+            {
+              addToast(DIALOG_TYPE_INFO, message);
             }
           }
-          statusScreen_setMsg((uint8_t *)"M117", (uint8_t *)&message);
-          if (infoMenu.menu[infoMenu.cur] != menuStatus)
-          {
-            addToast(DIALOG_TYPE_INFO, message);
-          }
-        }
-        break;
+          break;
 
         case 190:  // M190
           if (fromTFT)

--- a/TFT/src/User/Menu/MarlinMode.c
+++ b/TFT/src/User/Menu/MarlinMode.c
@@ -30,6 +30,7 @@ void menuMarlinMode(void)
 
   #if defined(ST7920_EMULATOR)
     ST7920 st7920;
+
     if (infoSettings.marlin_type == LCD12864)
     {
       marlinInit = SPI_Slave;

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -30,16 +30,37 @@ const GUI_RECT printinfo_val_rect[6] = {
    START_X + PICON_LG_WIDTH * 2 + PICON_SPACE_X * 2 + PICON_VAL_SM_EX, PICON_START_Y + PICON_HEIGHT * 1 + PICON_SPACE_Y * 1 + PICON_VAL_Y + BYTE_HEIGHT},
 };
 
-const GUI_RECT ProgressBar = {START_X + 1,                                PICON_START_Y + PICON_HEIGHT * 2 + PICON_SPACE_Y * 2 + 1,
-                              START_X + 4 * ICON_WIDTH + 3 * SPACE_X - 1, ICON_START_Y + ICON_HEIGHT + SPACE_Y - PICON_SPACE_Y - 1};
+#if !defined(TFT43_V3_0) && !defined(TFT50_V3_0)
+  #define PROGRESS_BAR_RAW_X0    (START_X + 1 * ICON_WIDTH + 1 * SPACE_X + 1)         // X0 aligned to second icon
+#else
+  #define PROGRESS_BAR_RAW_X0    (START_X + 0 * ICON_WIDTH + 0 * SPACE_X + 1)         // X0 aligned to first icon
+#endif
 
-const  char *const Speed_ID[2] = {"Speed", "Flow"};
+#define PROGRESS_BAR_RAW_X1      (START_X + 4 * ICON_WIDTH + 3 * SPACE_X - 1)         // X1 aligned to last icon
+#define PROGRESS_BAR_DELTA_X     ((PROGRESS_BAR_RAW_X1 - PROGRESS_BAR_RAW_X0) % 100)  // width rounding factor (multiple of 100 pixels)
+
+// progress bar rounded and aligned to center of icons
+#define PROGRESS_BAR_X0          (PROGRESS_BAR_RAW_X0 + PROGRESS_BAR_DELTA_X - PROGRESS_BAR_DELTA_X / 2)
+#define PROGRESS_BAR_X1          (PROGRESS_BAR_RAW_X1 - PROGRESS_BAR_DELTA_X / 2)
+
+#define PROGRESS_BAR_FULL_WIDTH  (PROGRESS_BAR_X1 - PROGRESS_BAR_X0)  // 100% progress bar width
+#define PROGRESS_BAR_SLICE_WIDTH (PROGRESS_BAR_FULL_WIDTH / 10)       // 10% progress bar width
+
+#if !defined(TFT43_V3_0) && !defined(TFT50_V3_0)
+  const GUI_RECT progressVal = {START_X,             PICON_START_Y + PICON_HEIGHT * 2 + PICON_SPACE_Y,
+                                PROGRESS_BAR_X0 - 1, ICON_START_Y + ICON_HEIGHT + SPACE_Y};
+#endif
+
+const GUI_RECT progressBar = {PROGRESS_BAR_X0, PICON_START_Y + PICON_HEIGHT * 2 + PICON_SPACE_Y * 2 + 1,
+                              PROGRESS_BAR_X1, ICON_START_Y + ICON_HEIGHT + SPACE_Y - PICON_SPACE_Y - 1};
+
+const char *const speedId[2] = {"Speed", "Flow"};
 bool hasFilamentData;
 
 #define TOGGLE_TIME  2000  // 1 seconds is 1000
 #define LAYER_DELTA  0.1   // minimal layer height change to update the layer display (avoid congestion in vase mode)
 
-#define LAYER_TITLE "Layer"
+#define LAYER_TITLE  "Layer"
 #define EXT_ICON_POS 0
 #define BED_ICON_POS 1
 #define FAN_ICON_POS 2
@@ -180,35 +201,68 @@ static inline void reDrawSpeed(int icon_pos)
   GUI_SetTextMode(GUI_TEXTMODE_TRANS);
   sprintf(tempstr, "%d%%", speedGetCurPercent(currentSpeedID));
   GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y,
-                 (uint8_t *)Speed_ID[currentSpeedID]);
+                 (uint8_t *)speedId[currentSpeedID]);
   GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (uint8_t *)tempstr);
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
 }
 
-static inline void reDrawProgress(int icon_pos, uint8_t prevProgress)
+static inline void reDrawTime(int icon_pos)
 {
-  char progress[6];
-  char timeElapsed[10];
+  char timeStr[10];
   uint8_t hour, min, sec;
-  uint8_t newProgress = getPrintProgress();
 
   getPrintTimeDetail(&hour, &min, &sec);
-  sprintf(progress, "%d%%", newProgress);
-  sprintf(timeElapsed, "%02u:%02u:%02u", hour, min, sec);
+  sprintf(timeStr, "%02u:%02u:%02u", hour, min, sec);
+
   GUI_SetNumMode(GUI_NUMMODE_ZERO);
   GUI_SetTextMode(GUI_TEXTMODE_TRANS);
   ICON_ReadDisplay(printinfo_points[icon_pos].x, printinfo_points[icon_pos].y, ICON_PRINTING_TIMER);
-  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (uint8_t *)progress);
-  GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (uint8_t *)timeElapsed);
+  GUI_DispString(printinfo_points[icon_pos].x + PICON_TITLE_X, printinfo_points[icon_pos].y + PICON_TITLE_Y, (uint8_t *)timeStr);
+
+  if (getPrintRemainingTime())  // if remaining time is pending
+  {
+    getPrintRemainingTimeDetail(&hour, &min, &sec);
+    sprintf(timeStr, "%02u:%02u:%02u", hour, min, sec);
+
+    GUI_DispStringInPrect(&printinfo_val_rect[icon_pos], (uint8_t *)timeStr);
+  }
+
   GUI_SetNumMode(GUI_NUMMODE_SPACE);
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
+}
 
-  if (newProgress != prevProgress)
-  {
-    uint16_t progStart = ((ProgressBar.x1 - ProgressBar.x0) * prevProgress) / 100;
-    uint16_t progEnd = ((ProgressBar.x1 - ProgressBar.x0) * newProgress) / 100;
-    GUI_FillRectColor(ProgressBar.x0 + progStart, ProgressBar.y0, ProgressBar.x0 + progEnd, ProgressBar.y1, MAT_ORANGE);
-  }
+static inline void reDrawProgressBar(uint8_t prevProgress, uint8_t nextProgress, uint16_t barColor, uint16_t sliceColor)
+{
+  uint16_t start = (PROGRESS_BAR_FULL_WIDTH * prevProgress) / 100;
+  uint16_t end = (PROGRESS_BAR_FULL_WIDTH * nextProgress) / 100;
+
+  GUI_FillRectColor(progressBar.x0 + start, progressBar.y0, progressBar.x0 + end, progressBar.y1, barColor);
+  GUI_SetColor(sliceColor);
+
+  start = prevProgress / 10 + 1;  // number of 10% markers + 1 (to skip redraw of 0% and already drawn marker)
+  end = nextProgress / 10;        // number of 10% markers
+
+  for (int i = start; i <= end; i++)
+    GUI_VLine(progressBar.x0 + PROGRESS_BAR_SLICE_WIDTH * i - 1, progressBar.y0 + 1, progressBar.y1 - 1);
+
+  GUI_RestoreColorDefault();
+}
+
+static inline void reDrawProgress(uint8_t prevProgress)
+{
+  uint8_t nextProgress = getPrintProgress();
+
+  #if !defined(TFT43_V3_0) && !defined(TFT50_V3_0)
+    char progStr[8];
+
+    sprintf(progStr, " %d%% ", nextProgress);
+    GUI_DispStringInPrect(&progressVal, (uint8_t *)progStr);
+  #endif
+
+  if (nextProgress >= prevProgress)
+    reDrawProgressBar(prevProgress, nextProgress, MAT_ORANGE, BLACK);
+  else  // if regress, swap indexes and colors
+    reDrawProgressBar(nextProgress, prevProgress, DARKGRAY, MAT_ORANGE);
 }
 
 static inline void reDrawLayer(int icon_pos)
@@ -262,18 +316,18 @@ static inline void toggleInfo(void)
 
 static inline void printingDrawPage(void)
 {
-  updatePrintProgress();
   reValueNozzle(EXT_ICON_POS);
   reValueBed(BED_ICON_POS);
   reDrawFan(FAN_ICON_POS);
-  reDrawProgress(TIM_ICON_POS, 0);
+  reDrawTime(TIM_ICON_POS);
   reDrawLayer(Z_ICON_POS);
   reDrawSpeed(SPD_ICON_POS);
+
+  // progress bar
   GUI_SetColor(ORANGE);
-  GUI_DrawRect(ProgressBar.x0 - 1, ProgressBar.y0 - 1, ProgressBar.x1 + 1, ProgressBar.y1 + 1);
-  GUI_SetColor(DARKGRAY);
-  GUI_FillPrect(&ProgressBar);
-  GUI_RestoreColorDefault();
+  GUI_DrawRect(progressBar.x0 - 1, progressBar.y0 - 1, progressBar.x1 + 1, progressBar.y1 + 1);
+  reDrawProgressBar(0, 100, DARKGRAY, MAT_ORANGE);
+  reDrawProgress(0);
 }
 
 void drawPrintInfo(void)
@@ -431,12 +485,19 @@ void menuPrinting(void)
     // check printing progress
     if (getPrintSize() != 0)
     {
-      // check print time or progress percentage change
-      if ((time != getPrintTime()) || (updatePrintProgress()))
+      // check print time change
+      if (time != getPrintTime())
       {
         time = getPrintTime();
         RAPID_SERIAL_LOOP();  // perform backend printing loop before drawing to avoid printer idling
-        reDrawProgress(TIM_ICON_POS, oldProgress);
+        reDrawTime(TIM_ICON_POS);
+      }
+
+      // check print progress percentage change
+      if (updatePrintProgress())
+      {
+        RAPID_SERIAL_LOOP();  // perform backend printing loop before drawing to avoid printer idling
+        reDrawProgress(oldProgress);
         oldProgress = getPrintProgress();
       }
     }
@@ -444,8 +505,9 @@ void menuPrinting(void)
     {
       if (getPrintProgress() != 100)
       {
+        reDrawTime(TIM_ICON_POS);
         updatePrintProgress();
-        reDrawProgress(TIM_ICON_POS, oldProgress);
+        reDrawProgress(oldProgress);
         oldProgress = getPrintProgress();
       }
     }

--- a/TFT/src/User/Variants/Resolution/TFT_320X240.h
+++ b/TFT/src/User/Variants/Resolution/TFT_320X240.h
@@ -51,7 +51,7 @@
 #define NAME_LARGE_FONT           FONT_SIZE_NORMAL
 #define VAL_LARGE_FONT            FONT_SIZE_NORMAL
 
-//Heating Menu
+// Heating Menu
 #define PREHEAT_TITLE_Y   3
 #define PREHEAT_TOOL_Y    32
 #define PREHEAT_BED_Y     55

--- a/TFT/src/User/Variants/Resolution/TFT_480X272.h
+++ b/TFT/src/User/Variants/Resolution/TFT_480X272.h
@@ -51,7 +51,7 @@
 #define NAME_LARGE_FONT           FONT_SIZE_NORMAL
 #define VAL_LARGE_FONT            FONT_SIZE_NORMAL
 
-//Heating Menu
+// Heating Menu
 #define PREHEAT_TITLE_Y   0
 #define PREHEAT_TOOL_Y    35
 #define PREHEAT_BED_Y     65

--- a/TFT/src/User/Variants/Resolution/TFT_480X320.h
+++ b/TFT/src/User/Variants/Resolution/TFT_480X320.h
@@ -51,7 +51,7 @@
 #define NAME_LARGE_FONT           FONT_SIZE_NORMAL
 #define VAL_LARGE_FONT            FONT_SIZE_NORMAL
 
-//Heating Menu
+// Heating Menu
 #define PREHEAT_TITLE_Y   4
 #define PREHEAT_TOOL_Y    43
 #define PREHEAT_BED_Y     74

--- a/TFT/src/User/Variants/Resolution/TFT_800X480.h
+++ b/TFT/src/User/Variants/Resolution/TFT_800X480.h
@@ -56,7 +56,7 @@
 #define VAL_LARGE_FONT            FONT_SIZE_LARGE
 #define VAL2_LARGE_FONT           FONT_SIZE_NORMAL
 
-//Heating Menu
+// Heating Menu
 #define PREHEAT_TITLE_Y   6
 #define PREHEAT_TOOL_Y    65
 #define PREHEAT_BED_Y     105

--- a/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
@@ -21,7 +21,7 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               HX8558  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558].
+  #define TFTLCD_DRIVER HX8558  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ILI9325, ST7789, HX8558].
 #endif
 //#define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT24_V1_1.h
+++ b/TFT/src/User/Variants/pin_TFT24_V1_1.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 //#define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT28_V1_0.h
+++ b/TFT/src/User/Variants/pin_TFT28_V1_0.h
@@ -18,8 +18,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       ILI9341  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 #ifndef LCD_DATA_16BIT
   #define LCD_DATA_16BIT 1  // LCD data 16bit or 8bit

--- a/TFT/src/User/Variants/pin_TFT28_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT28_V3_0.h
@@ -18,8 +18,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ST7789  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x05
+  #define TFTLCD_DRIVER       ST7789  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x05
 #endif
 
 #include "pin_TFT35_E3_V3_0.h"

--- a/TFT/src/User/Variants/pin_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V1_0.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT35_V1_2.h
+++ b/TFT/src/User/Variants/pin_TFT35_V1_2.h
@@ -8,8 +8,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               ILI9488  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       ILI9488  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 #ifndef LCD_DATA_16BIT
   #define LCD_DATA_16BIT 1  // LCD data 16bit or 8bit

--- a/TFT/src/User/Variants/pin_TFT35_V2_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V2_0.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT35_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT35_V3_0.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       (ILI9488 | NT35310)  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 #define STM32_HAS_FSMC  // FSMC 8080 interface(high speed), or normal IO interface(low speed)
 #ifndef LCD_DATA_16BIT

--- a/TFT/src/User/Variants/pin_TFT43_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT43_V3_0.h
@@ -17,8 +17,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
-  #define TFTLCD_DRIVER_SPEED         0x10     // SSD1963 needs slower speed
+  #define TFTLCD_DRIVER       SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
+  #define TFTLCD_DRIVER_SPEED 0x10     // SSD1963 needs slower speed
 #endif
 
 #ifndef SSD1963_LCD_PARA

--- a/TFT/src/User/Variants/pin_TFT70_V3_0.h
+++ b/TFT/src/User/Variants/pin_TFT70_V3_0.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
-  #define TFTLCD_DRIVER_SPEED         0x10     // SSD1963 needs slower speed
+  #define TFTLCD_DRIVER       SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
+  #define TFTLCD_DRIVER_SPEED 0x10     // SSD1963 needs slower speed
 #endif
 
 #ifndef SSD1963_LCD_PARA

--- a/TFT/src/User/Variants/pin_Template.h
+++ b/TFT/src/User/Variants/pin_Template.h
@@ -21,8 +21,8 @@
 
 // LCD interface
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER               RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
-  #define TFTLCD_DRIVER_SPEED         0x03
+  #define TFTLCD_DRIVER       RM68042  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
+  #define TFTLCD_DRIVER_SPEED 0x03
 #endif
 
 //#ifndef SSD1963_LCD_PARA  // Only for TFTLCD_DRIVER is SSD1963

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -81,8 +81,8 @@ baudrate:5
 
 #### Enable Multi-Serials
 # Multi-Serials connected to ESP3D, OctoPrint, Other TFT, etc...
-# Disable the serial port when it is not in use and floating
-# Avoid the serial port to receive the wrong data because of electromagnetic interference
+# Disable the serial port when it is not in use and floating.
+# Avoid the serial port to receive the wrong data because of electromagnetic interference.
 #   Options: [0: Disable all multi-serials,
 #             1: Enable SERIAL_PORT_2 alone,
 #             2: Enable SERIAL_PORT_3 alone,


### PR DESCRIPTION
**IMPROVEMENTS:**
* added M73 support printing from TFT:
  * format "M73 PXXX RXXX" (P: actual progression of print (%) - R: remaining time (minute)
* added M117 support for remaining print time printing from TFT:
  * format "M117 Time Left XXhYYmZZs"
* added action notification support for remaining print time printing from onboard SD
  * format "notification: Time Left XXhYYmZZs" (the notification is due to gcode "M117 Time Left XXhYYmZZs")
* autodetect M115 Cap:BUILD_PERCENT:. If the capability is supported by Marlin, when printing from TFT the M73 gcode is forwarded to Marlin
* improved progress bar layout displaying also 10% progress markers. It helps in case progress value cannot be displayed (not enough space on screen available) on screen (such as for TFT43/TFT50 having a low resolution)
* some code cleanup

If gcode M73/M117 or action notification for remaining print time is intercepetd and its value is greater than 0, then that information is displayed on the Time area in the Printing menu.
If gcode M73 P is intercepted, then progress value will be updated only by further gcode M73 P (controlled by slicer). That means the update performed by TFT has no more effect.
The print progress percentage value has been moved on the left of the progress bar. It was needed to free space for remaining time in Time area. Furthermore, that location is probably better. they are different representations of the same information (a print progress percentage).

**NOTE:** this PR is a review of PR #1410 started by belese. Thanks belese for your original work!

resolves PR #1410
resolves #1891

**PR STATE:** ready to merge


**LAYOUT FOR TFT DIFFERENT THAN TFT43/TFT50:**

![IMG_20210529_175356](https://user-images.githubusercontent.com/64427768/120077099-f60cba00-c0a8-11eb-932b-bbc8b19f0811.jpg)

![IMG_20210529_175914](https://user-images.githubusercontent.com/64427768/120077071-dc6b7280-c0a8-11eb-8f55-def9167fc01e.jpg)


**LAYOUT FOR TFT43/TFT50 (emulated on my TFT28):**

![IMG_20210529_182322](https://user-images.githubusercontent.com/64427768/120077614-919f2a00-c0ab-11eb-8eff-1232cdea86d4.jpg)

![IMG_20210529_182419](https://user-images.githubusercontent.com/64427768/120077637-ab407180-c0ab-11eb-90ba-caad3e26925c.jpg)
