### PR TITLE
RRF: don't try to show gcode previews

### DIFF
--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -56,7 +56,7 @@ void gocdeIconDraw(void)
     if (EnterDir(infoFile.file[i + infoFile.cur_page * NUM_PER_PAGE - infoFile.folderCount]) == false)
       break;
     // if model preview bmp exists, display bmp directly without writing to flash
-    if (model_DirectDisplay(getIconStartPoint(i), infoFile.title) != true)
+    if (infoMachineSettings.firmwareType == FW_REPRAPFW || !model_DirectDisplay(getIconStartPoint(i), infoFile.title))
     {
       curItem.icon = ICON_FILE;
       menuDrawItem(&curItem, i);


### PR DESCRIPTION
### Requirements

No new requirements

### Description

Avoid logic trying to load gcode previews in printing menu, some TFTs
crash because of it. Only skipped for RRF

### Benefits

Improves stability of the print menu for RRF users

### PR Status

Ready to merge

### Testing

Verified working on others' BTT TFT35 V3