### PR TITLE
Fix machine/bed size parsing from M115 response

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -680,17 +680,17 @@ void parseACK(void)
       // parse and store build volume size
       else if (ack_seen("work:"))
       {
-        if (ack_seen("min:"))
+        if (ack_continue_seen("min:"))
         {
-          if (ack_seen("X:")) infoSettings.machine_size_min[X_AXIS] = ack_value();
-          if (ack_seen("Y:")) infoSettings.machine_size_min[Y_AXIS] = ack_value();
-          if (ack_seen("Z:")) infoSettings.machine_size_min[Z_AXIS] = ack_value();
+          if (ack_continue_seen("x:")) infoSettings.machine_size_min[X_AXIS] = ack_value();
+          if (ack_continue_seen("y:")) infoSettings.machine_size_min[Y_AXIS] = ack_value();
+          if (ack_continue_seen("z:")) infoSettings.machine_size_min[Z_AXIS] = ack_value();
         }
-        if (ack_seen("max:"))
+        if (ack_continue_seen("max:"))
         {
-          if (ack_seen("X:")) infoSettings.machine_size_max[X_AXIS] = ack_value();
-          if (ack_seen("Y:")) infoSettings.machine_size_max[Y_AXIS] = ack_value();
-          if (ack_seen("Z:")) infoSettings.machine_size_max[Z_AXIS] = ack_value();
+          if (ack_continue_seen("x:")) infoSettings.machine_size_max[X_AXIS] = ack_value();
+          if (ack_continue_seen("y:")) infoSettings.machine_size_max[Y_AXIS] = ack_value();
+          if (ack_continue_seen("z:")) infoSettings.machine_size_max[Z_AXIS] = ack_value();
         }
       }
       // parse M48, Repeatability Test


### PR DESCRIPTION
- Fix Machine/bed size not parsing correctly from the M115 command's response from the printer.

Fixes #2128