### PR TITLE
RRF: enable A-Z, Z-A, oldest and newest sort in print menu

### DIFF
--- a/TFT/src/Libraries/json/JsonStreamingParser.cpp
+++ b/TFT/src/Libraries/json/JsonStreamingParser.cpp
@@ -26,6 +26,8 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 #include "JsonStreamingParser.hpp"
 #include <string.h>
 
+JsonStreamingParser jsonStreamingParser;
+
 JsonStreamingParser::JsonStreamingParser() {
     reset();
 }

--- a/TFT/src/Libraries/json/JsonStreamingParser.hpp
+++ b/TFT/src/Libraries/json/JsonStreamingParser.hpp
@@ -133,3 +133,5 @@ class JsonStreamingParser {
     void setListener(JsonListener* listener);
     void reset();
 };
+
+extern JsonStreamingParser jsonStreamingParser;

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -283,8 +283,6 @@ void request_M20_rrf_streaming(char *nextdir, FP_STREAM_HANDLER handler)
   resetRequestCommandInfo("{", "}", "Error:", NULL, NULL);
   requestCommandInfo.stream_handler = handler;
 
-  // TODO replace S2 with S3, for some reason, this immediately crashes when S3 is used???
-  // S3 works perfectly fine if used in request_M20_rrf above.
   mustStoreCmd("M20 S2 P\"/%s\"\n", nextdir);
 
   loopProcessToCondition(&isWaitingResponse);

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -263,29 +263,12 @@ void request_M98(char *filename)
 }
 
 // nextdir path must start with "macros" or "gcodes"
-char *request_M20_rrf(char *nextdir)
-{
-  resetRequestCommandInfo("{", "}", "Error:", NULL, NULL);
-
-  mustStoreCmd("M20 S2 P\"/%s\"\n", nextdir);
-
-  // Wait for response
-  loopProcessToCondition(&isWaitingResponse);
-
-  return requestCommandInfo.cmd_rev_buf;
-}
-
-// nextdir path must start with "macros" or "gcodes"
-// streaming variant, as there is easily potential for the data response to exceed the 5K buffer
-// RRF internally limits responses at about ~8k (with pagination handling) handle that as a TODO
-void request_M20_rrf_streaming(char *nextdir, FP_STREAM_HANDLER handler)
+void request_M20_rrf(char *nextdir, bool with_ts, FP_STREAM_HANDLER handler)
 {
   resetRequestCommandInfo("{", "}", "Error:", NULL, NULL);
   requestCommandInfo.stream_handler = handler;
 
-  // TODO replace S2 with S3, for some reason, this immediately crashes when S3 is used???
-  // S3 works perfectly fine if used in request_M20_rrf above.
-  mustStoreCmd("M20 S2 P\"/%s\"\n", nextdir);
+  mustStoreCmd("M20 S%d P\"/%s\"\n", with_ts ? 3 : 2, nextdir);
 
   loopProcessToCondition(&isWaitingResponse);
 }

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -283,6 +283,8 @@ void request_M20_rrf_streaming(char *nextdir, FP_STREAM_HANDLER handler)
   resetRequestCommandInfo("{", "}", "Error:", NULL, NULL);
   requestCommandInfo.stream_handler = handler;
 
+  // TODO replace S2 with S3, for some reason, this immediately crashes when S3 is used???
+  // S3 works perfectly fine if used in request_M20_rrf above.
   mustStoreCmd("M20 S2 P\"/%s\"\n", nextdir);
 
   loopProcessToCondition(&isWaitingResponse);

--- a/TFT/src/User/API/Gcode/gcode.h
+++ b/TFT/src/User/API/Gcode/gcode.h
@@ -47,8 +47,7 @@ void request_M27(uint8_t seconds);
 void request_M125(void);
 void request_M0(void);
 void request_M98(char *filename);
