### PR TITLE
Move preheat settings out of settings to reduce RAM usage

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -163,12 +163,6 @@ void infoSettingsReset(void)
     infoSettings.pause_feedrate[i]    = default_pause_speed[i];  // XY, Z, E
   }
 
-  for (int i = 0; i < PREHEAT_COUNT; i++)
-  {
-    infoSettings.preheat_temp[i]      = default_preheat_ext[i];
-    infoSettings.preheat_bed[i]       = default_preheat_bed[i];
-  }
-
   resetConfig();
 }
 

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -39,7 +39,8 @@ typedef enum
 
 #define FONT_CHECK_SIGN       (FONT_FLASH_SIGN + WORD_UNICODE + FLASH_SIGN_ADDR)
 #define CONFIG_CHECK_SIGN     (CONFIG_FLASH_SIGN + STRINGS_STORE_ADDR + \
-                               sizeof(SETTINGS) + sizeof(STRINGS_STORE) + sizeof(CUSTOM_GCODES) + sizeof(PRINT_GCODES))
+                               sizeof(SETTINGS) + sizeof(STRINGS_STORE) + sizeof(PREHEAT_STORE) + \
+                               sizeof(CUSTOM_GCODES) + sizeof(PRINT_GCODES))
 #define LANGUAGE_CHECK_SIGN   (LANGUAGE_FLASH_SIGN + LANGUAGE_ADDR + LABEL_NUM)
 #define ICON_CHECK_SIGN       (ICON_FLASH_SIGN + ICON_ADDR(0) + ICON_PREVIEW)
 

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -163,8 +163,6 @@ typedef struct
   uint8_t  z_steppers_alignment;
 
   uint16_t level_feedrate[FEEDRATE_COUNT - 1];  // XY, Z
-  uint16_t preheat_temp[PREHEAT_COUNT];
-  uint16_t preheat_bed[PREHEAT_COUNT];
 
   // Power Supply Settings
   uint8_t  auto_off;
@@ -207,8 +205,14 @@ typedef struct
 typedef struct
 {
   char marlin_title[MAX_GCODE_LENGTH + 1];
-  char preheat_name[PREHEAT_COUNT][MAX_GCODE_LENGTH + 1];
 } STRINGS_STORE;
