### PR TITLE
RRF: support load/unload menu via load/unload macros

### DIFF
--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -129,12 +129,28 @@ void menuLoadUnload(void)
           case HEATED:
             if (lastCmd == UNLOAD_REQUESTED)
             { // unload
-              mustStoreCmd("M702 T%d\n", tool_index);
+              if (infoMachineSettings.firmwareType != FW_REPRAPFW)
+              {
+                mustStoreCmd("M702 T%d\n", tool_index);
+              }
+              else
+              {
+                mustStoreCmd("T%d\n", tool_index);
+                request_M98("sys/unload.g");
+              }
               lastCmd = UNLOAD_STARTED;
             }
             else  // LOAD_REQUESTED
             { // load
-              mustStoreCmd("M701 T%d\n", tool_index);
+              if (infoMachineSettings.firmwareType != FW_REPRAPFW)
+              {
+                mustStoreCmd("M701 T%d\n", tool_index);
+              }
+              else
+              {
+                mustStoreCmd("T%d\n", tool_index);
+                request_M98("sys/load.g");
+              }
               lastCmd = LOAD_STARTED;
             }
          }


### PR DESCRIPTION
### Requirements

RRF users will need to create `/sys/load.g` and `/sys/unload.g` files

### Description

Call /sys/load.g and /sys/unload.g macros accordingly in the Load/Unload menu when on RRF

This is generally my load/unload files, parameters for individual machines should be adjusted as appropriate:

`load.g`:
```
; Load filament
M116 P0
M83          ; ensure relative extrusion
G1 E7 F2400  ; fill the short bowden, 45mm
G1 E50 F600  ; continue filling bowden and into the nozzle
G1 E20 F360  ; should see some extrude from nozzle
; ram
G0 E-5 F3600       ;extract filament to cold end area 
G4 S3                 ;wait for three seconds
G0 E5 F3600        ;push back the filament to smash any stringing 
G0 E-5 F3600       ;Extract back fast in the cold zone, helps reduce ooze
; end ram

```

`unload.g`:
```
M116 P0
M83 ; ensure relative extrusion
G1 E6 F300    ; extrude a little to get the hot bits out
; ram
G0 E-5 F3600       ;extract filament to cold end area 
G4 S3                 ;wait for three seconds
G0 E5 F3600        ;push back the filament to smash any stringing 
G0 E-5 F3600       ;Extract back fast in the cold zone, helps reduce ooze
; end ram
G0 E-60 F300       ;Continue extraction slowly, allow the filament time to cool solid before it reaches the gears
```

### Benefits

Enables LoadUnload menu support for RRF users

### Testing

Verified working on MKSTFT28

### PR Status

Ready to merge