### PR TITLE
Reworked fix to avoid freeze in loops caused by popups

### DIFF
--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -29,7 +29,7 @@ static void resetRequestCommandInfo(
 
   while (infoCmd.count || infoHost.wait)
   {
-    loopProcessNoPopup();  // Wait for the communication to be clean before requestCommand
+    loopProcess_PopupHandle();  // Wait for the communication to be clean before requestCommand
   }
   requestCommandInfo.inWaitResponse = true;
   requestCommandInfo.inResponse = false;
@@ -71,7 +71,7 @@ bool request_M21(void)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   clearRequestCommandInfo();
@@ -92,7 +92,7 @@ char *request_M20(void)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
@@ -121,7 +121,7 @@ char *request_M33(char *filename)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
@@ -172,7 +172,7 @@ long request_M23_M36(char *filename)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   if (requestCommandInfo.inError)
@@ -300,7 +300,7 @@ char *request_M20_macros(char *nextdir)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
@@ -317,7 +317,7 @@ void request_M98(char *filename)
   // Wait for response
   while (!requestCommandInfo.done)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   clearRequestCommandInfo();

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -3,11 +3,6 @@
 
 REQUEST_COMMAND_INFO requestCommandInfo = {0};
 
-bool isWaitingResponse(void)
-{
-  return (!requestCommandInfo.done);
-}
-
 static void resetRequestCommandInfo(
   const char *string_start,   // The magic to identify the start
   const char *string_stop,    // The magic to identify the stop
@@ -32,8 +27,10 @@ static void resetRequestCommandInfo(
   if (string_error2)
     requestCommandInfo.error_num = 3;
 
-  loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean before requestCommand
-
+  while (infoCmd.count || infoHost.wait)
+  {
+    loopProcessNoPopup();  // Wait for the communication to be clean before requestCommand
+  }
   requestCommandInfo.inWaitResponse = true;
   requestCommandInfo.inResponse = false;
   requestCommandInfo.done = false;
@@ -72,7 +69,10 @@ bool request_M21(void)
   mustStoreCmd("M21\n");
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   clearRequestCommandInfo();
   // Check reponse
@@ -90,7 +90,10 @@ char *request_M20(void)
   mustStoreCmd("M20\n");
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -116,7 +119,10 @@ char *request_M33(char *filename)
     mustStoreCmd("M33 %s\n", filename);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -164,7 +170,10 @@ long request_M23_M36(char *filename)
   }
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   if (requestCommandInfo.inError)
   {
@@ -289,7 +298,10 @@ char *request_M20_macros(char *nextdir)
   mustStoreCmd(command);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -303,7 +315,10 @@ void request_M98(char *filename)
   mustStoreCmd(command);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  while (!requestCommandInfo.done)
+  {
+    loopProcessNoPopup();
+  }
 
   clearRequestCommandInfo();
 }

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -24,11 +24,6 @@ static bool updateM27_waiting = false;
 static float last_E_pos;
 bool filamentRunoutAlarm;
 
-bool isHostPrinting(void)
-{
-  return (infoHost.printing);
-}
-
 void setRunoutAlarmTrue(void)
 {
   filamentRunoutAlarm = true;
@@ -445,12 +440,13 @@ void printAbort(void)
         request_M0();  // M524 is not supportet in reprap firmware
       }
 
-      if (infoHost.printing)
+      if (infoHost.printing == true)
       {
-        setDialogText(LABEL_SCREEN_INFO, LABEL_BUSY, LABEL_BACKGROUND, LABEL_BACKGROUND);
-        showDialog(DIALOG_TYPE_INFO, NULL, NULL, NULL);
-
-        loopProcessToCondition(&isHostPrinting);  // wait for the printer to settle down
+        popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
+        while (infoHost.printing == true)  // wait for the printer to settle down
+        {
+          loopProcessNoPopup();
+        }
       }
       break;
 
@@ -495,7 +491,12 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
     case TFT_UDISK:
     case TFT_SD:
       if (infoPrinting.pause == true && pauseType == PAUSE_M0)
-        loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
+      {
+        while (infoCmd.count != 0)
+        {
+          loopProcessNoPopup();
+        }
+      }
 
       static COORDINATE tmp;
       bool isCoorRelative = coorGetRelative();

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -442,10 +442,11 @@ void printAbort(void)
 
       if (infoHost.printing == true)
       {
+        GUI_Clear(infoSettings.bg_color);  // delete screen otherwise action buttons would be visible from previous dialog
         popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
         while (infoHost.printing == true)  // wait for the printer to settle down
         {
-          loopProcessNoPopup();
+          loopProcess_PopupHandle();
         }
       }
       break;
@@ -494,7 +495,7 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
       {
         while (infoCmd.count != 0)
         {
-          loopProcessNoPopup();
+          loopProcess_PopupHandle();
         }
       }
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -6,16 +6,6 @@ GCODE_QUEUE infoCacheCmd;  // Only when heatHasWaiting() is false the cmd in thi
 static uint8_t cmd_index = 0;
 static bool ispolling = true;
 
-bool isFullCmdQueue(void)
-{
-  return (infoCmd.count >= CMD_MAX_LIST);
-}
-
-bool isNotEmptyCmdQueue(void)
-{
-  return (infoCmd.count || infoHost.wait);
-}
-
 // Is there a code character in the current gcode command.
 static bool cmd_seen(char code)
 {
@@ -91,8 +81,11 @@ void mustStoreCmd(const char * format,...)
   if (pQueue->count >= CMD_MAX_LIST)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
+  }  
 
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+  while (pQueue->count >= CMD_MAX_LIST)
+  {
+    loopProcessNoPopup();
   }
 
   va_list va;
@@ -162,8 +155,11 @@ void mustStoreCacheCmd(const char * format,...)
   if (pQueue->count >= CMD_MAX_LIST)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
+  }
 
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+  while (pQueue->count >= CMD_MAX_LIST)
+  {
+    loopProcessNoPopup();
   }
 
   va_list va;

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -85,7 +85,7 @@ void mustStoreCmd(const char * format,...)
 
   while (pQueue->count >= CMD_MAX_LIST)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   va_list va;
@@ -159,7 +159,7 @@ void mustStoreCacheCmd(const char * format,...)
 
   while (pQueue->count >= CMD_MAX_LIST)
   {
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
   }
 
   va_list va;

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -878,38 +878,19 @@ void loopFrontEnd(void)
   // Loop for filament runout detection
   loopFrontEndFILRunoutDetect();
 #endif
-
-  // loop for popup menu
-  loopPopup();
 }
 