-char *request_M20_rrf(char *dir);
-void request_M20_rrf_streaming(char *dir, FP_STREAM_HANDLER handler);
+void request_M20_rrf(char *dir, bool with_ts, FP_STREAM_HANDLER handler);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/API/Gcode/gcode.h
+++ b/TFT/src/User/API/Gcode/gcode.h
@@ -11,6 +11,8 @@ extern "C" {
 #define CMD_MAX_REV   5000
 #define MAX_ERROR_NUM 3
 
+typedef void (*FP_STREAM_HANDLER)(const char *);
+
 typedef struct
 {
   char *cmd_rev_buf;       // buffer where store the command response
@@ -25,6 +27,7 @@ typedef struct
   bool done;               // true if command is executed and response is received
   bool inError;            // true if error response
   bool inJson;             // true if !inResponse and !inWaitResponse and '{' is found
+  FP_STREAM_HANDLER stream_handler;
 } REQUEST_COMMAND_INFO;
 
 extern REQUEST_COMMAND_INFO requestCommandInfo;
@@ -45,6 +48,7 @@ void request_M125(void);
 void request_M0(void);
 void request_M98(char *filename);
 char *request_M20_rrf(char *dir);
+void request_M20_rrf_streaming(char *dir, FP_STREAM_HANDLER handler);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -15,9 +15,23 @@ echo:SD card ok
   return request_M21();
 }
 
-void rrfScanPrintFilesGcodeFs(void)
+static inline void rrfScanPrintFilesGcodeFs(void)
 {
-  parseJobListResponse(request_M20_rrf(infoFile.title));
+  // TODO enable the optimization for fetching M20 S2 once the problem with M20 S3 is fixed
+  // switch (infoSettings.files_sort_by)
+  // {
+    // case SORT_NAME_ASCENDING:
+    // case SORT_NAME_DESCENDING:
+      // parseJobListResponse(request_M20_rrf(infoFile.title));
+      // clearRequestCommandInfo();
+      // break;
+    // case SORT_DATE_NEW_FIRST:
+    // case SORT_DATE_OLD_FIRST:
+      // properly getting timestamps requires M20 S3, which has a larger payload
+      // ~50 files would exceed 5K easily with M20 S3, ~100 files would exceed 5K with M20 S2
+  request_M20_rrf_streaming(infoFile.title, parseJobListResponseStreaming);
+      // break;
+  // }
 }
 
 //static uint32_t date = 0;

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -17,21 +17,7 @@ echo:SD card ok
 
 static inline void rrfScanPrintFilesGcodeFs(void)
 {
-  // TODO enable the optimization for fetching M20 S2 once the problem with M20 S3 is fixed
-  // switch (infoSettings.files_sort_by)
-  // {
-    // case SORT_NAME_ASCENDING:
-    // case SORT_NAME_DESCENDING:
-      // parseJobListResponse(request_M20_rrf(infoFile.title));
-      // clearRequestCommandInfo();
-      // break;
-    // case SORT_DATE_NEW_FIRST:
-    // case SORT_DATE_OLD_FIRST:
-      // properly getting timestamps requires M20 S3, which has a larger payload
-      // ~50 files would exceed 5K easily with M20 S3, ~100 files would exceed 5K with M20 S2
   request_M20_rrf_streaming(infoFile.title, parseJobListResponseStreaming);
-      // break;
-  // }
 }
 
 //static uint32_t date = 0;

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -17,21 +17,8 @@ echo:SD card ok
 
 static inline void rrfScanPrintFilesGcodeFs(void)
 {
-  // TODO enable the optimization for fetching M20 S2 once the problem with M20 S3 is fixed
-  // switch (infoSettings.files_sort_by)
-  // {
-    // case SORT_NAME_ASCENDING:
-    // case SORT_NAME_DESCENDING:
-      // parseJobListResponse(request_M20_rrf(infoFile.title));
-      // clearRequestCommandInfo();
-      // break;
-    // case SORT_DATE_NEW_FIRST:
-    // case SORT_DATE_OLD_FIRST:
-      // properly getting timestamps requires M20 S3, which has a larger payload
-      // ~50 files would exceed 5K easily with M20 S3, ~100 files would exceed 5K with M20 S2
-  request_M20_rrf_streaming(infoFile.title, parseJobListResponseStreaming);
-      // break;
-  // }
+  // TODO detect files_sort_by and set with_ts appropriately once M20 S3 works
+  request_M20_rrf(infoFile.title, false, parseJobListResponse);
 }
 
 //static uint32_t date = 0;

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -17,7 +17,21 @@ echo:SD card ok
 
 static inline void rrfScanPrintFilesGcodeFs(void)
 {
+  // TODO enable the optimization for fetching M20 S2 once the problem with M20 S3 is fixed
+  // switch (infoSettings.files_sort_by)
+  // {
+    // case SORT_NAME_ASCENDING:
+    // case SORT_NAME_DESCENDING:
+      // parseJobListResponse(request_M20_rrf(infoFile.title));
+      // clearRequestCommandInfo();
+      // break;
+    // case SORT_DATE_NEW_FIRST:
+    // case SORT_DATE_OLD_FIRST:
+      // properly getting timestamps requires M20 S3, which has a larger payload
+      // ~50 files would exceed 5K easily with M20 S3, ~100 files would exceed 5K with M20 S2
   request_M20_rrf_streaming(infoFile.title, parseJobListResponseStreaming);
+      // break;
+  // }
 }
 
 //static uint32_t date = 0;

