### PR TITLE
bugfix #2040 + improved #2035 + minor cleanup

### DIFF
--- a/TFT/src/User/API/HomeOffsetControl.c
+++ b/TFT/src/User/API/HomeOffsetControl.c
@@ -63,7 +63,7 @@ float homeOffsetResetValue(void)
 
   z_offset_value = HOME_Z_OFFSET_DEFAULT_VALUE;
   sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", unit);              // move nozzle
+  mustStoreCmd("G1 Z%.2f\n", unit);                               // move nozzle
 
   return z_offset_value;
 }
@@ -91,7 +91,7 @@ float homeOffsetUpdateValue(float unit, int8_t direction)
   unit = ((diff > unit) ? unit : diff) * direction;
   z_offset_value -= unit;
   sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", unit);              // move nozzle
+  mustStoreCmd("G1 Z%.2f\n", unit);                               // move nozzle
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -386,8 +386,8 @@ void printEnd(void)
   powerFailedDelete();
 
   infoPrinting.cur = infoPrinting.size;  // always update the print progress to 100% even if the print terminated
-  setPrintRemainingTime(0);
   infoPrinting.printing = infoPrinting.pause = false;
+  setPrintRemainingTime(0);
   preparePrintSummary();  // update print summary. infoPrinting are used
 
   if (infoSettings.send_end_gcode == 1)

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -576,7 +576,7 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
       break;
   }
 
-  infoPrinting.pause = isPause; // update pause status after pause/resume procedure
+  infoPrinting.pause = isPause;  // update pause status after pause/resume procedure
   loopDetected = false;
 
   return true;

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -82,9 +82,8 @@ float probeOffsetResetValue(void)
   float unit = z_offset_value - PROBE_Z_OFFSET_DEFAULT_VALUE;
 
   z_offset_value = PROBE_Z_OFFSET_DEFAULT_VALUE;
-
   sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", -unit);  // move nozzle
+  mustStoreCmd("G1 Z%.2f\n", -unit);                               // move nozzle
 
   return z_offset_value;
 }
@@ -112,7 +111,7 @@ float probeOffsetUpdateValue(float unit, int8_t direction)
   unit = ((diff > unit) ? unit : diff) * direction;
   z_offset_value += unit;
   sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, z_offset_value);  // set Z offset value
-  mustStoreCmd("G1 Z%.2f\n", unit);  // move nozzle
+  mustStoreCmd("G1 Z%.2f\n", unit);                                // move nozzle
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -1,6 +1,8 @@
 #include "SpeedControl.h"
 #include "includes.h"
 
+#define NEXT_SPEED_WAIT 500  // 1 second is 1000
+
 const char *const speedCmd[SPEED_NUM] = {"M220", "M221"};
 
 static uint16_t setPercent[SPEED_NUM] = {100, 100};
@@ -9,8 +11,6 @@ static uint16_t curPercent[SPEED_NUM] = {100, 100};
 
 static bool speedQueryWait = false;
 static uint32_t nextSpeedTime = 0;