-void loopProcess(void)
+// to be used in subfunctions of the menus
+void loopProcessNoPopup(void)  // use this in "while" loops where popups & dialogs should be avoided
 {
   loopBackEnd();
   loopFrontEnd();
 }
 
-void menuDummy(void)
+// to be used in menus in the "while" loop where the key presses are checked
+void loopProcessWithPopup(void)
 {
-  infoMenu.cur--;
-}
-
-void loopProcessToCondition(CONDITION_CALLBACK condCallback)
-{
-  uint8_t curMenu = infoMenu.cur;
-  bool invokedUI = false;
-
-  while (condCallback())  // loop until the condition is no more satisfied
-  {
-    loopProcess();
-
-    if (infoMenu.cur > curMenu)  // if a user interaction is needed (e.g. dialog box UI), handle it
-    {
-      invokedUI = true;
-      (*infoMenu.menu[infoMenu.cur])();
-    }
-  }
-
-  if (invokedUI)  // if a UI was invoked, load a dummy menu just to force the caller also to refresh its menu
-    infoMenu.menu[++infoMenu.cur] = menuDummy;
+  loopBackEnd();
+  loopFrontEnd();
+  loopPopup();
 }

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -892,14 +892,17 @@ void loopProcess(void)
 // to be used in subroutines with loops that need to handle eventual popups
 void loopProcess_PopupHandle(void)
 {
-  loopProcess();
+  loopBackEnd();
+  loopFrontEnd();
   loopPopupHandle();
 }
 
 // to be used inside menus in the while loop that keeps the menu alive
 void loopProcess_MenuLoop(void)
 {
-  loopProcess_PopupHandle();
+  loopBackEnd();
+  loopFrontEnd();
+  loopPopupHandle();
   if (lastMenu == menuDialog)
   {
     lastMenu = infoMenu.menu[infoMenu.cur];

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -878,19 +878,32 @@ void loopFrontEnd(void)
   // Loop for filament runout detection
   loopFrontEndFILRunoutDetect();
 #endif
-}
 
-// to be used in subfunctions of the menus
-void loopProcessNoPopup(void)  // use this in "while" loops where popups & dialogs should be avoided
-{
-  loopBackEnd();
-  loopFrontEnd();
-}
-
-// to be used in menus in the "while" loop where the key presses are checked
-void loopProcessWithPopup(void)
-{
-  loopBackEnd();
-  loopFrontEnd();
+  // loop for popup menu
   loopPopup();
 }
+
+void loopProcess(void)
+{
+  loopBackEnd();
+  loopFrontEnd();
+}
+
+// to be used in subroutines with loops that need to handle eventual popups
+void loopProcess_PopupHandle(void)
+{
+  loopProcess();
+  loopPopupHandle();
+}
+
+// to be used inside menus in the while loop that keeps the menu alive
+void loopProcess_MenuLoop(void)
+{
+  loopProcess_PopupHandle();
+  if (lastMenu == menuDialog)
+  {
+    lastMenu = infoMenu.menu[infoMenu.cur];
+    infoMenu.menu[infoMenu.cur] = NULL;  // flag, popup in a loop
+  }
+}
+

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -139,8 +139,6 @@ typedef struct
   LIVE_DATA lines[LIVEICON_LINES];
 } LIVE_INFO;
 