--- a/TFT/src/User/API/RRFM20Parser.cpp
+++ b/TFT/src/User/API/RRFM20Parser.cpp
@@ -1,5 +1,41 @@
 #include "RRFM20Parser.hpp"
+#include "FlashStore.h"
 
+/*
+  Parses a document like the following for M20 S2
+  {
+    "dir": "0:/gcodes/",
+    "first": 0,
+    "files": [
+        "sample.gcode",
+        ...
+    ],
+    "next": 0,
+    "err": 0
+  }
+
+  Also parses a document like the following for M20 S3
+  {
+    "dir": "0:/gcodes/",
+    "first": 0,
+    "files": [
+        {
+            "type": "f",
+            "name": "Phone Stand.gcode",
+            "size": 2126889,
+            "date": "2021-06-28T09:28:24"
+        },
+        {
+            "type": "d",
+            "name": "Test",
+            "size": 0,
+            "date": "2021-08-25T16:38:20"
+        },
+        ...
+    ],
+    "next": 0
+  }
+ */
 const TCHAR *skip_number(const TCHAR *value)
 {
   if (isdigit(*value))
@@ -14,14 +50,64 @@ const TCHAR *skip_number(const TCHAR *value)
   return value;
 }
 
-int compare_items(const void *a, const void *b)
+int compare_items(void *arg, const void *a, const void *b)
 {
+  bool macro_sort = *(bool *)arg;
+  if (macro_sort)
+    return strcasecmp(((M20_LIST_ITEM *)a)->file_name, ((M20_LIST_ITEM *)b)->file_name);
+
+  switch (infoSettings.files_sort_by)
+  {
+    case SORT_DATE_NEW_FIRST:
+      return strcmp(((M20_LIST_ITEM *)b)->timestamp, ((M20_LIST_ITEM *)a)->timestamp);
+    case SORT_DATE_OLD_FIRST:
+      return strcmp(((M20_LIST_ITEM *)a)->timestamp, ((M20_LIST_ITEM *)b)->timestamp);
+    case SORT_NAME_ASCENDING:
+      return strcasecmp(((M20_LIST_ITEM *)a)->file_name, ((M20_LIST_ITEM *)b)->file_name);
+    case SORT_NAME_DESCENDING:
+      return strcasecmp(((M20_LIST_ITEM *)b)->file_name, ((M20_LIST_ITEM *)a)->file_name);
+  }
   return strcmp(((M20_LIST_ITEM *)a)->file_name, ((M20_LIST_ITEM *)b)->file_name);
+}
+
+void RRFM20Parser::startObject()
+{
+  in_object = in_files;
+}
+
+void RRFM20Parser::endObject()
+{
+  in_object = false;
+  if (in_files && fileCount < FILE_NUM)
+    ++fileCount;
 }
 
 void RRFM20Parser::endDocument()
 {
-  qsort(fileList, fileCount, sizeof(M20_LIST_ITEM), compare_items);
+  if (macro_sort)
+    qsort_r(fileList, fileCount, sizeof(M20_LIST_ITEM), &macro_sort, compare_items);
+  else
+  {
+    switch (infoSettings.files_sort_by)
+    {
+      // TODO remove workaround for broken M20 S3 in gcode.c (request_M20_rrf_timestamps)
+      case SORT_DATE_NEW_FIRST:
+        // M20 appears to be sorted oldest first, implicitly, reverse it.
+        int i, j;
+        for (i = 0, j = fileCount - 1; i < j; ++i, --j)
+        {
+          M20_LIST_ITEM tmp;
+          tmp = fileList[i];
+          fileList[i] = fileList[j];
+          fileList[j] = tmp;
+        }
+        break;
+      case SORT_NAME_ASCENDING:
+      case SORT_NAME_DESCENDING:
+          qsort_r(fileList, fileCount, sizeof(M20_LIST_ITEM), &macro_sort, compare_items);
+        break;
+    }
+  }
 
   for (int i = 0; i < fileCount; i++)
   {
@@ -34,28 +120,91 @@ void RRFM20Parser::endDocument()
       infoFile.Longfile[infoFile.fileCount] = fileList[i].file_name;
       infoFile.file[infoFile.fileCount++] = fileList[i].display_name;
     }
+
+    if (fileList[i].timestamp != NULL)
+      free(fileList[i].timestamp);
+  }
+  need_reset = true;
+}
+
+// TODO handle `next` parameter when there are too many files to list
+// above ~8k response payloads result in pagination that needs handling
+void RRFM20Parser::key(const char *key)
+{
+  state = none;
+  if (!in_array)
+    in_files = strcmp(FILES, key) == 0;
+
+  if (in_files)
+  {
+    if (strcmp(FILES_TYPE, key) == 0)
+      state = type;
+    else if (strcmp(FILES_NAME, key) == 0)
+      state = name;
+    else if (strcmp(FILES_DATE, key) == 0)
+      state = date;
   }
 }
 
