### PR TITLE
RRF: Remove M118 requirement for print status updates

### DIFF
--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -14,6 +14,45 @@ static bool macro_busy = false;
 
 void rrfStatusSet(char status)
 {
+  if (rrf_status != status)
+  {
+    switch (status)
+    {
+      case 'R':
+      case 'P':
+        switch (rrf_status)
+        {
+          case 'D':
+          case 'A':
+            hostDialog = false;
+            setPrintResume(true);
+            break;
+          case 'I':
+            // parseACK will take care of going to the print screen
+            mustStoreCmd("M409 K\"job.file.fileName\"\n");
+            break;
+        }
+        break;
+
+      case 'I':
+        switch (rrf_status)
+        {
+          case 'P':
+          case 'R':
+          case 'A':
+          case 'D':
+            setPrintAbort(); // done is the same as abort
+            break;
+        }
+        break;
+
+      case 'D':
+      case 'A':
+        if (rrf_status == 'P')
+          setPrintPause(false, PAUSE_EXTERNAL);
+        break;
+    }
+  }
   rrf_status = status;
   if (status != 'B')
   {


### PR DESCRIPTION
### Requirements

RRF users **must** remove the `M118` `//action:cancel` `//action:pause` `M409 K"job.file.fileName"` etc. integrations from their config files

These files should be updated to remove the `M409` and `M118` commands that were previously used to notify the TFT of print status changes:
`start.g`
`pause.g`
`resume.g`
`cancel.g`
`stop.g`

### Description

Determine print status from M408 requests to determine entry into the print status screen. Automatically updates pause/resume/cancel statuses without `M118` commands.


### Benefits

Reduces configuration burden for RRF users

### PR Status

Ready to merge

### Testing

Verified to work as expected on my MKSTFT28

### Related

#1743 -- this change added print status update support for RRF and called out some config changes required; nothing is altered in this original change, but the config updates are no longer required. All the existing mechanisms remain.