### PR TITLE
Remove duplicate code and misc. clean-up

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -402,8 +402,9 @@ fan_speed_percent:1
 #   Options: [Percentage & Elapsed time: 0, Percentage & Remaining time: 1, Elapsed time & Remaining time: 2]
 prog_disp_type:2
 
-#### Pause Settings
-# These settings are used when a print is paused.
+#### Pause/Nozzle Park Settings
+# These settings are used when a print is paused or in any feature which requires moving/parking the nozzle
+# before performing a task like in load/unload or extruder tuning menu.
 
 ## Pause Retract Length
 #   Format: [pause_retract: R<retract length> P<resume purge length>]

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -402,8 +402,9 @@ fan_speed_percent:1
 #   Options: [Percentage & Elapsed time: 0, Percentage & Remaining time: 1, Elapsed time & Remaining time: 2]
 prog_disp_type:2
 
-#### Pause Settings
-# These settings are used when a print is paused.
+#### Pause/Nozzle Park Settings
+# These settings are used when a print is paused or in any feature which requires moving/parking the nozzle
+# before performing a task like in load/unload or extruder tuning menu.
 
 ## Pause Retract Length
 #   Format: [pause_retract: R<retract length> P<resume purge length>]

--- a/TFT/src/User/API/BabystepControl.c
+++ b/TFT/src/User/API/BabystepControl.c
@@ -3,6 +3,9 @@
 
 static float babystep_value = BABYSTEP_DEFAULT_VALUE;
 
+#define BABYSTEP_CMD     "M290 Z%.2f\n"
+#define BABYSTEP_CMD_SMW "G43.2 Z%.2f\n"
+
 // Reset only babystep value to default value
 float babystepReset(void)
 {
@@ -23,6 +26,7 @@ float babystepResetValue(void)
   if (babystep_value == BABYSTEP_DEFAULT_VALUE)  // if already default value, nothing to do
     return babystep_value;
 
+  char * babtStepCmd = (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE) ? BABYSTEP_CMD_SMW : BABYSTEP_CMD;
   int step_count;
   float last_unit;
   float processed_baby_step = 0.0f;
@@ -32,24 +36,17 @@ float babystepResetValue(void)
     neg = -1;
 
   step_count = (babystep_value * neg) / BABYSTEP_MAX_STEP;
+
   for (; step_count > 0; step_count--)
   {
-    if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)
-      mustStoreCmd("G43.2 Z%.2f\n", -(BABYSTEP_MAX_STEP * neg));
-    else
-      mustStoreCmd("M290 Z%.2f\n", -(BABYSTEP_MAX_STEP * neg));
-
+    mustStoreCmd(babtStepCmd, -(BABYSTEP_MAX_STEP * neg));
     processed_baby_step += BABYSTEP_MAX_STEP;
   }
 
   last_unit = (babystep_value * neg) - processed_baby_step;
   if (last_unit > 0.0f)
   {
-    if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)
-      mustStoreCmd("G43.2 Z%.2f\n", -(last_unit * neg));
-    else
-      mustStoreCmd("M290 Z%.2f\n", -(last_unit * neg));
-
+    mustStoreCmd(babtStepCmd, -(last_unit * neg));
     processed_baby_step += last_unit;
   }
 
@@ -61,6 +58,7 @@ float babystepResetValue(void)
 // Update babystep value
 float babystepUpdateValue(float unit, int8_t direction)
 {
+  char * babtStepCmd = (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE) ? BABYSTEP_CMD_SMW : BABYSTEP_CMD;
   float diff;
 
   if (direction < 0)
@@ -81,10 +79,7 @@ float babystepUpdateValue(float unit, int8_t direction)
   unit = ((diff > unit) ? unit : diff) * direction;
   babystep_value += unit;
 
-  if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)
-    mustStoreCmd("G43.2 Z%.2f\n", unit);
-  else
-    mustStoreCmd("M290 Z%.2f\n", unit);
+  mustStoreCmd(babtStepCmd, unit);
 
   return babystep_value;
 }

--- a/TFT/src/User/API/HomeOffsetControl.c
+++ b/TFT/src/User/API/HomeOffsetControl.c
@@ -3,7 +3,6 @@
 
 static float z_offset_value = HOME_Z_OFFSET_DEFAULT_VALUE;
 static bool home_offset_enabled = false;
