### PR TITLE
Revert PR #1959 in Extrude and (Un)Load menu

### DIFF
--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -38,7 +38,10 @@ void menuExtrude(void)
 
   if (eAxisBackup.backedUp == false)
   {
-    loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
+    while (infoCmd.count != 0)
+    {
+      loopProcess();
+    }
 
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
     eAxisBackup.feedrate = coordinateGetFeedRate();

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -42,7 +42,10 @@ void menuLoadUnload(void)
 
   if (eAxisBackup.backedUp == false)
   {
-    loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
+    while (infoCmd.count != 0)
+    {
+      loopProcess();
+    }
 
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
     eAxisBackup.backedUp = true;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This PR reverts the changes made by PR #1959 to the Extruder and (Un)Load menu.
PR #1959 adds unnecessary extra safety measures to these menus that could cause temporary freezing of the TFT.