-typedef bool (* CONDITION_CALLBACK)(void);
-
 void showLiveInfo(uint8_t index, const LIVE_INFO * liveicon, const ITEM * item);
 
 extern const GUI_RECT exhibitRect;
@@ -179,8 +177,23 @@ GUI_POINT getIconStartPoint(int index);
 
 void loopBackEnd(void);
 void loopFrontEnd(void);
-void loopProcess(void);
-void loopProcessToCondition(CONDITION_CALLBACK condCallback);
+
+// to be used in subfunctions of the menus
+extern void loopProcessNoPopup(void);
+
+// to be used in menus in the "while" loop where the key presses are checked
+extern void loopProcessWithPopup(void);
+
+// to be used at start of menus in the "while" loop where waiting for a conditional
+// (ex. waiting for an empty buffer, waiting for host, etc)
+#define LOOP_PROCESS_POPUP_HANDLE               \
+{                                               \
+  loopProcessWithPopup();                       \
+  if (lastMenu != infoMenu.menu[infoMenu.cur])  \
+  {                                             \
+    return;                                     \
+  }                                             \
+}
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -177,19 +177,16 @@ GUI_POINT getIconStartPoint(int index);
 
 void loopBackEnd(void);
 void loopFrontEnd(void);
-
-// to be used in subfunctions of the menus
-void loopProcessNoPopup(void);
-
-// to be used in menus in the "while" loop where the key presses are checked
-void loopProcessWithPopup(void);
+void loopProcess(void);
+void loopProcess_PopupHandle(void);
+void loopProcess_MenuLoop(void);
 
 // to be used at start of menus in the "while" loop where waiting for a conditional
 // (ex. waiting for an empty buffer, waiting for host, etc)