-void RRFM20Parser::handle_value(const char *value)
+void RRFM20Parser::value(const char *value)
 {
-  uint16_t current = fileCount++;
-  if (current >= FILE_NUM)
+  if (!in_files)
     return;
 
-  if ((fileList[current].is_directory = (*value == '*')))
+  if (in_object)
   {
-    ++value;
+    if (fileCount >= FILE_NUM)
+      return;
+
+    uint16_t len = strlen(value + 1);
+
+    switch (state)
+    {
+      case type:
+        fileList[fileCount].is_directory = value[0] == 'd';
+        break;
+
+      case name:
+        if ((fileList[fileCount].file_name = (TCHAR *)malloc(len)) != NULL)
+          strcpy(fileList[fileCount].file_name, value);
+        value = macro_sort ? skip_number(value) : value;
+        len = strlen(value) + 1;
+        if ((fileList[fileCount].display_name = (TCHAR *)malloc(len)) != NULL)
+          strcpy(fileList[fileCount].display_name, value);
+        break;
+
+      case date:
+        if ((fileList[fileCount].timestamp = (TCHAR *)malloc(len)) != NULL)
+          strcpy(fileList[fileCount].timestamp, value);
+        break;
+
+      case none:
+        break;
+    }
+    state = none;
   }
-  uint16_t len = strlen(value) + 1;
+  else
+  {
+    uint16_t current = fileCount++;
+    if (current >= FILE_NUM)
+      return;
 
-  if ((fileList[current].file_name = (TCHAR *)malloc(len)) != NULL)
-    strcpy(fileList[current].file_name, value);
+    fileList[current].timestamp = NULL;
 
-  value = macro_sort ? skip_number(value) : value;
-  len = strlen(value) + 1;
-  if ((fileList[current].display_name = (TCHAR *)malloc(len)) != NULL)
-    strcpy(fileList[current].display_name, value);
+    if ((fileList[current].is_directory = (*value == '*')))
+    {
+      ++value;
+    }
+    uint16_t len = strlen(value) + 1;
+
+    if ((fileList[current].file_name = (TCHAR *)malloc(len)) != NULL)
+      strcpy(fileList[current].file_name, value);
+
+    value = macro_sort ? skip_number(value) : value;
+    len = strlen(value) + 1;
+    if ((fileList[current].display_name = (TCHAR *)malloc(len)) != NULL)
+      strcpy(fileList[current].display_name, value);
+  }
 }
 
 void parseM20Response(const char *data, bool macro_sorting)
@@ -78,4 +227,23 @@ void parseMacroListResponse(const char *data)
 void parseJobListResponse(const char *data)
 {
   parseM20Response(data, false);
+}
+
+void parseJobListResponseStreaming(const char  *data)
+{
+  static JsonStreamingParser parser;
+  static RRFM20Parser handler;
+
+  handler.macro_sort = false;
+  parser.setListener(&handler);
+  while (*data != 0)
+  {
+    parser.parse(*data++);
+  }
+
+  if (handler.need_reset)
+  {
+    handler.reset();
+    parser.reset();
+  }
 }

