### PR TITLE
Fix incorrect M914 parsing

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,7 @@ onlyLabels: []
 exemptLabels:
   - pinned
   - security
+  - TODO
   - "[Status] Maybe Later"
 
 # Set to true to ignore issues in a project (defaults to false)

--- a/TFT/src/User/API/MachineParameters.h
+++ b/TFT/src/User/API/MachineParameters.h
@@ -92,7 +92,7 @@ typedef struct
   float LinAdvance[2];
   float FilamentSetting[3];
   float Current[STEPPER_INDEX_COUNT];
-  float BumpSensitivity[3];
+  float BumpSensitivity[STEPPER_INDEX_COUNT];
   float HybridThreshold[STEPPER_INDEX_COUNT];
   float StealthChop[STEPPER_INDEX_COUNT];
   float MblOffset[1];

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -999,8 +999,8 @@ void sendQueueCmd(void)
         {
           uint8_t i = (cmd_seen('I')) ? cmd_value() : 0;
           if (cmd_seen('X')) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_X + i, cmd_value());
-          if (cmd_seen('Y')) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_X + i, cmd_value());
-          if (cmd_seen('Z')) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_X + i, cmd_value());
+          if (cmd_seen('Y')) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_Y + i, cmd_value());
+          if (cmd_seen('Z')) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_Z + i, cmd_value());
           break;
         }
       }

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1033,11 +1033,12 @@ void parseACK(void)
         if (ack_seen("E")) setParameter(P_HYBRID_THRESHOLD, STEPPER_INDEX_E0 + i, ack_value());
       }
       // parse and store TMC Bump sensitivity values
-      else if (ack_seen("M914 X"))
+      else if (ack_seen("M914"))
       {
-                           setParameter(P_BUMPSENSITIVITY, AXIS_INDEX_X, ack_value());
-        if (ack_seen("Y")) setParameter(P_BUMPSENSITIVITY, AXIS_INDEX_Y, ack_value());
-        if (ack_seen("Z")) setParameter(P_BUMPSENSITIVITY, AXIS_INDEX_Z, ack_value());
+        uint8_t i = (ack_seen("I")) ? ack_value() : 0;
+        if (ack_seen("X")) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_X + i, ack_value());
+        if (ack_seen("Y")) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_Y + i, ack_value());
+        if (ack_seen("Z")) setParameter(P_BUMPSENSITIVITY, STEPPER_INDEX_Z + i, ack_value());
       }
       // parse and store ABL type if auto-detect is enabled
       #if ENABLE_BL_VALUE == 1


### PR DESCRIPTION
- Fix incorrect M914 parsing due to wrong index. (#2036)
- Add `TODO` label to stale bot ignore list.
- 
Fixes #2036 