-#define LOOP_PROCESS_POPUP_HANDLE               \
+#define LOOP_PROCESS_START_OF_MENU              \
 {                                               \
-  loopProcessWithPopup();                       \
-  if (lastMenu != infoMenu.menu[infoMenu.cur])  \
+  loopProcess_PopupHandle();                    \
+  if (lastMenu == menuDialog)                   \
   {                                             \
     return;                                     \
   }                                             \

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -179,10 +179,10 @@ void loopBackEnd(void);
 void loopFrontEnd(void);
 
 // to be used in subfunctions of the menus
-extern void loopProcessNoPopup(void);
+void loopProcessNoPopup(void);
 
 // to be used in menus in the "while" loop where the key presses are checked
-extern void loopProcessWithPopup(void);
+void loopProcessWithPopup(void);
 
 // to be used at start of menus in the "while" loop where waiting for a conditional
 // (ex. waiting for an empty buffer, waiting for host, etc)

--- a/TFT/src/User/Menu/ABL.c
+++ b/TFT/src/User/Menu/ABL.c
@@ -163,7 +163,7 @@ void menuUBLSaveLoad(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 

--- a/TFT/src/User/Menu/ABL.c
+++ b/TFT/src/User/Menu/ABL.c
@@ -163,7 +163,7 @@ void menuUBLSaveLoad(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 

--- a/TFT/src/User/Menu/BLTouch.c
+++ b/TFT/src/User/Menu/BLTouch.c
@@ -57,6 +57,6 @@ void menuBLTouch(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/BLTouch.c
+++ b/TFT/src/User/Menu/BLTouch.c
@@ -57,6 +57,6 @@ void menuBLTouch(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -217,7 +217,7 @@ void menuBabystep(void)
       babyReDraw(now_babystep, new_z_offset, force_z_offset, true);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   offsetSetValue(new_z_offset);  // set new Z offset. Required if current Z offset is not changed applying babystep changes (e.g. no BABYSTEP_ZPROBE_OFFSET is set in Marlin FW)

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -217,7 +217,7 @@ void menuBabystep(void)
       babyReDraw(now_babystep, new_z_offset, force_z_offset, true);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   offsetSetValue(new_z_offset);  // set new Z offset. Required if current Z offset is not changed applying babystep changes (e.g. no BABYSTEP_ZPROBE_OFFSET is set in Marlin FW)

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -135,6 +135,6 @@ void menuBedLeveling(void)
       blUpdateState(&bedLevelingItems);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -135,6 +135,6 @@ void menuBedLeveling(void)
       blUpdateState(&bedLevelingItems);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/BedLevelingLayer2.c
+++ b/TFT/src/User/Menu/BedLevelingLayer2.c
@@ -119,6 +119,6 @@ void menuBedLevelingLayer2(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/BedLevelingLayer2.c
+++ b/TFT/src/User/Menu/BedLevelingLayer2.c
@@ -119,6 +119,6 @@ void menuBedLevelingLayer2(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/CaseLight.c
+++ b/TFT/src/User/Menu/CaseLight.c
@@ -109,6 +109,6 @@ void menuCaseLight(void)
       caseLightBrightnessReDraw();
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/CaseLight.c
+++ b/TFT/src/User/Menu/CaseLight.c
@@ -109,6 +109,6 @@ void menuCaseLight(void)
       caseLightBrightnessReDraw();
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -90,7 +90,7 @@ void menuBaudrate(void)
       reminderMessage(LABEL_UNCONNECTED, STATUS_UNCONNECT);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -137,6 +137,6 @@ void menuConnectionSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -90,7 +90,7 @@ void menuBaudrate(void)
       reminderMessage(LABEL_UNCONNECTED, STATUS_UNCONNECT);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -137,6 +137,6 @@ void menuConnectionSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -107,7 +107,7 @@ void menuExtrude(void)
         else
         {
           infoMenu.menu[++infoMenu.cur] = menuHeat;
-          eAxisBackup.backedUp = false; // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
+          eAxisBackup.backedUp = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
         }
         break;
 
@@ -128,7 +128,7 @@ void menuExtrude(void)
       case KEY_ICON_7:
         cooldownTemperature();
         infoMenu.cur--;
-        eAxisBackup.backedUp = false; // exiting from Extrude menu, no need for it anymore
+        eAxisBackup.backedUp = false;  // exiting from Extrude menu, no need for it anymore
         break;
 
       default:

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -41,13 +41,17 @@ void menuExtrude(void)
     if (infoCmd.count != 0)
     {
       if ((strncmp(infoCmd.queue[infoCmd.index_r].gcode, "M155", 4) != 0) || (infoCmd.count > 1))
-      { // avoid splash when returning from "Heat" menu 
+      { // avoid splash when returning from "Heat" menu
+        if (lastMenu == menuDialog)
+        { // delete screen otherwise action buttons would be visible from previous dialog
+          GUI_Clear(infoSettings.bg_color);
+        }
         popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
       }
 
       while (infoCmd.count != 0)
       {
-        LOOP_PROCESS_POPUP_HANDLE;
+        LOOP_PROCESS_START_OF_MENU;
       }
     }
 
@@ -167,7 +171,7 @@ void menuExtrude(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (eAxisBackup.backedUp == false)  // the user exited from menu (not any other process/popup/etc)

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -156,6 +156,6 @@ void menuFan(void)
       fanReDraw(fan_index, true);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -156,6 +156,6 @@ void menuFan(void)
       fanReDraw(fan_index, true);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -383,7 +383,7 @@ void menuFeatureSettings(void)
         listViewRefreshItem(index);
       }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -383,7 +383,7 @@ void menuFeatureSettings(void)
         listViewRefreshItem(index);
       }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -122,7 +122,7 @@ void menuHeat(void)
       temperatureReDraw(tool_index, NULL, true);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   // Set slow update time if not waiting for target temperature

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -122,7 +122,7 @@ void menuHeat(void)
       temperatureReDraw(tool_index, NULL, true);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   // Set slow update time if not waiting for target temperature

--- a/TFT/src/User/Menu/Home.c
+++ b/TFT/src/User/Menu/Home.c
@@ -36,6 +36,6 @@ void menuHome(void)
       default: break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Home.c
+++ b/TFT/src/User/Menu/Home.c
@@ -36,6 +36,6 @@ void menuHome(void)
       default: break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -501,7 +501,7 @@ void menuLEDColorCustom(void)
       updateForced = sendingNeeded = false;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   // restore default
@@ -576,6 +576,6 @@ void menuLEDColor(void)
     if (key_num <= KEY_ICON_5)  // change LED color
       ledSendValue(&ledValue);
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -501,7 +501,7 @@ void menuLEDColorCustom(void)
       updateForced = sendingNeeded = false;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   // restore default
@@ -576,6 +576,6 @@ void menuLEDColor(void)
     if (key_num <= KEY_ICON_5)  // change LED color
       ledSendValue(&ledValue);
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -188,6 +188,6 @@ void menuLevelCorner(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -188,6 +188,6 @@ void menuLevelCorner(void)
       }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -114,6 +114,6 @@ void menuManualLeveling(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -114,6 +114,6 @@ void menuManualLeveling(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -45,13 +45,17 @@ void menuLoadUnload(void)
     if (infoCmd.count != 0)
     {
       if ((strncmp(infoCmd.queue[infoCmd.index_r].gcode, "M155", 4) != 0) || (infoCmd.count > 1))
-      { // avoid splash when returning from "Heat" menu 
+      { // avoid splash when returning from "Heat" menu
+        if (lastMenu == menuDialog)
+        { // delete screen otherwise action buttons would be visible from previous dialog
+          GUI_Clear(infoSettings.bg_color);
+        }
         popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
       }
 
       while (infoCmd.count != 0)
       {
-        LOOP_PROCESS_POPUP_HANDLE;
+        LOOP_PROCESS_START_OF_MENU;
       }
     }
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
@@ -151,7 +155,7 @@ void menuLoadUnload(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (eAxisBackup.backedUp == false)  // the user exited from menu (not any other process/popup/etc)

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -28,7 +28,6 @@ typedef enum
 } CMD_TYPE;
 
 static uint8_t tool_index = NOZZLE0;
-static CMD_TYPE lastCmd = NONE;
 
 // set the hotend to the minimum extrusion temperature if user selected "OK"
 void loadMinTemp_OK(void)
@@ -39,6 +38,7 @@ void loadMinTemp_OK(void)
 void menuLoadUnload(void)
 {
   KEY_VALUES key_num = KEY_IDLE;
+  static CMD_TYPE lastCmd = NONE;
 
   if (eAxisBackup.backedUp == false)
   {
@@ -105,7 +105,7 @@ void menuLoadUnload(void)
         case KEY_ICON_5:  // heat menu
           infoMenu.menu[++infoMenu.cur] = menuHeat;
           lastCmd = NONE;
-          eAxisBackup.backedUp = false; // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
+          eAxisBackup.backedUp = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
           break;
 
         case KEY_ICON_6:  // cool down nozzle
@@ -117,7 +117,7 @@ void menuLoadUnload(void)
           cooldownTemperature();
           lastCmd = NONE;
           infoMenu.cur--;
-          eAxisBackup.backedUp = false; // the user exited from menu (not any other process/popup/etc)
+          eAxisBackup.backedUp = false;  // the user exited from menu (not any other process/popup/etc)
           break;
 
         default:

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -282,6 +282,6 @@ void menuMBL(void)
 
     probeHeightQueryCoord();
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -282,6 +282,6 @@ void menuMBL(void)
 
     probeHeightQueryCoord();
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/MachineSettings.c
+++ b/TFT/src/User/Menu/MachineSettings.c
@@ -29,7 +29,7 @@ void menuCustom(void)
     if (curIndex < customcodes.count)
       mustStoreScript(customcodes.gcode[curIndex]);
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -97,7 +97,7 @@ void menuEepromSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -178,6 +178,6 @@ void menuMachineSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/MachineSettings.c
+++ b/TFT/src/User/Menu/MachineSettings.c
@@ -29,7 +29,7 @@ void menuCustom(void)
     if (curIndex < customcodes.count)
       mustStoreScript(customcodes.gcode[curIndex]);
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 
@@ -97,7 +97,7 @@ void menuEepromSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 
@@ -178,6 +178,6 @@ void menuMachineSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/MainPage.c
+++ b/TFT/src/User/Menu/MainPage.c
@@ -98,7 +98,7 @@ void menuMain(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 

--- a/TFT/src/User/Menu/MainPage.c
+++ b/TFT/src/User/Menu/MainPage.c
@@ -98,7 +98,7 @@ void menuMain(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -966,7 +966,7 @@ void menuMeshEditor(void)
       oldIndex = curIndex;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (forceExit)

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -966,7 +966,7 @@ void menuMeshEditor(void)
       oldIndex = curIndex;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (forceExit)

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -172,7 +172,7 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
 
     probeHeightQueryCoord();
 
-    loopProcess();
+    loopProcessNoPopup();
 
     if (infoMenu.menu[infoMenu.cur] != menuMeshEditor)
     {

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -172,7 +172,7 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
 
     probeHeightQueryCoord();
 
-    loopProcessNoPopup();
+    loopProcess_PopupHandle();
 
     if (infoMenu.menu[infoMenu.cur] != menuMeshEditor)
     {

--- a/TFT/src/User/Menu/MeshValid.c
+++ b/TFT/src/User/Menu/MeshValid.c
@@ -59,6 +59,6 @@ void menuMeshValid(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/MeshValid.c
+++ b/TFT/src/User/Menu/MeshValid.c
@@ -59,6 +59,6 @@ void menuMeshValid(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/More.c
+++ b/TFT/src/User/Menu/More.c
@@ -100,6 +100,6 @@ void menuMore(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/More.c
+++ b/TFT/src/User/Menu/More.c
@@ -100,6 +100,6 @@ void menuMore(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -152,7 +152,7 @@ void menuMove(void)
           #endif
           break;
     }
-    loopProcess();
+    loopProcessWithPopup();
     update_gantry();
   }
   mustStoreCmd("G90\n");

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -152,7 +152,7 @@ void menuMove(void)
           #endif
           break;
     }
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
     update_gantry();
   }
   mustStoreCmd("G90\n");

--- a/TFT/src/User/Menu/NotificationMenu.c
+++ b/TFT/src/User/Menu/NotificationMenu.c
@@ -87,7 +87,7 @@ void menuNotification(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   setNotificationHandler(NULL);

--- a/TFT/src/User/Menu/NotificationMenu.c
+++ b/TFT/src/User/Menu/NotificationMenu.c
@@ -87,7 +87,7 @@ void menuNotification(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   setNotificationHandler(NULL);

--- a/TFT/src/User/Menu/ParameterSettings.c
+++ b/TFT/src/User/Menu/ParameterSettings.c
@@ -183,7 +183,7 @@ void menuShowParameter(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -286,6 +286,6 @@ void menuParameterSettings(void)
         }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/ParameterSettings.c
+++ b/TFT/src/User/Menu/ParameterSettings.c
@@ -183,7 +183,7 @@ void menuShowParameter(void)
       }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 
@@ -286,6 +286,6 @@ void menuParameterSettings(void)
         }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -144,7 +144,7 @@ void menuPidWait(void)
 
     pidCheckTimeout();
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -323,6 +323,6 @@ void menuPid(void)
 
     pidCheckTimeout();
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -144,7 +144,7 @@ void menuPidWait(void)
 
     pidCheckTimeout();
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 
@@ -323,6 +323,6 @@ void menuPid(void)
 
     pidCheckTimeout();
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -119,7 +119,7 @@ void menuDialog(void)
     if (action_loop != NULL)
       action_loop();
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -238,5 +238,17 @@ void loopPopup(void)
   if (infoMenu.menu[infoMenu.cur] != menuDialog)
   { //handle the user interaction, then reload the previous menu
     infoMenu.menu[++infoMenu.cur] = menuDialog;
+  }
+}
+
+void loopPopupHandle(void)
+{
+  if ((lastMenu != NULL) && (infoMenu.menu[infoMenu.cur] == menuDialog))
+  {
+    lastMenu = NULL;  // popup in a loop
+    (*infoMenu.menu[infoMenu.cur])();
+    
+    // process will return here after the popup/dialog is closed
+    lastMenu = menuDialog;  // flag that there has been a popup during a loop
   }
 }

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -119,7 +119,7 @@ void menuDialog(void)
     if (action_loop != NULL)
       action_loop();
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 

--- a/TFT/src/User/Menu/Popup.h
+++ b/TFT/src/User/Menu/Popup.h
@@ -63,6 +63,13 @@ void loopPopup(void);
     showDialog(_type, NULL, NULL, NULL);                          \
   }
 
+#define popupSplash(_type, _title, _msg)                                          \
+  {                                                                               \
+    LABELCHAR(title, _title);                                                     \
+    LABELCHAR(msg, _msg);                                                         \
+    popupDrawPage(_type, NULL, (uint8_t *)title, (uint8_t *)msg, NULL, NULL);     \
+  }
+
 #ifdef __cplusplus
 }
 #endif

--- a/TFT/src/User/Menu/Popup.h
+++ b/TFT/src/User/Menu/Popup.h
@@ -56,6 +56,7 @@ void popupDrawPage(DIALOG_TYPE type, BUTTON * btn, const uint8_t * title, const 
 void menuDialog(void);
 void showDialog(DIALOG_TYPE type, void (*ok_action)(), void (*cancel_action)(), void (*loop_action)());
 void loopPopup(void);
+void loopPopupHandle(void);
 
 #define popupReminder(_type, _title, _msg)                        \
   {                                                               \

--- a/TFT/src/User/Menu/PowerFailed.c
+++ b/TFT/src/User/Menu/PowerFailed.c
@@ -249,7 +249,7 @@ void menuPowerOff(void)
         }
       #endif
 
-      loopProcess();
+      loopProcessWithPopup();
     }
   }
   else

--- a/TFT/src/User/Menu/PowerFailed.c
+++ b/TFT/src/User/Menu/PowerFailed.c
@@ -249,7 +249,7 @@ void menuPowerOff(void)
         }
       #endif
 
-      loopProcessWithPopup();
+      loopProcess_MenuLoop();
     }
   }
   else

--- a/TFT/src/User/Menu/PreheatMenu.c
+++ b/TFT/src/User/Menu/PreheatMenu.c
@@ -137,6 +137,6 @@ void menuPreheat(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/PreheatMenu.c
+++ b/TFT/src/User/Menu/PreheatMenu.c
@@ -137,6 +137,6 @@ void menuPreheat(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -307,7 +307,7 @@ void menuPrintFromSource(void)
       }
     #endif
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 
@@ -386,7 +386,7 @@ void menuPrint(void)
       default:
         break;
     }
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
 selectEnd:

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -307,7 +307,7 @@ void menuPrintFromSource(void)
       }
     #endif
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 
@@ -386,7 +386,7 @@ void menuPrint(void)
       default:
         break;
     }
-    loopProcess();
+    loopProcessWithPopup();
   }
 
 selectEnd:

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -631,6 +631,6 @@ void menuPrinting(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -631,6 +631,6 @@ void menuPrinting(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/RRFMacros.c
+++ b/TFT/src/User/Menu/RRFMacros.c
@@ -204,7 +204,7 @@ void menuCallMacro(void)
       GUI_SetBkColor(infoSettings.bg_color);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }
 

--- a/TFT/src/User/Menu/RRFMacros.c
+++ b/TFT/src/User/Menu/RRFMacros.c
@@ -204,7 +204,7 @@ void menuCallMacro(void)
       GUI_SetBkColor(infoSettings.bg_color);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }
 

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -70,7 +70,7 @@ void menuLanguage(void)
       }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -127,7 +127,7 @@ void menuEmulatorBGColor(void)
       }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -181,7 +181,7 @@ void menuEmulatorFontColor(void)
       }
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -257,7 +257,7 @@ void menuMarlinModeSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -325,7 +325,7 @@ void menuSoundSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -396,7 +396,7 @@ void menuBrightnessSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -498,7 +498,7 @@ void menuScreenSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -70,7 +70,7 @@ void menuLanguage(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -127,7 +127,7 @@ void menuEmulatorBGColor(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -181,7 +181,7 @@ void menuEmulatorFontColor(void)
       }
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -257,7 +257,7 @@ void menuMarlinModeSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -325,7 +325,7 @@ void menuSoundSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -396,7 +396,7 @@ void menuBrightnessSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))
@@ -498,7 +498,7 @@ void menuScreenSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   if (memcmp(&now, &infoSettings, sizeof(SETTINGS)))

--- a/TFT/src/User/Menu/SelectMode.c
+++ b/TFT/src/User/Menu/SelectMode.c
@@ -229,7 +229,7 @@ void switchMode(void)
           updateNextHeatCheckTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
           while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
           {
-            loopProcessNoPopup();
+            loopProcess_PopupHandle();
           }
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshBoot = false;

--- a/TFT/src/User/Menu/SelectMode.c
+++ b/TFT/src/User/Menu/SelectMode.c
@@ -229,7 +229,7 @@ void switchMode(void)
           updateNextHeatCheckTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
           while (OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME)  // Display logo BTT_BOOTSCREEN_TIME ms
           {
-            loopProcess();
+            loopProcessNoPopup();
           }
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           freshBoot = false;

--- a/TFT/src/User/Menu/SettingsMenu.c
+++ b/TFT/src/User/Menu/SettingsMenu.c
@@ -205,6 +205,6 @@ void menuSettings(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/SettingsMenu.c
+++ b/TFT/src/User/Menu/SettingsMenu.c
@@ -205,6 +205,6 @@ void menuSettings(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -131,6 +131,6 @@ void menuSpeed(void)
       percentageReDraw(item_index, true);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -131,6 +131,6 @@ void menuSpeed(void)
       percentageReDraw(item_index, true);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -324,7 +324,7 @@ void menuStatus(void)
     }
 
     toggleTool();
-    loopProcess();
+    loopProcessWithPopup();
   }
   // disable position auto report
   coordinateQuery(0);

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -324,7 +324,7 @@ void menuStatus(void)
     }
 
     toggleTool();
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
   // disable position auto report
   coordinateQuery(0);

--- a/TFT/src/User/Menu/Touchmi.c
+++ b/TFT/src/User/Menu/Touchmi.c
@@ -67,6 +67,6 @@ void menuTouchMi(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Touchmi.c
+++ b/TFT/src/User/Menu/Touchmi.c
@@ -67,6 +67,6 @@ void menuTouchMi(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -6,7 +6,6 @@
 static uint8_t tool_index = NOZZLE0;
 static uint8_t degreeSteps_index = 1;
 static uint8_t extStep_index = 0;
-static bool loadRequested = false;
 
 // set the hotend to the minimum extrusion temperature if user selected "OK"
 void extrudeMinTemp_OK(void)
@@ -76,6 +75,7 @@ void menuTuneExtruder(void)
   int16_t lastTarget = heatGetTargetTemp(tool_index);
   int16_t actCurrent;
   int16_t actTarget;
+  static bool loadRequested;
 
   heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
 
@@ -189,7 +189,7 @@ void menuTuneExtruder(void)
       temperatureReDraw(tool_index, NULL, true);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   // Set slow update time if not waiting for target temperature
@@ -292,6 +292,6 @@ void menuNewExtruderESteps(void)
       showNewESteps(measured_length, old_esteps, &new_esteps);
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -189,7 +189,7 @@ void menuTuneExtruder(void)
       temperatureReDraw(tool_index, NULL, true);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   // Set slow update time if not waiting for target temperature
@@ -292,6 +292,6 @@ void menuNewExtruderESteps(void)
       showNewESteps(measured_length, old_esteps, &new_esteps);
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Tuning.c
+++ b/TFT/src/User/Menu/Tuning.c
@@ -50,6 +50,6 @@ void menuTuning(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/Tuning.c
+++ b/TFT/src/User/Menu/Tuning.c
@@ -50,6 +50,6 @@ void menuTuning(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/UnifiedHeat.c
+++ b/TFT/src/User/Menu/UnifiedHeat.c
@@ -52,6 +52,6 @@ void menuUnifiedHeat(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/UnifiedHeat.c
+++ b/TFT/src/User/Menu/UnifiedHeat.c
@@ -52,6 +52,6 @@ void menuUnifiedHeat(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/UnifiedMove.c
+++ b/TFT/src/User/Menu/UnifiedMove.c
@@ -71,6 +71,6 @@ void menuUnifiedMove(void)
         break;
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 }

--- a/TFT/src/User/Menu/UnifiedMove.c
+++ b/TFT/src/User/Menu/UnifiedMove.c
@@ -71,6 +71,6 @@ void menuUnifiedMove(void)
         break;
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 }

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -272,7 +272,7 @@ void menuZOffset(void)
       babystepReset();
     }
 
-    loopProcess();
+    loopProcessWithPopup();
   }
 
   // restore original ABL state

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -272,7 +272,7 @@ void menuZOffset(void)
       babystepReset();
     }
 
-    loopProcessWithPopup();
+    loopProcess_MenuLoop();
   }
 
   // restore original ABL state

--- a/TFT/src/User/includes.h
+++ b/TFT/src/User/includes.h
@@ -144,6 +144,7 @@ typedef struct
 } MENU;
 
 extern MENU infoMenu;
