### PR TITLE
Add comments for filament sensor connected to the main board

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -510,6 +510,16 @@ auto_shutdown_temp:50
 #### Default Filament Runout Sensor
 # Enable filament runout sensor.
 #   Options: [enable: 1, disable: 0, smart: 2]
+#
+# If the sensor is connected to the board, you must set this to 0 (Disabled. 'OFF' option in the TFT Display), 
+# and put a M75 code at 'start_gcode' option, and enable it. For consistency you would to put a M77 code 
+# at end gcode script an enable it too.
+#
+# Example:
+#   end_gcode_enabled:1
+#   start_gcode_enabled:1
+#   start_gcode:M75\n
+#   end_gcode:M77\n
 fil_runout:0
 
 #### Inverted Filament Runout Logic

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -510,6 +510,16 @@ auto_shutdown_temp:50
 #### Default Filament Runout Sensor
 # Enable filament runout sensor.
 #   Options: [enable: 1, disable: 0, smart: 2]
+#
+# If the sensor is connected to the board, you must set this to 0 (Disabled. 'OFF' option in the TFT Display), 
+# and put a M75 code at 'start_gcode' option, and enable it. For consistency you would to put a M77 code 
+# at end gcode script an enable it too.
+#
+# Example:
+#   end_gcode_enabled:1
+#   start_gcode_enabled:1
+#   start_gcode:M75\n
+#   end_gcode:M77\n
 fil_runout:0
 
 #### Inverted Filament Runout Logic

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -504,12 +504,22 @@ auto_shutdown_temp:50
 
 
 #--------------------------------------------------------------------
-# Filament Runout Settings (if connected to TFT controller)
+# Filament Runout Settings (if connected to TFT controller only)
 #--------------------------------------------------------------------
 
 #### Default Filament Runout Sensor
 # Enable filament runout sensor.
 #   Options: [enable: 1, disable: 0, smart: 2]
+#
+# If the sensor is connected to the board, you must set this to 0 (Disabled. 'OFF' option in the TFT Display), 
+# and put a M75 code at 'start_gcode' option, and enable it. For consistency you would to put a M77 code 
+# at end gcode script an enable it too.
+#
+# Example:
+#   end_gcode_enabled:1
+#   start_gcode_enabled:1
+#   start_gcode:M75\n
+#   end_gcode:M77\n
 fil_runout:0
 
 #### Inverted Filament Runout Logic
@@ -654,6 +664,7 @@ custom_gcode_7:M502\n
 #--------------------------------------------------------------------
 # Start, End & Cancel Gcode Commands
 #--------------------------------------------------------------------
+# See fil_runout description above if you have a filament runout sensor conencted to the main board.
 
 #### Default Start Gcode Status
 #   Options: [enable: 1, disable: 0]

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -504,7 +504,7 @@ auto_shutdown_temp:50
 
 
 #--------------------------------------------------------------------
-# Filament Runout Settings (if connected to TFT controller only)
+# Filament Runout Settings (if connected to TFT controller)
 #--------------------------------------------------------------------
 
 #### Default Filament Runout Sensor


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

Add description to avoid configurations problems when someone has a filament runout sensor connected to the main board instead of the TFT board.

No configuration is changed, only comments.

### Benefits

<!-- What does this fix or improve? -->
Help people to configures correctly the config.ini

### Related Issues

#2004
