### PR TITLE
added synchronous loopProcess function allowing popup handling

### DIFF
--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -32,7 +32,7 @@ static void resetRequestCommandInfo(
   if (string_error2)
     requestCommandInfo.error_num = 3;
 
-  loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean before requestCommand
+  loopProcessToCondition(&isNotEmptyCmdQueue, true);  // wait for the communication to be clean before requestCommand
 
   requestCommandInfo.inWaitResponse = true;
   requestCommandInfo.inResponse = false;
@@ -72,7 +72,7 @@ bool request_M21(void)
   mustStoreCmd("M21\n");
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   clearRequestCommandInfo();
   // Check reponse
@@ -90,7 +90,7 @@ char *request_M20(void)
   mustStoreCmd("M20\n");
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -116,7 +116,7 @@ char *request_M33(char *filename)
     mustStoreCmd("M33 %s\n", filename);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -164,7 +164,7 @@ long request_M23_M36(char *filename)
   }
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   if (requestCommandInfo.inError)
   {
@@ -289,7 +289,7 @@ char *request_M20_macros(char *nextdir)
   mustStoreCmd(command);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   //clearRequestCommandInfo();  //shall be call after copying the buffer ...
   return requestCommandInfo.cmd_rev_buf;
@@ -303,7 +303,7 @@ void request_M98(char *filename)
   mustStoreCmd(command);
 
   // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
+  loopProcessToCondition(&isWaitingResponse, true);
 
   clearRequestCommandInfo();
 }

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -450,7 +450,7 @@ void printAbort(void)
         setDialogText(LABEL_SCREEN_INFO, LABEL_BUSY, LABEL_BACKGROUND, LABEL_BACKGROUND);
         showDialog(DIALOG_TYPE_INFO, NULL, NULL, NULL);
 
-        loopProcessToCondition(&isHostPrinting);  // wait for the printer to settle down
+        loopProcessToCondition(&isHostPrinting, true);  // wait for the printer to settle down
       }
       break;
 
@@ -495,7 +495,7 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
     case TFT_UDISK:
     case TFT_SD:
       if (infoPrinting.pause == true && pauseType == PAUSE_M0)
-        loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
+        loopProcessToCondition(&isNotEmptyCmdQueue, true);  // wait for the communication to be clean
 
       static COORDINATE tmp;
       bool isCoorRelative = coorGetRelative();

--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -1100,7 +1100,7 @@ void Scroll_DispString(SCROLL * para, uint8_t align)
       }
       case CENTER:
       {
-        uint16_t x_offset=((para->rect.x1 - para->rect.x0 - para->totalPixelWidth) >>1);
+        uint16_t x_offset=((para->rect.x1 - para->rect.x0 - para->totalPixelWidth) >> 1);
         GUI_DispString(para->rect.x0+x_offset, para->rect.y0, para->text);
         break;
       }

--- a/TFT/src/User/API/UI/ui_draw.h
+++ b/TFT/src/User/API/UI/ui_draw.h
@@ -27,6 +27,7 @@ extern "C" {
 #define text_startx      (LCD_WIDTH / 2)
 
 void LOGO_ReadDisplay(void);
+void ICON_PartialReadDisplay(uint16_t sx, uint16_t sy, int16_t width, int16_t height, uint8_t icon, uint16_t isx, uint16_t isy);
 void ICON_ReadDisplay(uint16_t sx, uint16_t sy, uint8_t icon);
 void ICON_PrepareRead(uint16_t sx, uint16_t sy, uint8_t icon);
 void ICON_PrepareReadEnd(void);

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -92,7 +92,7 @@ void mustStoreCmd(const char * format,...)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
 
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+    loopProcessToCondition(&isFullCmdQueue, true);  // wait for a free slot in the queue in case the queue is currently full
   }
 
   va_list va;
@@ -163,7 +163,7 @@ void mustStoreCacheCmd(const char * format,...)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
 
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+    loopProcessToCondition(&isFullCmdQueue, true);  // wait for a free slot in the queue in case the queue is currently full
   }
 
   va_list va;

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -270,13 +270,6 @@ void menuDrawItem(const ITEM *item, uint8_t position)
   menuDrawIconText(item, position);
 }
 
-void menuDrawPartialIconOnly(const ITEM *item, uint8_t position, uint16_t sx, uint16_t sy, int16_t width, int16_t height, uint16_t isx, uint16_t isy)
-{
-  const GUI_RECT *rect = curRect + position;
-
-  ICON_PartialReadDisplay(rect->x0 + sx, rect->y0 + sy, width, height, item->icon, isx, isy);
-}
-
 void menuDrawIconOnly(const ITEM *item, uint8_t position)
 {
   const GUI_RECT *rect = curRect + position;
@@ -607,14 +600,7 @@ void showLiveInfo(uint8_t index, const LIVE_INFO * liveicon, const ITEM * item)
         GUI_SetTextMode(liveicon->lines[i].text_mode);
         GUI_SetBkColor(liveicon->lines[i].bk_color);
       }
-/*     #ifdef UNIFORM_LIVE_TEXT_BG_COLOR
-        else
-        {
-          GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
-          GUI_SetBkColor(ICON_ReadPixel(loc.x, loc.y));
-        }
-      #endif
-*/
+
       GUI_SetColor(liveicon->lines[i].fn_color);
       setFontSize(liveicon->lines[i].font);
 

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -180,7 +180,20 @@ GUI_POINT getIconStartPoint(int index);
 void loopBackEnd(void);
 void loopFrontEnd(void);
 void loopProcess(void);