-
 // Enable home offset
 void homeOffsetEnable(bool skipZOffset, float shim)
 {
@@ -38,7 +37,7 @@ bool homeOffsetGetStatus(void)
 // Set Z offset value
 float homeOffsetSetValue(float value)
 {
-  mustStoreCmd("M206 Z%.2f\n", value);
+  sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, value);
   mustStoreCmd("M206\n");  // needed by homeOffsetResetValue() to retrieve the new value
   z_offset_value = value;
 
@@ -62,7 +61,7 @@ float homeOffsetResetValue(void)
   float unit = z_offset_value - HOME_Z_OFFSET_DEFAULT_VALUE;
 
   z_offset_value = HOME_Z_OFFSET_DEFAULT_VALUE;
-  mustStoreCmd("M206 Z%.2f\n", z_offset_value);  // set Z offset value
+  sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
   mustStoreCmd("G1 Z%.2f\n", unit);              // move nozzle
 
   return z_offset_value;
@@ -90,7 +89,7 @@ float homeOffsetUpdateValue(float unit, int8_t direction)
 
   unit = ((diff > unit) ? unit : diff) * direction;
   z_offset_value -= unit;
-  mustStoreCmd("M206 Z%.2f\n", z_offset_value);  // set Z offset value
+  sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
   mustStoreCmd("G1 Z%.2f\n", unit);              // move nozzle
 
   return z_offset_value;

--- a/TFT/src/User/API/HomeOffsetControl.c
+++ b/TFT/src/User/API/HomeOffsetControl.c
@@ -3,6 +3,7 @@
 
 static float z_offset_value = HOME_Z_OFFSET_DEFAULT_VALUE;
 static bool home_offset_enabled = false;
+
 // Enable home offset
 void homeOffsetEnable(bool skipZOffset, float shim)
 {

--- a/TFT/src/User/API/ProbeHeightControl.c
+++ b/TFT/src/User/API/ProbeHeightControl.c
@@ -6,6 +6,10 @@
 static uint32_t nextQueryTime = 0;
 static bool curSoftwareEndstops = true;
 
+#define ENDSTOP_CMD     "M211 S%d\n"
+#define ENDSTOP_CMD_RRF "M564 S%d H%d\n" // for RRF
+#define MOVE_Z_CMD      "G1 Z%.2f F%d\n"
+
 // Enable probe height
 // Temporary disable software endstops
 void probeHeightEnable(void)
@@ -15,9 +19,9 @@ void probeHeightEnable(void)
   if (curSoftwareEndstops)  // if software endstops is enabled, disable it temporary
   {
     if (infoMachineSettings.firmwareType == FW_REPRAPFW)
-      mustStoreCmd("M564 S0 H0\n");
+      mustStoreCmd(ENDSTOP_CMD_RRF, 0, 0);
     else
-      mustStoreCmd("M211 S0\n");  // disable software endstops to move nozzle minus Zero (Z0) if necessary
+      mustStoreCmd(ENDSTOP_CMD, 0);  // disable software endstops to move nozzle minus Zero (Z0) if necessary
   }
 }
 
@@ -28,9 +32,9 @@ void probeHeightDisable(void)
   if (curSoftwareEndstops)  // if software endstops was originally enabled, enable it again
   {
     if (infoMachineSettings.firmwareType == FW_REPRAPFW)
-      mustStoreCmd("M564 S1 H1\n");
+      mustStoreCmd(ENDSTOP_CMD_RRF, 1, 1);
     else
-      mustStoreCmd("M211 S1\n");  // enable software endstops
+      mustStoreCmd(ENDSTOP_CMD, 1);  // enable software endstops
   }
 }
 
@@ -42,7 +46,7 @@ void probeHeightStart(float initialHeight, bool relativeHeight)
   else
     probeHeightAbsolute();                                // set absolute position mode
 
