### PR TITLE
fix filament runout sensor bug

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -598,6 +598,10 @@ fil_runout:0
 #   Options: [disable: 0, enable: 1]
 fil_runout_inverting:1
 
+#### Filament Sensor Normal Close
+#   Options: [Normal Open: 0, Normal Close: 1]
+fil_runout_nc:1
+
 #### Filament Noise Threshold
 # Pause print when filament runout is detected at least for this time period.
 #   Unit: [time in miliseconds]

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -598,6 +598,10 @@ fil_runout:0
 #   Options: [disable: 0, enable: 1]
 fil_runout_inverting:1
 
+#### Filament Sensor Normal Close
+#   Options: [Normal Open: 0, Normal Close: 1]
+fil_runout_nc:1
+
 #### Filament Noise Threshold
 # Pause print when filament runout is detected at least for this time period.
 #   Unit: [time in miliseconds]

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -100,6 +100,7 @@ void infoSettingsReset(void)
 // Filament Runout Settings (only if connected to TFT controller)
   infoSettings.runout                 = FIL_SENSOR_TYPE;
   infoSettings.runout_invert          = FIL_RUNOUT_INVERTING;
+  infoSettings.runout_nc              = FIL_RUNOUT_NC;
   infoSettings.runout_noise_ms        = FIL_NOISE_THRESHOLD;
   infoSettings.runout_distance        = FILAMENT_RUNOUT_DISTANCE_MM;
 

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -177,6 +177,7 @@ typedef struct
 
   // Filament Runout Settings (only if connected to TFT controller)
   uint8_t  runout;
+  uint8_t  runout_nc;
   uint8_t  runout_invert;
   uint16_t runout_noise_ms;
   uint8_t  runout_distance;

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -177,8 +177,8 @@ typedef struct
 
   // Filament Runout Settings (only if connected to TFT controller)
   uint8_t  runout;
-  uint8_t  runout_nc;
   uint8_t  runout_invert;
+  uint8_t  runout_nc;
   uint16_t runout_noise_ms;
   uint8_t  runout_distance;
 

--- a/TFT/src/User/API/SmartFeatures.c
+++ b/TFT/src/User/API/SmartFeatures.c
@@ -40,25 +40,29 @@ static bool sfs_alive = false;  // Use an encoder disc to toggles the runout. Su
 
 void FIL_Runout_Init(void)
 {
+  GPIO_MODE pull =
   #if defined(MKS_TFT)
-    GPIO_InitSet(FIL_RUNOUT_PIN, MGPIO_MODE_IPN, 0);  // MKS TFTs already have an external pull-up resistor on PB0 and PB1 pins
+    MGPIO_MODE_IPN;  // MKS TFTs already have an external pull-up resistor on PB0 and PB1 pins
   #else
-    GPIO_InitSet(FIL_RUNOUT_PIN, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    (infoSettings.runout_invert ^ infoSettings.runout_nc) ? MGPIO_MODE_IPD : MGPIO_MODE_IPU;
   #endif
+
+  GPIO_InitSet(FIL_RUNOUT_PIN, pull, 0);
+
   #ifdef FIL_RUNOUT_PIN_1
-    GPIO_InitSet(FIL_RUNOUT_PIN_1, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    GPIO_InitSet(FIL_RUNOUT_PIN_1, pull, 0);
   #endif
   #ifdef FIL_RUNOUT_PIN_2
-    GPIO_InitSet(FIL_RUNOUT_PIN_2, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    GPIO_InitSet(FIL_RUNOUT_PIN_2, pull, 0);
   #endif
   #ifdef FIL_RUNOUT_PIN_3
-    GPIO_InitSet(FIL_RUNOUT_PIN_3, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    GPIO_InitSet(FIL_RUNOUT_PIN_3, pull, 0);
   #endif
   #ifdef FIL_RUNOUT_PIN_4
-    GPIO_InitSet(FIL_RUNOUT_PIN_4, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    GPIO_InitSet(FIL_RUNOUT_PIN_4, pull, 0);
   #endif
   #ifdef FIL_RUNOUT_PIN_5
-    GPIO_InitSet(FIL_RUNOUT_PIN_5, infoSettings.runout_invert ? MGPIO_MODE_IPU : MGPIO_MODE_IPD, 0);
+    GPIO_InitSet(FIL_RUNOUT_PIN_5, pull, 0);
   #endif
 }
 
@@ -123,6 +127,9 @@ bool FIL_NormalRunoutDetect(void)
           pinState = GPIO_GetLevel(FIL_RUNOUT_PIN_5);
           break;
       #endif
+      default:
+        pinState = GPIO_GetLevel(FIL_RUNOUT_PIN);
+        break;
     }
 
     if (pinState)

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -903,6 +903,10 @@ void parseConfigKey(uint16_t index)
         infoSettings.runout_invert = getOnOff();
         break;
 
+      case C_INDEX_RUNOUT_NC:
+        infoSettings.runout_nc = getOnOff();
+        break;
+
       case C_INDEX_RUNOUT_NOISE:
         SET_VALID_INT_VALUE(infoSettings.runout_noise_ms, MIN_DELAY_MS, MAX_DELAY_MS);
         break;

--- a/TFT/src/User/API/config.h
+++ b/TFT/src/User/API/config.h
@@ -105,6 +105,7 @@ extern "C" {
 //-----------------------------Filament Runout Settings (only if connected to TFT controller)
 #define CONFIG_RUNOUT                 "fil_runout:"
 #define CONFIG_RUNOUT_LOGIC           "fil_runout_inverting:"
+#define CONFIG_RUNOUT_NC              "fil_runout_nc:"
 #define CONFIG_RUNOUT_NOISE           "fil_noise_threshold:"
 #define CONFIG_RUNOUT_DISTANCE        "fil_runout_distance:"
 //-----------------------------Power Loss Recovery & BTT UPS Settings

--- a/TFT/src/User/API/config.inc
+++ b/TFT/src/User/API/config.inc
@@ -95,6 +95,7 @@ X_CONFIG(SHUTDOWN_TEMP)
 //-----------------------------Filament Runout Settings (only if connected to TFT controller)
 X_CONFIG(RUNOUT)
 X_CONFIG(RUNOUT_LOGIC)
+X_CONFIG(RUNOUT_NC)
 X_CONFIG(RUNOUT_NOISE)
 X_CONFIG(RUNOUT_DISTANCE)
 //-----------------------------Power Loss Recovery & BTT UPS Settings

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -361,6 +361,14 @@
  */
 #define FIL_RUNOUT_INVERTING 1  // Default: 1
 
+/**
+ * Filament runout sensor NC(Normal Close)
+ * Invert the logic of the sensor.
+ *
+ *   Options: [Normal Open: 0, Normal Close: 1]
+ */
+#define FIL_RUNOUT_NC 1  // Default: 1
+
 // Filament Noise Threshold
 // Pause print when filament runout is detected at least for this time period.
 #define FIL_NOISE_THRESHOLD 100   // Default: 100 (ms)

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -598,6 +598,10 @@ fil_runout:0
 #   Options: [disable: 0, enable: 1]
 fil_runout_inverting:1
 
+#### Filament Sensor Normal Close
+#   Options: [Normal Open: 0, Normal Close: 1]
+fil_runout_nc:1
+
 #### Filament Noise Threshold
 # Pause print when filament runout is detected at least for this time period.
 #   Unit: [time in miliseconds]


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
* Default use `FIL_RUNOUT_PIN` port when multiple extruder and only one filament sensor port. 
* Add the feature of configuring normal open or normal closed of filament sensor port
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