-void loopProcessToCondition(CONDITION_CALLBACK condCallback);
+
+/**
+ * RETURN:
+ *   true: if a popup was handled
+ *   false if no popup was handled
+ *
+ * INPUT:
+ *   reloadMenuOnPopup: taken into account in case a popup was handled:
+ *     false: to let the caller handle the menu relaod. Usable in case the caller is a menu so it can decide to simply redraw the menu instead of reloading the entire menu
+ *     true: used in case the caller is not a menu so it is not able to provide any kind of menu relaod (e.g. mustStoreCmd). The previous menu will be forced to be reloaded
+ */
+bool loopProcessWithPopup(bool reloadMenuOnPopup);
+
+bool loopProcessToCondition(CONDITION_CALLBACK condCallback, bool reloadMenuOnPopup);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -496,11 +496,25 @@
 #define TERMINAL_KEYBOARD_LAYOUT 0  // Default: 0
 
 /**
- * Progress bar layout
- * Uncomment to enable progress bar with 10% markers.
- * Comment to enable standard progress bar.
+ * Progress bar layout on Printing menu
+ * Uncomment to enable a progress bar with 10% markers.
+ * Comment to enable a standard progress bar.
  */
 //#define MARKED_PROGRESS_BAR  // Default: disabled
+
+/**
+ * Live text background color rendering technique on Printing menu
+ * Uncomment to enable the sampling and use of a uniform background color across all the icons.
+ * Comment to enable a standard rendering based on the sampling and use, in a pixel by pixel basis,
+ * of the underlying icon background colors.
+ *
+ * NOTE: Enable it only in case all the icons have the same and uniform background color under all
+ *       the live text areas (e.g. applicable to Unified, Round Miracle etc... menu themes).
+ *       If enabled, it speeds up the rendering of the live text and the responsiveness of the TFT,
+ *       so it can improve the print quality.
+ *       Suitable in particular for the TFTs with a not fast HW (e.g. 24, 48 MHz).
+ */
+//#define UNIFORM_LIVE_TEXT_BG_COLOR  // Default: disabled
 
 
 //===========================================================================

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -36,20 +36,7 @@ void menuExtrude(void)
   float extrNewCoord  = 0.0f;
   float extrKnownCoord = 0.0f;
 
-  if (eAxisBackup.backedUp == false)
-  {
-    loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
-
-    eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
-    eAxisBackup.feedrate = coordinateGetFeedRate();
-    eAxisBackup.relative = eGetRelative();
-    eAxisBackup.backedUp = true;
-  }
-
   extrKnownCoord = extrNewCoord = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
-
-  if (eAxisBackup.relative) // Set extruder to absolute
-    mustStoreCmd("M82\n");
 
   extrudeItems.items[KEY_ICON_4].icon = (infoSettings.ext_count > 1) ? ICON_NOZZLE : ICON_HEAT;
   extrudeItems.items[KEY_ICON_4].label.index = (infoSettings.ext_count > 1) ? LABEL_NOZZLE : LABEL_HEAT;
@@ -58,6 +45,23 @@ void menuExtrude(void)
 
   menuDrawPage(&extrudeItems);
   extruderReDraw(curExtruder_index, extrKnownCoord, false);
+
+  if (eAxisBackup.backedUp == false)
+  {
+    if (loopProcessToCondition(&isNotEmptyCmdQueue, false) == true)  // wait for the communication to be clean
+    { // if a popup was handled, redraw the menu
+      menuDrawPage(&extrudeItems);
+      extruderReDraw(curExtruder_index, extrKnownCoord, false);
+    }
+
+    eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
+    eAxisBackup.feedrate = coordinateGetFeedRate();
+    eAxisBackup.relative = eGetRelative();
+    eAxisBackup.backedUp = true;
+  }
+
+  if (eAxisBackup.relative) // Set extruder to absolute
+    mustStoreCmd("M82\n");
 
   #if LCD_ENCODER_SUPPORT
     encoderPosition = 0;

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -40,16 +40,20 @@ void menuLoadUnload(void)
 {
   KEY_VALUES key_num = KEY_IDLE;
 
+  menuDrawPage(&loadUnloadItems);
+  temperatureReDraw(tool_index, NULL, false);
+
   if (eAxisBackup.backedUp == false)
   {
-    loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
+    if (loopProcessToCondition(&isNotEmptyCmdQueue, false) == true)  // wait for the communication to be clean
+    { // if a popup was handled, redraw the menu
+      menuDrawPage(&loadUnloadItems);
+      temperatureReDraw(tool_index, NULL, false);
+    }
 
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
     eAxisBackup.backedUp = true;
   }
-
-  menuDrawPage(&loadUnloadItems);
-  temperatureReDraw(tool_index, NULL, false);
 
   heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
 


### PR DESCRIPTION
**IMPROVEMENTS:**
* Added a variant of loopProcess function allowing to handle popup dialogs in a synchronous mode (bocking function). That means, in case a popup is displayed it is also handled by the function. The function will notify the caller about a popup was handled. The notification can be used by the caller menu to redraw the menu without the need to exit the menu and let "main" function to reload the entire menu.

The new function has the following signature:

**bool loopProcessWithPopup(bool reloadMenuOnPopup);**

 RETURN:
  *  true: if a popup was handled
  * false if no popup was handled

INPUT:
  * reloadMenuOnPopup: taken into account in case a popup was handled:
    * false: to let the caller handle the menu relaod. Usable in case the caller is a menu so it can decide to simply redraw the menu instead of reloading the entire menu
    * true: used in case the caller is not a menu so it is not able to provide any kind of menu relaod (e.g. mustStoreCmd). The previous menu will be forced to be reloaded
