### PR TITLE
enhancement to live text with uniform bg on Printing menu + bug fix

### DIFF
--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -1100,7 +1100,7 @@ void Scroll_DispString(SCROLL * para, uint8_t align)
       }
       case CENTER:
       {
-        uint16_t x_offset=((para->rect.x1 - para->rect.x0 - para->totalPixelWidth) >>1);
+        uint16_t x_offset=((para->rect.x1 - para->rect.x0 - para->totalPixelWidth) >> 1);
         GUI_DispString(para->rect.x0+x_offset, para->rect.y0, para->text);
         break;
       }

--- a/TFT/src/User/API/UI/ui_draw.h
+++ b/TFT/src/User/API/UI/ui_draw.h
@@ -27,6 +27,7 @@ extern "C" {
 #define text_startx      (LCD_WIDTH / 2)
 
 void LOGO_ReadDisplay(void);
+void ICON_PartialReadDisplay(uint16_t sx, uint16_t sy, int16_t width, int16_t height, uint8_t icon, uint16_t isx, uint16_t isy);
 void ICON_ReadDisplay(uint16_t sx, uint16_t sy, uint8_t icon);
 void ICON_PrepareRead(uint16_t sx, uint16_t sy, uint8_t icon);
 void ICON_PrepareReadEnd(void);

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -510,8 +510,9 @@
  *
  * NOTE: Enable it only in case all the icons have the same and uniform background color under
  *       all the live text areas.
- *       If enabled, it speeds up the rendering of the live text. Suitable in particular for
- *       the TFTs with a not fast HW (e.g. 24, 48 MHz).
+ *       If enabled, it speeds up the rendering of the live text and the responsiveness of the TFT,
+ *       so it can improve the print quality.
+ *       Suitable in particular for the TFTs with a not fast HW (e.g. 24, 48 MHz).
  */
 //#define UNIFORM_LIVE_TEXT_BG_COLOR  // Default: disabled
 

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -496,11 +496,24 @@
 #define TERMINAL_KEYBOARD_LAYOUT 0  // Default: 0
 
 /**
- * Progress bar layout
- * Uncomment to enable progress bar with 10% markers.
- * Comment to enable standard progress bar.
+ * Progress bar layout on Printing menu
+ * Uncomment to enable a progress bar with 10% markers.
+ * Comment to enable a standard progress bar.
  */
 //#define MARKED_PROGRESS_BAR  // Default: disabled
+
+/**
+ * Live text background color rendering technique on Printing menu
+ * Uncomment to enable the sampling and use of a uniform background color across all the icons.
+ * Comment to enable a standard rendering based on the sampling and use, in a pixel by pixel basis,
+ * of the underlying icon background colors.
+ *
+ * NOTE: Enable it only in case all the icons have the same and uniform background color under
+ *       all the live text areas.
+ *       If enabled, it speeds up the rendering of the live text. Suitable in particular for
+ *       the TFTs with a not fast HW (e.g. 24, 48 MHz).
+ */
+//#define UNIFORM_LIVE_TEXT_BG_COLOR  // Default: disabled
 
 
 //===========================================================================

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -508,8 +508,8 @@
  * Comment to enable a standard rendering based on the sampling and use, in a pixel by pixel basis,
  * of the underlying icon background colors.
  *
- * NOTE: Enable it only in case all the icons have the same and uniform background color under
- *       all the live text areas.
+ * NOTE: Enable it only in case all the icons have the same and uniform background color under all
+ *       the live text areas (e.g. applicable to Unified, Round Miracle etc... menu themes).
  *       If enabled, it speeds up the rendering of the live text and the responsiveness of the TFT,
  *       so it can improve the print quality.
  *       Suitable in particular for the TFTs with a not fast HW (e.g. 24, 48 MHz).


### PR DESCRIPTION
**IMPROVEMENTS:**
 * Alternative live text background color rendering technique on Printing menu made configurable in Configuration.h:
   * Uncomment UNIFORM_LIVE_TEXT_BG_COLOR to enable the sampling and use of a uniform background color across all the icons.
   * Comment UNIFORM_LIVE_TEXT_BG_COLOR to enable a standard rendering based on the sampling and use, in a pixel by pixel basis, of the underlying icon background colors.

 **NOTE:**
 * Enable it only in case all the icons have the same and uniform background color under all the live text areas (e.g. applicable to Unified, Round Miracle etc... menu themes).
 * If enabled, it speeds up the rendering of the live text and the responsiveness of the TFT, so it can improve the print quality. 
 * Suitable in particular for the TFTs with a not fast HW (e.g. 24, 48 MHz). 

**BUG FIXES:**
* Fixed an invalid reference use (out of scope) to timeStr in PrintingMenu.c


**PR STATE:** Ready to be merged