--- a/TFT/src/User/API/RRFM20Parser.cpp
+++ b/TFT/src/User/API/RRFM20Parser.cpp
@@ -58,28 +58,12 @@ int compare_items(void *arg, const void *a, const void *b)
 
   switch (infoSettings.files_sort_by)
   {
-    case SORT_DATE_NEW_FIRST:
-      return strcmp(((M20_LIST_ITEM *)b)->timestamp, ((M20_LIST_ITEM *)a)->timestamp);
-    case SORT_DATE_OLD_FIRST:
-      return strcmp(((M20_LIST_ITEM *)a)->timestamp, ((M20_LIST_ITEM *)b)->timestamp);
     case SORT_NAME_ASCENDING:
       return strcasecmp(((M20_LIST_ITEM *)a)->file_name, ((M20_LIST_ITEM *)b)->file_name);
     case SORT_NAME_DESCENDING:
       return strcasecmp(((M20_LIST_ITEM *)b)->file_name, ((M20_LIST_ITEM *)a)->file_name);
   }
   return strcmp(((M20_LIST_ITEM *)a)->file_name, ((M20_LIST_ITEM *)b)->file_name);
-}
-
-void RRFM20Parser::startObject()
-{
-  in_object = in_files;
-}
-
-void RRFM20Parser::endObject()
-{
-  in_object = false;
-  if (in_files && fileCount < FILE_NUM)
-    ++fileCount;
 }
 
 void RRFM20Parser::endDocument()
@@ -90,7 +74,6 @@ void RRFM20Parser::endDocument()
   {
     switch (infoSettings.files_sort_by)
     {
-      // TODO remove workaround for broken M20 S3 in gcode.c (request_M20_rrf_timestamps)
       case SORT_DATE_NEW_FIRST:
         // M20 appears to be sorted oldest first, implicitly, reverse it.
         int i, j;
@@ -121,8 +104,6 @@ void RRFM20Parser::endDocument()
       infoFile.file[infoFile.fileCount++] = fileList[i].display_name;
     }
 
-    if (fileList[i].timestamp != NULL)
-      free(fileList[i].timestamp);
   }
   need_reset = true;
 }
@@ -131,19 +112,8 @@ void RRFM20Parser::endDocument()
 // above ~8k response payloads result in pagination that needs handling
 void RRFM20Parser::key(const char *key)
 {
-  state = none;
   if (!in_array)
     in_files = strcmp(FILES, key) == 0;
-
-  if (in_files)
-  {
-    if (strcmp(FILES_TYPE, key) == 0)
-      state = type;
-    else if (strcmp(FILES_NAME, key) == 0)
-      state = name;
-    else if (strcmp(FILES_DATE, key) == 0)
-      state = date;
-  }
 }
 
 void RRFM20Parser::value(const char *value)
@@ -151,60 +121,23 @@ void RRFM20Parser::value(const char *value)
   if (!in_files)
     return;
 
-  if (in_object)
+  uint16_t current = fileCount++;
+  if (current >= FILE_NUM)
+    return;
+
+  if ((fileList[current].is_directory = (*value == '*')))
   {
-    if (fileCount >= FILE_NUM)
-      return;
-
-    uint16_t len = strlen(value + 1);
-
-    switch (state)
-    {
-      case type:
-        fileList[fileCount].is_directory = value[0] == 'd';
-        break;
-
-      case name:
-        if ((fileList[fileCount].file_name = (TCHAR *)malloc(len)) != NULL)
-          strcpy(fileList[fileCount].file_name, value);
-        value = macro_sort ? skip_number(value) : value;
-        len = strlen(value) + 1;
-        if ((fileList[fileCount].display_name = (TCHAR *)malloc(len)) != NULL)
-          strcpy(fileList[fileCount].display_name, value);
-        break;
-
-      case date:
-        if ((fileList[fileCount].timestamp = (TCHAR *)malloc(len)) != NULL)
-          strcpy(fileList[fileCount].timestamp, value);
-        break;
-
-      case none:
-        break;
-    }
-    state = none;
+    ++value;
   }
