### PR TITLE
Add remaining time based on comments from gCode file if generated with Cura or IdeaMaker

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -644,10 +644,11 @@ void setPrintResume(bool updateHost)
 // get gcode command from TFT (SD card or USB)
 void loopPrintFromTFT(void)
 {
-  bool    read_comment_mode = false;
+  bool    read_comment = false;
   bool    read_leading_space = true;
   char    read_char;
-  uint8_t read_count = 0;
+  uint8_t gCode_count = 0;
+  uint8_t comment_count = 0;
   UINT    br = 0;
 
   if (heatHasWaiting() || infoCmd.count || infoPrinting.pause) return;
@@ -667,53 +668,58 @@ void loopPrintFromTFT(void)
     // Gcode or comment
     if (read_char == '\n' )  // '\n' is end flag for per command
     {
-      if (read_count != 0)
+      if (gCode_count != 0)
       {
-        switch (read_comment_mode)
-        {
-          case false:
-            infoCmd.queue[infoCmd.index_w].gcode[read_count++] = '\n';
-            infoCmd.queue[infoCmd.index_w].gcode[read_count] = 0;  // terminate string
-            infoCmd.queue[infoCmd.index_w].src = SERIAL_PORT;
-            infoCmd.index_w = (infoCmd.index_w + 1) % CMD_MAX_LIST;
-            infoCmd.count++;
-            break;
+        infoCmd.queue[infoCmd.index_w].gcode[gCode_count++] = '\n';
+        infoCmd.queue[infoCmd.index_w].gcode[gCode_count] = 0;  // terminate string
+        infoCmd.queue[infoCmd.index_w].src = SERIAL_PORT;
+        infoCmd.index_w = (infoCmd.index_w + 1) % CMD_MAX_LIST;
+        infoCmd.count++;
+      }
 
-          case true:
-            gCode_comment.content[read_count++] = '\n';
-            gCode_comment.content[read_count] = 0;  // terminate string
-            gCode_comment.handled = false;
-            break;
-        }
+      if (comment_count != 0)
+      {
+        gCode_comment.content[comment_count++] = '\n';
+        gCode_comment.content[comment_count] = 0;  // terminate string
+        gCode_comment.handled = false;
+      }
 
-        read_count = 0;  // clear buffer
+      if (gCode_count + comment_count > 0)
+      {
         break;
       }
 
-      read_comment_mode  = false;  // for new command
+      read_comment = false;
       read_leading_space = true;
     }
-    else if (read_count >= CMD_MAX_CHAR - 2)
-    {}  // when the command length beyond the maximum, ignore the following bytes
+    else if (!read_comment && gCode_count >= CMD_MAX_CHAR - 2)
+    {}  // if command length is beyond the maximum, ignore the following bytes
+    else if (read_comment && comment_count >= CMD_MAX_CHAR - 2)
+    {}  // if comment length is beyond the maximum, ignore the following bytes
     else
     {
-      if (read_char == ';')  // ';' is comment out flag
+      if (read_char == ';')  // ';' is comment flag
       {
-        read_comment_mode = true;
+        read_comment = true;
         read_leading_space = true;  // comment might come after a gCode in the same line
+        comment_count = 0;  // there might be a comment in a commented line
       }
       else
       {
         if (read_leading_space && read_char != ' ')  // ignore ' ' space bytes
+        {
           read_leading_space = false;
+        }
 
         if (!read_leading_space && read_char != '\r')
         {
-          if (!read_comment_mode)   // normal gcode
-            infoCmd.queue[infoCmd.index_w].gcode[read_count++] = read_char;
+          if (!read_comment)   // normal gcode
+          {
+            infoCmd.queue[infoCmd.index_w].gcode[gCode_count++] = read_char;
+          }
           else // comment
           {
-            gCode_comment.content[read_count++] = read_char;
+            gCode_comment.content[comment_count++] = read_char;
           }
         }
       }

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -85,7 +85,7 @@ void parseComment()
       temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
       lowerCase(temp_char);
       if (strcmp(temp_char, "time") == 0 && M73R_presence == false)// check if first word is "time"
-      {
+      {// Cura specific
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
         if (strcmp(temp_char, "elapsed") == 0 && totalTime > 0)  // check if next word is "elapsed"
@@ -109,7 +109,7 @@ void parseComment()
       temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
       lowerCase(temp_char);
       if (strcmp(temp_char, "remaining") == 0 && M73R_presence == false)// check if first word is "remaining"
-      {
+      {// IdeaMaker specific
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
         if (strcmp(temp_char, "time") == 0)  // check if next word is "time"

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -7,6 +7,7 @@
 COMMENT gCode_comment = {0, true};
 static uint16_t layerNumber = 0;
 static uint16_t layerCount = 0;
+static uint32_t totalTime = 0;
 
 void lowerCase (char * tempChar)
 {
@@ -32,6 +33,11 @@ void setLayerNumber(uint16_t layer_number)
   layerNumber = layer_number;
 }
 
+void setTotalTime(uint32_t time)
+{
+  totalTime = time;
+}
+
 void parseComment()
 {
     char * temp_char;
@@ -42,30 +48,52 @@ void parseComment()
     // check for "layer" keyword in comment (layer number or layer count)
     if (gCode_comment.content[0] == 'l' || gCode_comment.content[0] == 'L')
     {
-        temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
-        if (temp_char != NULL)
-        {
-          lowerCase(temp_char);
-        }
-        if (strcmp(temp_char, "layer") == 0)
+      temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
+      lowerCase(temp_char);
+      if (strcmp(temp_char, "layer") == 0)
+      {
+        temp_char = strtok(NULL, TOKEN_DELIMITERS);
+        lowerCase(temp_char);
+        if (strcmp(temp_char, "count") == 0)  // check if next word is "count"
         {
           temp_char = strtok(NULL, TOKEN_DELIMITERS);
-          lowerCase(temp_char);
-          if (strcmp(temp_char, "count") == 0)  // check if next word is "count"
-          {
-            temp_char = strtok(NULL, TOKEN_DELIMITERS);
-            temp_value = strtoul(temp_char, NULL, 0);
-            if (temp_value != 0)
-              layerCount = temp_value;
-          }
-          else if (temp_char[0] >= '0' && temp_char[0] <= '9')  // check if a number is found
-          {
-            temp_value = strtoul(temp_char, NULL, 0);
-
-            // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
-            layerNumber = (layerNumber == temp_value) ? temp_value + 1: temp_value;
-          }
+          temp_value = strtoul(temp_char, NULL, 0);
+          if (temp_value != 0)
+            layerCount = temp_value;
         }
+        else if (temp_char[0] >= '0' && temp_char[0] <= '9')  // check if a number is found
+        {
+          temp_value = strtoul(temp_char, NULL, 0);
+
+          // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
+          layerNumber = (layerNumber == temp_value) ? temp_value + 1: temp_value;
+        }
+      }
+      // continue here with "else if" for another token that starts with "l" or "L"
+    }
+
+    // check for "time" keyword in comment to retrieve total or elapsed time
+    else if (gCode_comment.content[0] == 't' || gCode_comment.content[0] == 'T')
+    {
+      temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
+      lowerCase(temp_char);
+      if (strcmp(temp_char, "time") == 0)
+      {
+        temp_char = strtok(NULL, TOKEN_DELIMITERS);
+        lowerCase(temp_char);
+        if (strcmp(temp_char, "elapsed") == 0 && totalTime > 0)  // check if next word is "elapsed"
+        {
+          temp_char = strtok(NULL, TOKEN_DELIMITERS);
+          temp_value = strtoul(temp_char, NULL, 0);  // get the elapsed time in seconds
+          setPrintRemainingTime(totalTime - temp_value);
+        }
+        else if (temp_char[0] >= '0' && temp_char[0] <= '9')  // check if a number is found
+        {
+          totalTime = strtoul(temp_char, NULL, 0);
+          setPrintRemainingTime(totalTime);
+        }
+      }
+      // continue here with "else if" for another token that starts with "t" or "T"
     }
 
     gCode_comment.handled = true;

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -41,7 +41,7 @@ void setTotalTime(uint32_t time)
 void parseComment()
 {
     char * temp_char;
-    uint16_t temp_value = 0;
+    uint32_t temp_value = 0;
     if (gCode_comment.handled == true)
       return;
 

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -112,10 +112,10 @@ void parseComment()
       {
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
-        if (strcmp(temp_char, "time") == 0 && totalTime > 0)  // check if next word is "time"
+        if (strcmp(temp_char, "time") == 0)  // check if next word is "time"
         {
           temp_char = strtok(NULL, TOKEN_DELIMITERS);
-          temp_value = strtoul(temp_char, NULL, 0);  // get the elapsed time in seconds
+          temp_value = strtoul(temp_char, NULL, 0);  // get the remaining time in seconds
           setPrintRemainingTime(temp_value);
         }
       }

--- a/TFT/src/User/API/comment.h
+++ b/TFT/src/User/API/comment.h
@@ -21,7 +21,8 @@ extern COMMENT gCode_comment;
 void parseComment();
 uint16_t getLayerNumber();
 uint16_t getLayerCount();
-void setLayerNumber (uint16_t layer_number);
+void setLayerNumber(uint16_t layer_number);
+void setTotalTime(uint32_t time);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/API/comment.h
+++ b/TFT/src/User/API/comment.h
@@ -22,6 +22,7 @@ void parseComment();
 uint16_t getLayerNumber();
 uint16_t getLayerCount();
 void setLayerNumber(uint16_t layer_number);
+void setM73_presence(bool present);
 void setTotalTime(uint32_t time);
 
 #ifdef __cplusplus

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -564,7 +564,7 @@ void sendQueueCmd(void)
           if (cmd_seen('R'))
           {
             setPrintRemainingTime((cmd_value() * 60));
-            setTotalTime(0);  // disable parsing remaning time from gCode comments
+            setM73_presence(0);  // disable parsing remaning time from gCode comments
           }
 
           if (!infoMachineSettings.buildPercent)  // if M73 is not supported by Marlin, skip it

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -557,10 +557,15 @@ void sendQueueCmd(void)
 
         case 73:
           if (cmd_seen('P'))
+          {
             setPrintProgressPercentage(cmd_value());
+          }
 
           if (cmd_seen('R'))
+          {
             setPrintRemainingTime((cmd_value() * 60));
+            setTotalTime(0);  // disable parsing remaning time from gCode comments
+          }
 
           if (!infoMachineSettings.buildPercent)  // if M73 is not supported by Marlin, skip it
           {

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -153,6 +153,7 @@ void menuBeforePrinting(void)
   progDisplayType = infoSettings.prog_disp_type;
   layerDisplayType = infoSettings.layer_disp_type * 2;
   setLayerNumber(0);
+  setTotalTime(0);
   infoMenu.menu[infoMenu.cur] = menuPrinting;
 }
 

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -150,10 +150,14 @@ void menuBeforePrinting(void)
       infoMenu.cur--;
       return;
   }
+
+  // initialize things before print start
   progDisplayType = infoSettings.prog_disp_type;
   layerDisplayType = infoSettings.layer_disp_type * 2;
   setLayerNumber(0);
+  setM73_presence(false);
   setTotalTime(0);
+  
   infoMenu.menu[infoMenu.cur] = menuPrinting;
 }
 

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -237,7 +237,11 @@ notification_m117:0
 # It can be changed during print by pressing the hourglass icon.
 # At each click it will alter between the 3 variants.
 #
-# NOTE: If no remainig time info is present in the gCode file,
+# NOTE: 
+#       Some slicers include time related info in the gCode files as comment. For those
+#       which doesn't and remainig time display is desired, a post processing plugin is
+#       needed that adds that info in the gCode file (comment or M73 Rxx format).
+#       If no remainig time info is present in the gCode file (comment or M73 Rxx),
 #       the display defaults to option 0.
 #
 #   Options: [Percentage & Elapsed time: 0, Percentage & Remaining time: 1, Elapsed time & Remaining time: 2]


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This PR adds the remaining time info in the printing screen if the gCode is generated with Cura or IdeaMaker. There's no need anymore to use a plugin to insert M73 commands. In case M73 Rxx is present in the gCode, the comments are ignored, M73 has priority.

### Benefits

Everyone using Cura and/or IdeaMaker.


### Note

If there's any other slicer that inserts comments into the gCode file related to total time, elapsed or remaining time please let me know so I can implement that slicer's info too.