-
-#define NEXT_SPEED_WAIT 500  // 1 second is 1000
 
 void speedSetCurPercent(uint8_t tool, uint16_t per)
 {
@@ -36,10 +36,11 @@ void loopSpeed(void)
 {
   for (uint8_t i = 0; i < SPEED_NUM; i++)
   {
-    if (lastSetPercent[i] != setPercent[i] && (OS_GetTimeMs() > nextSpeedTime))
+    if ((lastSetPercent[i] != setPercent[i]) && (OS_GetTimeMs() > nextSpeedTime))
     {
       if (storeCmd("%s S%d D%d\n", speedCmd[i], setPercent[i], heatGetCurrentTool()))
         lastSetPercent[i] = setPercent[i];
+
       nextSpeedTime = OS_GetTimeMs() + NEXT_SPEED_WAIT;  // avoid rapid fire, clogging the queue
     }
   }

--- a/TFT/src/User/API/extend.h
+++ b/TFT/src/User/API/extend.h
@@ -18,8 +18,8 @@ void PS_ON_Init(void);
 void PS_ON_On(void);
 void PS_ON_Off(void);
 void FIL_Runout_Init(void);
-void FIL_PosE_SetUpdate(bool isUpdated);
-void FIL_SFS_SetAlive(bool isAlive);
+void FIL_PosE_SetUpdateWaiting(bool waiting);
+void FIL_SFS_SetAlive(bool alive);
 void loopBackEndFILRunoutDetect(void);
 void loopFrontEndFILRunoutDetect(void);
 

--- a/TFT/src/User/API/extend.h
+++ b/TFT/src/User/API/extend.h
@@ -17,9 +17,9 @@ enum
 void PS_ON_Init(void);
 void PS_ON_On(void);
 void PS_ON_Off(void);
-void positionSetUpdateWaiting(bool isWaiting);
 void FIL_Runout_Init(void);
-void FIL_SFS_SetAlive(uint8_t alive);
+void FIL_PosE_SetUpdate(bool isUpdated);
+void FIL_SFS_SetAlive(bool isAlive);
 void loopBackEndFILRunoutDetect(void);
 void loopFrontEndFILRunoutDetect(void);
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -669,7 +669,7 @@ void sendQueueCmd(void)
         case 114:  // M114
           #ifdef FIL_RUNOUT_PIN
             if (fromTFT)
-              positionSetUpdateWaiting(false);
+              FIL_PosE_SetUpdate(false);
           #endif
           break;
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -669,7 +669,7 @@ void sendQueueCmd(void)
         case 114:  // M114
           #ifdef FIL_RUNOUT_PIN
             if (fromTFT)
-              FIL_PosE_SetUpdate(false);
+              FIL_PosE_SetUpdateWaiting(false);
           #endif
           break;
 

--- a/TFT/src/User/Hal/stm32f10x/spi_slave.c
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave.c
@@ -6,7 +6,7 @@
 #include "Settings.h"
 #include "HD44780.h"
 
-#if !defined (MKS_TFT)
+#if !defined(MKS_TFT)
 
 #if defined(ST7920_EMULATOR)
 // TODO:
@@ -169,4 +169,4 @@ void EXTI15_10_IRQHandler(void)
 }
 #endif
 
-#endif             // endif for #if !defined (MKS_TFT)
+#endif             // endif for #if !defined(MKS_TFT)

--- a/TFT/src/User/Hal/stm32f10x/spi_slave_mks.c
+++ b/TFT/src/User/Hal/stm32f10x/spi_slave_mks.c
@@ -54,13 +54,9 @@ void SPI_Slave(CIRCULAR_QUEUE *queue)
 
   NVIC_InitTypeDef NVIC_InitStructure;
 
-#ifndef SPI3_PIN_SMART_USAGE                       // if enabled, it avoids any SPI3 CS pin usage and free the MISO (PB4 pin) for encoder pins
+#ifndef SPI3_PIN_SMART_USAGE                                         // if enabled, it avoids any SPI3 CS pin usage and free the MISO (PB4 pin) for encoder pins
   SPI_GPIO_Init(ST7920_SPI);
-  #ifdef MKS_TFT                                   // MKS TFTs already have an external pull-up resistor on PB0 and PB1 pins
-    GPIO_InitSet(SPI3_CS_PIN, MGPIO_MODE_IPN, 0);  // CS
-  #else
-    GPIO_InitSet(SPI3_CS_PIN, MGPIO_MODE_IPU, 0);  // CS
-  #endif
+  GPIO_InitSet(SPI3_CS_PIN, MGPIO_MODE_IPN, 0);                      // MKS TFTs already have an external pull-up resistor on PB0 and PB1 pins
 #endif
 
   NVIC_InitStructure.NVIC_IRQChannel = SPI3_IRQn;

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -659,10 +659,12 @@ void menuPrinting(void)
       case PS_TOUCH_6:
         if (isPrinting())
         {
-          if (!isHostDialog())
-            printPause(!isPaused(), PAUSE_NORMAL);
-          else
+          if (isHostDialog())
             addToast(DIALOG_TYPE_ERROR, (char *)textSelect(LABEL_BUSY));
+          else if (getPrintRunout())
+            addToast(DIALOG_TYPE_ERROR, (char *)textSelect(LABEL_FILAMENT_RUNOUT));
+          else
+            printPause(!isPaused(), PAUSE_NORMAL);
         }
         #ifndef TFT70_V3_0
           else

--- a/TFT/src/User/main.c
+++ b/TFT/src/User/main.c
@@ -34,7 +34,7 @@ void Hardware_GenericInit(void)
     GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);  //disable JTAG & SWD
   #endif
 
-  #if defined (MKS_TFT)
+  #if defined(MKS_TFT)
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_AFIO, ENABLE);
     GPIO_PinRemapConfig(GPIO_Remap_USART2, ENABLE);
   #endif
@@ -63,7 +63,7 @@ void Hardware_GenericInit(void)
     Buzzer_Config();
   #endif
 
-  #if !defined (MKS_TFT)
+  #if !defined(MKS_TFT)
     //causes hang if we deinit spi1
     SD_DeInit();
   #endif


### PR DESCRIPTION
**BUGFIX:**
* fixed #2040. That bug was introduced by PR #2035. The FIL_IsRunout() function needs always to be periodically performed to maintain the proper runout state while PR #2035 avoided to perform FIL_IsRunout() in case of no printing or paused print. In case of runout, resuming the print forced FIL_IsRunout() to return (as initial state) always "false". That value will not allow to resume the print in case the runout sensor uses a not inverted logic (e.g. MKS TFT). In that case that initial value triggers a runout and the print is always forced to pause with no possibility to resume

**IMPROVEMENTS:**
* improved runout logic. Current runout logic allows to resume the print even in case of a pending runout. In that case the resume will loose/waste (no filament is provided on top of the print) at least one gcode of the print file before the runout is detected and the print is paused. The new logic will simply avoid to resume a print in case of a pending runout. That will avoid any wasted gcode. As already done for pending Marlin dialog (e.g. M600), an error message (Filament Runout!) is displayed on the notification bar trying to resume a print with a pending runout
* simplified loopBackEndFILRunoutDetect() funtion. The runout state is now totally handled on that function (no need to split it across also loopFrontEndFILRunoutDetect() function. Also no need to check the status of a print (not printing, paused etc...). The runout state must always be periodically updated to provide at any time the correct state when requested (e.g. on PrintingMenu to allow or deny the print resume)
* minor cleanup

fixed #2040
resolved #2035

**PR STATE:** ready to merge