-  else
-  {
-    uint16_t current = fileCount++;
-    if (current >= FILE_NUM)
-      return;
+  uint16_t len = strlen(value) + 1;
 
-    fileList[current].timestamp = NULL;
+  if ((fileList[current].file_name = (TCHAR *)malloc(len)) != NULL)
+    strcpy(fileList[current].file_name, value);
 
-    if ((fileList[current].is_directory = (*value == '*')))
-    {
-      ++value;
-    }
-    uint16_t len = strlen(value) + 1;
-
-    if ((fileList[current].file_name = (TCHAR *)malloc(len)) != NULL)
-      strcpy(fileList[current].file_name, value);
-
-    value = macro_sort ? skip_number(value) : value;
-    len = strlen(value) + 1;
-    if ((fileList[current].display_name = (TCHAR *)malloc(len)) != NULL)
-      strcpy(fileList[current].display_name, value);
-  }
+  value = macro_sort ? skip_number(value) : value;
+  len = strlen(value) + 1;
+  if ((fileList[current].display_name = (TCHAR *)malloc(len)) != NULL)
+    strcpy(fileList[current].display_name, value);
 }
 
 void parseM20Response(const char *data, bool macro_sorting)

--- a/TFT/src/User/API/RRFM20Parser.hpp
+++ b/TFT/src/User/API/RRFM20Parser.hpp
@@ -18,9 +18,8 @@ extern "C"
     TCHAR *file_name;
     TCHAR *timestamp;
   } M20_LIST_ITEM;
-  void parseMacroListResponse(const char *data);
   void parseJobListResponse(const char *data);
-  void parseJobListResponseStreaming(const char *data);
+  void parseMacroListResponse(const char *data);
 #ifdef __cplusplus
 }
 #endif
@@ -50,6 +49,7 @@ public:
   bool macro_sort = false;
   bool need_reset = false;
 
+  virtual ~RRFM20Parser() {}
   inline void startDocument() {}
   virtual void startObject();
   virtual void endObject();

--- a/TFT/src/User/API/RRFM20Parser.hpp
+++ b/TFT/src/User/API/RRFM20Parser.hpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "ff.h"
+#include "gcode.h"
 #include "vfs.h"
 
 #ifdef __cplusplus
@@ -15,9 +16,11 @@ extern "C"
     bool is_directory;
     TCHAR *display_name;
     TCHAR *file_name;
+    TCHAR *timestamp;
   } M20_LIST_ITEM;
   void parseMacroListResponse(const char *data);
   void parseJobListResponse(const char *data);
+  void parseJobListResponseStreaming(const char *data);
 #ifdef __cplusplus
 }
 #endif
@@ -26,24 +29,45 @@ extern "C"
 #include "JsonStreamingParser.hpp"
 #include <string.h>
 
-static const char *FILES = "files";
+#define FILES "files"
+#define FILES_TYPE "type"
+#define FILES_NAME "name"
+#define FILES_DATE "date"
+enum RRFM20ParserState { none, type, name, date };
+
 class RRFM20Parser : public JsonListener
 {
 
 private:
   bool in_array = false;
+  bool in_object = false;
   bool in_files = false;
   uint16_t fileCount = 0;
+  RRFM20ParserState state = none;
   M20_LIST_ITEM fileList[FILE_NUM];
 
 public:
   bool macro_sort = false;
+  bool need_reset = false;
 
   inline void startDocument() {}
-  inline void startObject() {}
-  inline void endObject() {}
+  virtual void startObject();
+  virtual void endObject();
   inline void whitespace(char c) {}
   virtual void endDocument();
+  virtual void key(const char *key);
+  virtual void value(const char *value);
+
+  inline void reset()
+  {
+    in_array = false;
+    in_object = false;
+    in_files = false;
+    fileCount = 0;
+    state = none;
+    need_reset = false;
+  }
+
   inline void startArray()
   {
     in_array = in_files;
@@ -51,18 +75,9 @@ public:
   inline void endArray()
   {
     in_array = false;
+    in_files = false;
   }
 
-  inline void key(const char *key)
-  {
-    in_files = strcmp(FILES, key) == 0;
-  }
-  inline void value(const char *value)
-  {
-    if (in_array)
-      handle_value(value);
-  }
-  void handle_value(const char *value);
 };
 #endif
 

--- a/TFT/src/User/API/RRFM20Parser.hpp
+++ b/TFT/src/User/API/RRFM20Parser.hpp
@@ -16,6 +16,7 @@ extern "C"
     bool is_directory;
     TCHAR *display_name;
     TCHAR *file_name;
+    TCHAR *timestamp;
   } M20_LIST_ITEM;
   void parseMacroListResponse(const char *data);
   void parseJobListResponse(const char *data);
@@ -29,14 +30,20 @@ extern "C"
 #include <string.h>
 
 #define FILES "files"