-  mustStoreCmd("G1 Z%.2f F%d\n",
+  mustStoreCmd(MOVE_Z_CMD,
                initialHeight,
                infoSettings.level_feedrate[FEEDRATE_Z]);  // move nozzle to provided absolute Z point and set feedrate
   probeHeightRelative();                                  // set relative position mode
@@ -52,7 +56,7 @@ void probeHeightStart(float initialHeight, bool relativeHeight)
 void probeHeightStop(float raisedHeight)
 {
   probeHeightRelative();                                  // set relative position mode
-  mustStoreCmd("G1 Z%.2f F%d\n",
+  mustStoreCmd(MOVE_Z_CMD,
                raisedHeight,
                infoSettings.level_feedrate[FEEDRATE_Z]);  // raise Z and set feedrate
   probeHeightAbsolute();                                  // set absolute position mode
@@ -73,7 +77,7 @@ void probeHeightAbsolute(void)
 // Change probe height
 void probeHeightMove(float unit, int8_t direction)
 {
-  storeCmd("G1 Z%.2f F%d\n", unit * direction,
+  storeCmd(MOVE_Z_CMD, unit * direction,
            infoSettings.level_feedrate[FEEDRATE_Z]);
 }
 

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -58,7 +58,7 @@ bool probeOffsetGetStatus(void)
 // Set Z offset value
 float probeOffsetSetValue(float value)
 {
-  mustStoreCmd("M851 Z%.2f\n", value);
+  sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, value);
   mustStoreCmd("M851\n");  // needed by probeOffsetGetValue() to retrieve the new value
   z_offset_value = value;
 
@@ -82,7 +82,8 @@ float probeOffsetResetValue(void)
   float unit = z_offset_value - PROBE_Z_OFFSET_DEFAULT_VALUE;
 
   z_offset_value = PROBE_Z_OFFSET_DEFAULT_VALUE;
-  mustStoreCmd("M851 Z%.2f\n", z_offset_value);  // set Z offset value
+
+  sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
   mustStoreCmd("G1 Z%.2f\n", -unit);             // move nozzle
 
   return z_offset_value;
@@ -110,8 +111,8 @@ float probeOffsetUpdateValue(float unit, int8_t direction)
 
   unit = ((diff > unit) ? unit : diff) * direction;
   z_offset_value += unit;
-  mustStoreCmd("M851 Z%.2f\n", z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", unit);              // move nozzle
+  sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
+  mustStoreCmd("G1 Z%.2f\n", unit);  // move nozzle
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -84,7 +84,7 @@ float probeOffsetResetValue(void)
   z_offset_value = PROBE_Z_OFFSET_DEFAULT_VALUE;
 
   sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", -unit);             // move nozzle
+  mustStoreCmd("G1 Z%.2f\n", -unit);  // move nozzle
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -553,7 +553,7 @@ void sendQueueCmd(void)
             setPrintProgressPercentage(cmd_value());
 
           if (cmd_seen('R'))
-            setPrintRemainingTime((int32_t) (cmd_float() * 60));
+            setPrintRemainingTime((cmd_value() * 60));
 
           if (!infoMachineSettings.buildPercent)  // if M73 is not supported by Marlin, skip it
           {

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1043,11 +1043,17 @@ void parseACK(void)
       // parse and store ABL type if auto-detect is enabled
       #if ENABLE_BL_VALUE == 1
         else if (ack_seen("Auto Bed Leveling"))
+        {
           infoMachineSettings.leveling = BL_ABL;
+        }
         else if (ack_seen("Unified Bed Leveling"))
+        {
           infoMachineSettings.leveling = BL_UBL;
+        }
         else if (ack_seen("Mesh Bed Leveling"))
+        {
           infoMachineSettings.leveling = BL_MBL;
+        }
       #endif
       // parse M115 capability report
       else if (ack_seen("FIRMWARE_NAME:"))

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -119,19 +119,21 @@ const GUI_RECT ledKeyRect[KEY_NUM] = {
 #endif
 };
 
-#ifdef KEYBOARD_ON_LEFT
 const GUI_RECT ledColorRect = {
-  3 * KB_WIDTH, 0 * KB_HEIGHT, 4 * KB_WIDTH, 1 * KB_HEIGHT};
+  #ifdef KEYBOARD_ON_LEFT
+    3 * KB_WIDTH, 0 * KB_HEIGHT, 4 * KB_WIDTH, 1 * KB_HEIGHT
+  #else
+    0 * KB_WIDTH, 0 * KB_HEIGHT, 1 * KB_WIDTH, 1 * KB_HEIGHT
+  #endif
+};
 
 const GUI_RECT ledPageRect = {
-  2 * CTRL_WIDTH, 4 * CTRL_HEIGHT, 3 * CTRL_WIDTH, 5 * KB_HEIGHT};
-#else
-const GUI_RECT ledColorRect = {
-  0 * KB_WIDTH, 0 * KB_HEIGHT, 1 * KB_WIDTH, 1 * KB_HEIGHT};
-
-const GUI_RECT ledPageRect = {
-  0 * CTRL_WIDTH, 4 * CTRL_HEIGHT, 1 * CTRL_WIDTH, 5 * KB_HEIGHT};
-#endif
+  #ifdef KEYBOARD_ON_LEFT
+    2 * CTRL_WIDTH, 4 * CTRL_HEIGHT, 3 * CTRL_WIDTH, 5 * KB_HEIGHT
+  #else
+    0 * CTRL_WIDTH, 4 * CTRL_HEIGHT, 1 * CTRL_WIDTH, 5 * KB_HEIGHT
+  #endif
+};
 
 // area rectangles
 const GUI_RECT ledAreaRect[2] = {

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -3,6 +3,9 @@
 
 #define LC_VALUE_COUNT 5
 
+#define ENABLE_STEPPER_CMD "M17 X Y Z\n"
+#define DISABLE_STEPPER_CMD "M18 S0 X Y Z\n"
+
 // Buffer current z value measured in Level Corner = {position 1, position 2, position 3, position 4, probe accuracy(M48)}
 static float levelCornerPosition[LC_VALUE_COUNT];
 const uint8_t valIconIndex[LC_VALUE_COUNT] = {4, 5, 1, 0, 3};
@@ -22,19 +25,17 @@ void ScanLevelCorner(uint8_t point)
     {infoSettings.machine_size_min[X_AXIS] + infoSettings.level_edge, infoSettings.machine_size_max[Y_AXIS] - infoSettings.level_edge},
   };
 
-  if (infoSettings.touchmi_sensor != 0)
-  {
+  if (infoSettings.touchmi_sensor == 1)
     mustStoreCmd("M401\n");
-    mustStoreCmd("G30 E0 X%d Y%d\n", pointPosition[point][0], pointPosition[point][1]);
-    mustStoreCmd("G1 Z10\n");
-  }
-  else
-  {
-    mustStoreCmd("G30 E1 X%d Y%d\n", pointPosition[point][0], pointPosition[point][1]);
-  }
 
-  mustStoreCmd("M17 X Y Z\n");
-  mustStoreCmd("M18 S0 X Y Z\n");
+  // move to selected point
+  mustStoreCmd("G30 E0 X%d Y%d\n", pointPosition[point][0], pointPosition[point][1]);
+
+  if (infoSettings.touchmi_sensor == 1)
+    mustStoreCmd("G1 Z10\n");
+
+  mustStoreCmd(ENABLE_STEPPER_CMD);
+  mustStoreCmd(DISABLE_STEPPER_CMD);
 }
 
 // Draw values under icons
@@ -151,8 +152,8 @@ void menuLevelCorner(void)
 
       case KEY_ICON_3:
         mustStoreCmd("M48\n");
-        mustStoreCmd("M17 X Y Z\n");
-        mustStoreCmd("M18 S0 X Y Z\n");
+        mustStoreCmd(ENABLE_STEPPER_CMD);
+        mustStoreCmd(DISABLE_STEPPER_CMD);
         drawProbeAccuracyIcon(&levelCornerItems);
         break;
 

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -1,8 +1,6 @@
 #include "ZOffset.h"
 #include "includes.h"
 
-#define ITEM_Z_OFFSET_SUBMENU_NUM 4
-
 static bool probeOffsetMenu = false;
 static uint8_t curUnit_index = 0;
 static uint8_t curSubmenu_index = 0;
@@ -58,7 +56,7 @@ void zOffsetSetMenu(bool probeOffset)
 
 void menuZOffset(void)
 {
-  ITEM itemZOffsetSubmenu[ITEM_Z_OFFSET_SUBMENU_NUM] = {
+  ITEM itemZOffsetSubmenu[] = {
     // icon                        label
     {ICON_01_MM,                   LABEL_01_MM},
     {ICON_RESET_VALUE,             LABEL_RESET},
@@ -191,7 +189,7 @@ void menuZOffset(void)
 
       // change submenu
       case KEY_ICON_5:
-        curSubmenu_index = (curSubmenu_index + 1) % ITEM_Z_OFFSET_SUBMENU_NUM;
+        curSubmenu_index = (curSubmenu_index + 1) % COUNT(itemZOffsetSubmenu);
         zOffsetItems.items[KEY_ICON_6] = itemZOffsetSubmenu[curSubmenu_index];
 
         menuDrawItem(&zOffsetItems.items[KEY_ICON_6], KEY_ICON_6);
@@ -203,7 +201,7 @@ void menuZOffset(void)
         {
           // change unit
           case 0:
-            curUnit_index = (curUnit_index + 1) % ITEM_FINE_MOVE_LEN_NUM;
+            curUnit_index = (curUnit_index + 1) % COUNT(itemZOffsetSubmenu);
             itemZOffsetSubmenu[curSubmenu_index] = itemMoveLen[curUnit_index];
             zOffsetItems.items[key_num] = itemZOffsetSubmenu[curSubmenu_index];
 

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -402,8 +402,9 @@ fan_speed_percent:1
 #   Options: [Percentage & Elapsed time: 0, Percentage & Remaining time: 1, Elapsed time & Remaining time: 2]
 prog_disp_type:2
 
-#### Pause Settings
-# These settings are used when a print is paused.
+#### Pause/Nozzle Park Settings
+# These settings are used when a print is paused or in any feature which requires moving/parking the nozzle
+# before performing a task like in load/unload or extruder tuning menu.
 
 ## Pause Retract Length
 #   Format: [pause_retract: R<retract length> P<resume purge length>]


### PR DESCRIPTION
- Remove some duplicate code.
- Extruder Calibration/Tuning menu now uses pause/ park location settings instead of hardcoded position.
- Misc code clean-up and reduce some memory usage.