### PR TITLE
Bugfix - commands ignored if comment is present

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -644,10 +644,11 @@ void setPrintResume(bool updateHost)
 // get gcode command from TFT (SD card or USB)
 void loopPrintFromTFT(void)
 {
-  bool    read_comment_mode = false;
+  bool    read_comment = false;
   bool    read_leading_space = true;
   char    read_char;
-  uint8_t read_count = 0;
+  uint8_t gCode_count = 0;
+  uint8_t comment_count = 0;
   UINT    br = 0;
 
   if (heatHasWaiting() || infoCmd.count || infoPrinting.pause) return;
@@ -667,53 +668,58 @@ void loopPrintFromTFT(void)
     // Gcode or comment
     if (read_char == '\n' )  // '\n' is end flag for per command
     {
-      if (read_count != 0)
+      if (gCode_count != 0)
       {
-        switch (read_comment_mode)
-        {
-          case false:
-            infoCmd.queue[infoCmd.index_w].gcode[read_count++] = '\n';
-            infoCmd.queue[infoCmd.index_w].gcode[read_count] = 0;  // terminate string
-            infoCmd.queue[infoCmd.index_w].src = SERIAL_PORT;
-            infoCmd.index_w = (infoCmd.index_w + 1) % CMD_MAX_LIST;
-            infoCmd.count++;
-            break;
+        infoCmd.queue[infoCmd.index_w].gcode[gCode_count++] = '\n';
+        infoCmd.queue[infoCmd.index_w].gcode[gCode_count] = 0;  // terminate string
+        infoCmd.queue[infoCmd.index_w].src = SERIAL_PORT;
+        infoCmd.index_w = (infoCmd.index_w + 1) % CMD_MAX_LIST;
+        infoCmd.count++;
+      }
 
-          case true:
-            gCode_comment.content[read_count++] = '\n';
-            gCode_comment.content[read_count] = 0;  // terminate string
-            gCode_comment.handled = false;
-            break;
-        }
+      if (comment_count != 0)
+      {
+        gCode_comment.content[comment_count++] = '\n';
+        gCode_comment.content[comment_count] = 0;  // terminate string
+        gCode_comment.handled = false;
+      }
 
-        read_count = 0;  // clear buffer
+      if (gCode_count + comment_count > 0)
+      {
         break;
       }
 
-      read_comment_mode  = false;  // for new command
+      read_comment = false;
       read_leading_space = true;
     }
-    else if (read_count >= CMD_MAX_CHAR - 2)
-    {}  // when the command length beyond the maximum, ignore the following bytes
+    else if (!read_comment && gCode_count >= CMD_MAX_CHAR - 2)
+    {}  // if command length is beyond the maximum, ignore the following bytes
+    else if (read_comment && comment_count >= CMD_MAX_CHAR - 2)
+    {}  // if comment length is beyond the maximum, ignore the following bytes
     else
     {
-      if (read_char == ';')  // ';' is comment out flag
+      if (read_char == ';')  // ';' is comment flag
       {
-        read_comment_mode = true;
+        read_comment = true;
         read_leading_space = true;  // comment might come after a gCode in the same line
+        comment_count = 0;  // there might be a comment in a commented line
       }
       else
       {
         if (read_leading_space && read_char != ' ')  // ignore ' ' space bytes
+        {
           read_leading_space = false;
+        }
 
         if (!read_leading_space && read_char != '\r')
         {
-          if (!read_comment_mode)   // normal gcode
-            infoCmd.queue[infoCmd.index_w].gcode[read_count++] = read_char;
+          if (!read_comment)   // normal gcode
+          {
+            infoCmd.queue[infoCmd.index_w].gcode[gCode_count++] = read_char;
+          }
           else // comment
           {
-            gCode_comment.content[read_count++] = read_char;
+            gCode_comment.content[comment_count++] = read_char;
           }
         }
       }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

There was a bug (introduced by PR #2096) where commands from gCode files were ignored if a comment was present in the same line.

### Related Issues

Fixes #2129