+#define FILES_TYPE "type"
+#define FILES_NAME "name"
+#define FILES_DATE "date"
+enum RRFM20ParserState { none, type, name, date };
 
 class RRFM20Parser : public JsonListener
 {
 
 private:
   bool in_array = false;
+  bool in_object = false;
   bool in_files = false;
   uint16_t fileCount = 0;
+  RRFM20ParserState state = none;
   M20_LIST_ITEM fileList[FILE_NUM];
 
 public:
@@ -44,8 +51,8 @@ public:
   bool need_reset = false;
 
   inline void startDocument() {}
-  inline void startObject() {}
-  inline void endObject() {}
+  virtual void startObject();
+  virtual void endObject();
   inline void whitespace(char c) {}
   virtual void endDocument();
   virtual void key(const char *key);
@@ -54,8 +61,10 @@ public:
   inline void reset()
   {
     in_array = false;
+    in_object = false;
     in_files = false;
     fileCount = 0;
+    state = none;
     need_reset = false;
   }
 

--- a/TFT/src/User/API/RRFM20Parser.hpp
+++ b/TFT/src/User/API/RRFM20Parser.hpp
@@ -16,7 +16,7 @@ extern "C"
     bool is_directory;
     TCHAR *display_name;
     TCHAR *file_name;
-    TCHAR *timestamp;
+    uint32_t timestamp;
   } M20_LIST_ITEM;
   void parseJobListResponse(const char *data);
   void parseMacroListResponse(const char *data);

--- a/TFT/src/User/API/RRFM20Parser.hpp
+++ b/TFT/src/User/API/RRFM20Parser.hpp
@@ -16,7 +16,6 @@ extern "C"
     bool is_directory;
     TCHAR *display_name;
     TCHAR *file_name;
-    TCHAR *timestamp;
   } M20_LIST_ITEM;
   void parseMacroListResponse(const char *data);
   void parseJobListResponse(const char *data);
@@ -30,20 +29,14 @@ extern "C"
 #include <string.h>
 
 #define FILES "files"