+
+typedef struct
+{
+  char     preheat_name[PREHEAT_COUNT][MAX_GCODE_LENGTH + 1];
+  uint16_t preheat_temp[PREHEAT_COUNT];
+  uint16_t preheat_bed[PREHEAT_COUNT];
+} PREHEAT_STORE;
 
 typedef struct
 {

--- a/TFT/src/User/API/boot.h
+++ b/TFT/src/User/API/boot.h
@@ -19,7 +19,8 @@ extern "C" {
   #define _8X16_FONT_SIZE           0x1000
   #define FLASH_SIGN_SIZE           0x1000  // store status of last font/icon/config update
   #define LANGUAGE_SIZE            0x14000  // Language pack size
-  #define STRINGS_STORE_MAX_SIZE    0x5000  // label strings max size
+  #define STRINGS_STORE_MAX_SIZE    0x1000  // label strings max size
+  #define PREHEAT_STORE_MAX_SIZE    0x1000  // preheat setting max size
   #define PRINT_GCODES_MAX_SIZE     0x5000  // start/end/cancel gcodes  max size
   #define CUSTOM_GCODE_MAX_SIZE     0x5000  // custom gocdes max size
   #define ICON_MAX_SIZE             0x5000
@@ -37,7 +38,8 @@ extern "C" {
 #define FLASH_SIGN_ADDR         (_8X16_FONT_ADDR + _8X16_FONT_SIZE)            // for language label strings from language file
 #define LANGUAGE_ADDR           (FLASH_SIGN_ADDR + FLASH_SIGN_SIZE)            // for label strings from config file
 #define STRINGS_STORE_ADDR      (LANGUAGE_ADDR + LANGUAGE_SIZE)                // for label strings from config file
-#define PRINT_GCODES_ADDR       (STRINGS_STORE_ADDR + STRINGS_STORE_MAX_SIZE)  // for start/end/cancel gcodes from config file
+#define PREHEAT_STORE_ADDR      (STRINGS_STORE_ADDR + STRINGS_STORE_MAX_SIZE)  // for preheat settings from config file
+#define PRINT_GCODES_ADDR       (PREHEAT_STORE_ADDR + PREHEAT_STORE_MAX_SIZE)  // for start/end/cancel gcodes from config file
 #define CUSTOM_GCODE_ADDR       (PRINT_GCODES_ADDR + PRINT_GCODES_MAX_SIZE)    // for custom gcodes from config file
 
 #define ICON_ADDR(num)          ((num) * ICON_MAX_SIZE + CUSTOM_GCODE_ADDR + CUSTOM_GCODE_MAX_SIZE)

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -31,6 +31,7 @@ CONFIGFILE* CurConfigFile;
 CUSTOM_GCODES* configCustomGcodes = NULL;
 PRINT_GCODES* configPrintGcodes = NULL;
 STRINGS_STORE* configStringsStore = NULL;
+PREHEAT_STORE* configPreheatStore = NULL;
 
 char * cur_line = NULL;
 uint16_t c_index = 0;
@@ -50,10 +51,12 @@ bool getConfigFromFile(void)
   CUSTOM_GCODES tempCustomGcodes;
   PRINT_GCODES tempPrintCodes;
   STRINGS_STORE tempStringStore;
+  PREHEAT_STORE tempPreheatStore;
 
   configCustomGcodes = &tempCustomGcodes;
   configPrintGcodes = &tempPrintCodes;
   configStringsStore = &tempStringStore;
+  configPreheatStore = &tempPreheatStore;
   customcode_index = 0;
   foundkeys = 0;
 
@@ -383,6 +386,7 @@ void saveConfig(void)
   writeConfig((uint8_t *)configCustomGcodes, sizeof(CUSTOM_GCODES), CUSTOM_GCODE_ADDR, CUSTOM_GCODE_MAX_SIZE);
   writeConfig((uint8_t *)configPrintGcodes, sizeof(PRINT_GCODES), PRINT_GCODES_ADDR, PRINT_GCODES_MAX_SIZE);
   writeConfig((uint8_t *)configStringsStore, sizeof(STRINGS_STORE), STRINGS_STORE_ADDR, STRINGS_STORE_MAX_SIZE);
+  writeConfig((uint8_t *)configPreheatStore, sizeof(PREHEAT_STORE), PREHEAT_STORE_ADDR, PREHEAT_STORE_MAX_SIZE);
 
   #ifdef CONFIG_DEBUG
     CUSTOM_GCODES tempgcode;  // = NULL;
@@ -422,6 +426,7 @@ void resetConfig(void)
   CUSTOM_GCODES tempCG;
   STRINGS_STORE tempST;
   PRINT_GCODES tempPC;
+  PREHEAT_STORE tempPH;
 
   // restore custom gcode presets
   int n = 0;
@@ -441,7 +446,7 @@ void resetConfig(void)
 
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
-    strcpy(tempST.preheat_name[i],preheatNames[i]);
+    strcpy(tempPH.preheat_name[i], preheatNames[i]);
   }
 
   // restore print gcodes
@@ -849,7 +854,7 @@ void parseConfigKey(uint16_t index)
       int utf8len = getUTF8Length((uint8_t *)pchr);
       int bytelen = strlen(pchr) + 1;
       if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_STRING_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
-        strcpy(configStringsStore->preheat_name[index - C_INDEX_PREHEAT_NAME_1], pchr);
+        strcpy(configPreheatStore->preheat_name[index - C_INDEX_PREHEAT_NAME_1], pchr);
       break;
     }
 
@@ -861,8 +866,8 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_PREHEAT_TEMP_6:
     {
       int val_index = index - C_INDEX_PREHEAT_TEMP_1;
-      if (key_seen("B")) SET_VALID_INT_VALUE(infoSettings.preheat_bed[val_index], MIN_BED_TEMP, MAX_BED_TEMP);
-      if (key_seen("T")) SET_VALID_INT_VALUE(infoSettings.preheat_temp[val_index], MIN_TOOL_TEMP, MAX_TOOL_TEMP);
+      if (key_seen("B")) SET_VALID_INT_VALUE(configPreheatStore->preheat_bed[val_index], MIN_BED_TEMP, MAX_BED_TEMP);
+      if (key_seen("T")) SET_VALID_INT_VALUE(configPreheatStore->preheat_temp[val_index], MIN_TOOL_TEMP, MAX_TOOL_TEMP);
       break;
     }
 

--- a/TFT/src/User/Menu/MeshValid.c
+++ b/TFT/src/User/Menu/MeshValid.c
@@ -19,12 +19,15 @@ void menuMeshValid(void)
     }
   };
 