+extern FP_MENU lastMenu;
 
 typedef struct
 {

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -3,7 +3,7 @@
 HOST   infoHost;   // Information interaction with Marlin
 MENU   infoMenu;   // Menu structure
 CLOCKS mcuClocks;  // system clocks: SYSCLK, AHB, APB1, APB2, APB1_Timer, APB2_Timer2
-FP_MENU lastMenu;
+FP_MENU lastMenu;  // last active menu
 
 void mcu_GetClocksFreq(CLOCKS *clk)
 {

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -114,7 +114,14 @@ int main(void)
 
   for (; ;)
   {
-    lastMenu = infoMenu.menu[infoMenu.cur];
+    if (infoMenu.menu[infoMenu.cur]== NULL)
+    { // there has been a popup in the menu, it needs to be redrawn
+      infoMenu.menu[infoMenu.cur] = lastMenu;
+    }
+    else
+    { // keep track of last active menu
+      lastMenu = infoMenu.menu[infoMenu.cur];
+    }
     (*infoMenu.menu[infoMenu.cur])();
   }
 }

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -3,6 +3,7 @@
 HOST   infoHost;   // Information interaction with Marlin
 MENU   infoMenu;   // Menu structure
 CLOCKS mcuClocks;  // system clocks: SYSCLK, AHB, APB1, APB2, APB1_Timer, APB2_Timer2
+FP_MENU lastMenu;
 
 void mcu_GetClocksFreq(CLOCKS *clk)
 {
@@ -113,6 +114,7 @@ int main(void)
 
   for (; ;)
   {
+    lastMenu = infoMenu.menu[infoMenu.cur];
     (*infoMenu.menu[infoMenu.cur])();
   }
 }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This is a reworked fix in order to avoid TFT freeze caused by popups during a loop. It is a universal fix, no need for extra functions for extra conditional process loops.

### Benefits

Popups are not triggered during sub-functions of the menus. If there's a popup than it is handled by the menu it occurred in.

### Related Issues

Previous fix could cause unfinished procedures caused by popups during a sub-function of a menu. The TFT wouldn't freeze because of that but results could be unpredictable as menus were restarted without the sub-functions successful finishing. Resets, initializations, final touches could been ignored/skipped.
Also, previous fix wasn't universal, for any new conditional loops more specific functions should be written.


### So, it's ready to be merged?

Not for the moment. It's been impossible to test all possible scenarios. Hopefully other developers would take a look and give their blessing or point out flaws to be fixed.

### Anything else?

Yeah. 

- SplashScreen type popup added.

It displays automatically upon calling it and it is the programmer's responsibility to delete it and redraw the relevant screen when the SplashScreen is not needed anymore.

- Extrude menu counter shows the extruded/loaded amount, not the temporary E coordinate as it was previously

The keypad input selects the desired extrude or unload length. Positive values will extrude and negative values will unload filament.