-#define FILES_TYPE "type"
-#define FILES_NAME "name"
-#define FILES_DATE "date"
-enum RRFM20ParserState { none, type, name, date };
 
 class RRFM20Parser : public JsonListener
 {
 
 private:
   bool in_array = false;
-  bool in_object = false;
   bool in_files = false;
   uint16_t fileCount = 0;
-  RRFM20ParserState state = none;
   M20_LIST_ITEM fileList[FILE_NUM];
 
 public:
@@ -51,8 +44,8 @@ public:
   bool need_reset = false;
 
   inline void startDocument() {}
-  virtual void startObject();
-  virtual void endObject();
+  inline void startObject() {}
+  inline void endObject() {}
   inline void whitespace(char c) {}
   virtual void endDocument();
   virtual void key(const char *key);
@@ -61,10 +54,8 @@ public:
   inline void reset()
   {
     in_array = false;
-    in_object = false;
     in_files = false;
     fileCount = 0;
-    state = none;
     need_reset = false;
   }
 

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -39,10 +39,6 @@ static int8_t m291_mode = 0;
 static bool show_m291 = false;
 static uint32_t m291_seq = 0xffffffff;
 static uint32_t expire_time = 0;
-static bool need_parser_reset = false;
-
-static JsonStreamingParser parser;
-static ParseACKJsonParser handler;
 
 static void m291_confirm(void)
 {
@@ -154,11 +150,14 @@ void ParseACKJsonParser::value(const char *value)
 
 void rrfParseACK(const char *data)
 {
+  static JsonStreamingParser parser;
+  static ParseACKJsonParser handler;
+
   parser.setListener(&handler);
-  if (need_parser_reset)
+  if (handler.need_parser_reset)
   {
     parser.reset();
-    need_parser_reset = false;
+    handler.need_parser_reset = false;
   }
   while (*data != 0)
   {

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -150,17 +150,16 @@ void ParseACKJsonParser::value(const char *value)
 
 void rrfParseACK(const char *data)
 {
-  static JsonStreamingParser parser;
   static ParseACKJsonParser handler;
 
-  parser.setListener(&handler);
-  if (handler.need_parser_reset)
-  {
-    parser.reset();
-    handler.need_parser_reset = false;
-  }
+  jsonStreamingParser.setListener(&handler);
   while (*data != 0)
   {
-    parser.parse(*data++);
+    jsonStreamingParser.parse(*data++);
+  }
+  if (handler.need_parser_reset)
+  {
+    jsonStreamingParser.reset();
+    handler.need_parser_reset = false;
   }
 }

--- a/TFT/src/User/API/RRFParseACK.hpp
+++ b/TFT/src/User/API/RRFParseACK.hpp
@@ -39,6 +39,7 @@ private:
   uint32_t m291_timeo = 0;
 
 public:
+  bool need_parser_reset = false;
   inline void startDocument() {}
   inline void startObject() {}
   inline void endObject() {}

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -444,7 +444,15 @@ void parseACK(void)
         requestCommandInfo.inError = true;
         requestCommandInfo.inWaitResponse = false;
 
-        strcpy(requestCommandInfo.cmd_rev_buf, dmaL2Cache);
+        if (requestCommandInfo.stream_handler != NULL)
+        {
+          clearRequestCommandInfo(); // unused if the streaming handler is involved.
+          requestCommandInfo.stream_handler(dmaL2Cache);
+        }
+        else
+        {
+          strcpy(requestCommandInfo.cmd_rev_buf, dmaL2Cache);
+        }
         BUZZER_PLAY(SOUND_ERROR);
         goto parse_end;
       }
@@ -453,7 +461,17 @@ void parseACK(void)
 
     if (requestCommandInfo.inResponse)
     {
-      if (strlen(requestCommandInfo.cmd_rev_buf) + strlen(dmaL2Cache) < CMD_MAX_REV)
+      if (requestCommandInfo.stream_handler != NULL)
+      {
+        clearRequestCommandInfo(); // unused if the streaming handler is involved.
+        requestCommandInfo.stream_handler(dmaL2Cache);
+        if (ack_seen(requestCommandInfo.stopMagic))
+        {
+          requestCommandInfo.done = true;
+          requestCommandInfo.inResponse = false;
+        }
+      }
+      else if (strlen(requestCommandInfo.cmd_rev_buf) + strlen(dmaL2Cache) < CMD_MAX_REV)
       {
         strcat(requestCommandInfo.cmd_rev_buf, dmaL2Cache);
         if (ack_seen(requestCommandInfo.stopMagic))

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -316,7 +316,7 @@ void menuPrint(void)
 {
   if (infoMachineSettings.firmwareType == FW_REPRAPFW)
   {
-    list_mode = true;  // force list mode in Onboard sd card
+    list_mode = infoSettings.file_listmode;
     infoFile.source = BOARD_SD;
     infoMenu.menu[infoMenu.cur] = menuPrintFromSource;
     goto selectEnd;

--- a/TFT/src/User/Menu/RRFMacros.c
+++ b/TFT/src/User/Menu/RRFMacros.c
@@ -63,6 +63,7 @@ void menuCallMacro(void)
 {
   uint16_t key_num = KEY_IDLE;
   uint8_t update = 1;
+  infoFile.cur_page = 0;
   infoFile.source = BOARD_SD;
 
   GUI_Clear(BACKGROUND_COLOR);

--- a/TFT/src/User/Menu/RRFMacros.c
+++ b/TFT/src/User/Menu/RRFMacros.c
@@ -9,9 +9,7 @@ extern const GUI_RECT titleRect;
 void scanInfoFilesFs(void)
 {
   clearInfoFile();
-  char *data = request_M20_rrf(infoFile.title);
-  parseMacroListResponse(data);
-  clearRequestCommandInfo();
+  request_M20_rrf(infoFile.title, false, parseMacroListResponse);
 }
 
 void rrfShowRunningMacro(void)


### PR DESCRIPTION
### Requirements

No new requirements

### Description

* Adds `stream_handler` to requestCommandInfo to support >5K payloads
* Adjusts scope of parser/handler in RRFParseACK
* Unlocks icon/grid mode print job listing, fixes #1981
* Resets macro menu cur_page to 0 upon entry (fixes state between print
  and macro menus)
* Code in place to support `M20 S3` once the kinks are worked out

### Benefits

Improves RRF support

### Related Issues

Addresses #1981 request for print menu icon mode

### Testing

Verified working on my MKSTFT28

### PR Status

Ready to merge pending reviews.

### Help Wanted

It seems I've made some memory allocation mistakes when parsing the JSON for `M20 S3` -- it would be greatly appreciated if someone could throw some eyeballs at my changes to see where I goofed? I'm thinking I have some problems around allocating/deallocating `file_name` and `display_name` but can't come to terms with what is happening.