-  KEY_VALUES  key_num;
+  KEY_VALUES key_num;
+  PREHEAT_STORE preheatStore;
 
+  W25Qxx_ReadBuffer((uint8_t*)&preheatStore, PREHEAT_STORE_ADDR, sizeof(PREHEAT_STORE));
   menuDrawPage(&meshValidItems);
+
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
-    refreshPreheatIcon(i, i, &meshValidItems.items[i]);
+    refreshPreheatIcon(&preheatStore, i, &meshValidItems.items[i]);
   }
 
   while (infoMenu.menu[infoMenu.cur] == menuMeshValid)
@@ -45,10 +48,10 @@ void menuMeshValid(void)
       // MESHVALID NYLON
       case KEY_ICON_5:
         mustStoreCmd("G28\n");
-        mustStoreCmd("G26 H%u B%u R99\n", infoSettings.preheat_temp[key_num], infoSettings.preheat_bed[key_num]);
+        mustStoreCmd("G26 H%u B%u R99\n", preheatStore.preheat_temp[key_num], preheatStore.preheat_bed[key_num]);
         mustStoreCmd("G1 Z10 F%d\n", infoSettings.level_feedrate[FEEDRATE_Z]);
         mustStoreCmd("G1 X0 F%d\n", infoSettings.level_feedrate[FEEDRATE_XY]);
-        refreshPreheatIcon(key_num, key_num, &meshValidItems.items[key_num]);
+        refreshPreheatIcon(&preheatStore, key_num, &meshValidItems.items[key_num]);
         break;
 
       case KEY_ICON_7:

--- a/TFT/src/User/Menu/PreheatMenu.h
+++ b/TFT/src/User/Menu/PreheatMenu.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdint.h>
 #include "menu.h"
+#include "Settings.h"
 
 typedef enum
 {
@@ -15,7 +16,7 @@ typedef enum
   NOZZLE0_PREHEAT = 2,
 } TOOLPREHEAT;
 
-void refreshPreheatIcon(int8_t preheatnum, int8_t icon_index, const ITEM * menuitem);
+void refreshPreheatIcon(PREHEAT_STORE * preheatStore, int8_t index, const ITEM * menuitem);
 void menuPreheat(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -70,7 +70,8 @@ enum
   PRINTING_VALUE = (1 << 2),
 };
 
