### PR TITLE
RRF: support printing > busy > idle state transition

### DIFF
--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -8,6 +8,7 @@
 // I=idle, P=printing from SD card, S=stopped (i.e. needs a reset), C=running config file (i.e starting up),
 // A=paused, D=pausing, R=resuming from a pause, B=busy (e.g. running a macro), F=performing firmware update
 static char rrf_status = 'I';
+static bool was_printing = false;
 
 static uint16_t rrf_query_interval = RRF_NORMAL_STATUS_QUERY_MS;
 static bool macro_busy = false;
@@ -43,6 +44,11 @@ void rrfStatusSet(char status)
           case 'D':
             setPrintAbort(); // done is the same as abort
             break;
+
+          case 'B':
+            if (was_printing)
+              setPrintAbort();
+            break;
         }
         break;
 
@@ -50,6 +56,22 @@ void rrfStatusSet(char status)
       case 'A':
         if (rrf_status == 'P')
           setPrintPause(false, PAUSE_EXTERNAL);
+        break;
+
+      case 'B':
+        switch (rrf_status)
+        {
+          case 'P':
+          case 'R':
+          case 'A':
+          case 'D':
+            was_printing = true;
+            break;
+
+          default:
+            was_printing = false;
+            break;
+        }
         break;
     }
   }


### PR DESCRIPTION
### Requirements

No new requirements

### Description

Small diff to support an additional state change for detecting a print has finished/canceled: Printing > Busy > Idle

### Benefits

Captures print stop better