-const uint8_t printingIcon[] = {ICON_PRINTING_NOZZLE, ICON_PRINTING_BED, ICON_PRINTING_FAN, ICON_PRINTING_TIMER, ICON_PRINTING_ZLAYER, ICON_PRINTING_SPEED, ICON_PRINTING_FLOW};
+const uint8_t printingIcon[] = {ICON_PRINTING_NOZZLE, ICON_PRINTING_BED,   ICON_PRINTING_FAN,
+                                ICON_PRINTING_TIMER, ICON_PRINTING_ZLAYER, ICON_PRINTING_SPEED, ICON_PRINTING_FLOW};
 const char *const speedId[2] = {"Speed", "Flow "};
 bool hasFilamentData;
 

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -26,7 +26,6 @@ const char *const labelMarlinType[ITEM_MARLIN_TYPE_NUM] =
 
 void menuLanguage(void)
 {
-  #define LANGUAGE_PAGE_COUNT  (LANGUAGE_NUM + LISTITEM_PER_PAGE - 1) / LISTITEM_PER_PAGE
   LABEL title = {LABEL_LANGUAGE};
   LISTITEM totalItems[LANGUAGE_NUM];
   uint16_t curIndex = KEY_IDLE;

--- a/TFT/src/User/SanityCheck.c
+++ b/TFT/src/User/SanityCheck.c
@@ -7,6 +7,7 @@ void sizecheck(void)
   // then the size of the array is larger than allocated size in flash.
   SIZE_CHECK((sizeof(SETTINGS) + 12 + sizeof(TSC_Para)) > PARA_SIZE); // Size of infoSettings is larger than allocated size in flash.
   SIZE_CHECK(sizeof(STRINGS_STORE) > STRINGS_STORE_MAX_SIZE);         // Size of strings_store is larger than allocated size in flash.
+  SIZE_CHECK(sizeof(PREHEAT_STORE) > PREHEAT_STORE_MAX_SIZE);         // Size of preheat_store is larger than allocated size in flash.
   SIZE_CHECK(sizeof(CUSTOM_GCODES) > CUSTOM_GCODE_MAX_SIZE);          // Size of custom_gcodes is larger than allocated size in flash.
   SIZE_CHECK(sizeof(PRINT_GCODES) > PRINT_GCODES_MAX_SIZE);           // Size of print_gcodes is larger than allocated size in flash.
   SIZE_CHECK((LABEL_NUM * MAX_LANG_LABEL_LENGTH) > LANGUAGE_SIZE);    // Size of Language pack is larger than allocated size in flash.

--- a/TFT/src/User/Variants/Resolution/TFT_800X480.h
+++ b/TFT/src/User/Variants/Resolution/TFT_800X480.h
@@ -92,19 +92,20 @@
 #define W25QXX_SECTOR_SIZE (0x1000) // 4096byte = 4K
 
 #ifndef LOGO_MAX_SIZE
-  #define LOGO_MAX_SIZE            0xBC000    // 800*480*2 = 0xBB800(+0xBC000) bytes
-  #define WORD_UNICODE_SIZE       0x480000    // 24*24/8 * 65536(unicode) = 0x480000 bytes(4.5M)
-  #define BYTE_ASCII_SIZE           0x1000    // 24*12/8 * 95(visible ascii) = 0x0D5C (+0x1000 4K)
+  #define LOGO_MAX_SIZE            0xBC000  // 800*480*2 = 0xBB800(+0xBC000) bytes
+  #define WORD_UNICODE_SIZE       0x480000  // 24*24/8 * 65536(unicode) = 0x480000 bytes(4.5M)
+  #define BYTE_ASCII_SIZE           0x1000  // 24*12/8 * 95(visible ascii) = 0x0D5C (+0x1000 4K)
   #define LARGE_FONT_SIZE           0x3000
   #define _8X16_FONT_SIZE           0x1000
-  #define FLASH_SIGN_SIZE           0x1000    // store status of last font/icon/config update
+  #define FLASH_SIGN_SIZE           0x1000  // store status of last font/icon/config update
   #define LANGUAGE_SIZE            0x14000
-  #define STRINGS_STORE_MAX_SIZE    0x5000    // label strings max size
-  #define PRINT_GCODES_MAX_SIZE     0x5000    // start/end/cancel gcodes  max size
-  #define CUSTOM_GCODE_MAX_SIZE     0x5000    // custom gocdes max size
-  #define ICON_MAX_SIZE             0xB000    // 160*140*2 = 0xAF00 (+0xB000) per button icon
-  #define INFOBOX_MAX_SIZE         0x19000    // 360*140*2 = 0x189C0 (+0x19000)
-  #define SMALL_ICON_MAX_SIZE       0x2000    // 24*24*2 = 0x480 (+0x1000) per small icon
+  #define STRINGS_STORE_MAX_SIZE    0x1000  // label strings max size
+  #define PREHEAT_STORE_MAX_SIZE    0x1000  // preheat setting max size
+  #define PRINT_GCODES_MAX_SIZE     0x5000  // start/end/cancel gcodes  max size
+  #define CUSTOM_GCODE_MAX_SIZE     0x5000  // custom gocdes max size
+  #define ICON_MAX_SIZE             0xB000  // 160*140*2 = 0xAF00 (+0xB000) per button icon
+  #define INFOBOX_MAX_SIZE         0x19000  // 360*140*2 = 0x189C0 (+0x19000)
+  #define SMALL_ICON_MAX_SIZE       0x2000  // 24*24*2 = 0x480 (+0x1000) per small icon
 #endif
 
 // The offset of the model preview icon in the gcode file


### PR DESCRIPTION
- Remove preheat settings from main settings to reduce RAM usage.
- Misc Clean up.