### PR TITLE
Clean-up and remove duplicate code 

### DIFF
--- a/TFT/src/User/API/UI/ListManager.c
+++ b/TFT/src/User/API/UI/ListManager.c
@@ -48,10 +48,6 @@ void listViewCreate(LABEL title, LISTITEM * items, uint16_t maxItems, uint16_t *
 
   listViewSetCurPage(curPageIndex);
   menuDrawListPage(&listItems);
-
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
 }
 
 // Set/Update List view title
@@ -183,7 +179,7 @@ uint16_t listViewGetSelectedIndex(void)
   if (key_num < LISTITEM_PER_PAGE)
   {
     // return actual item index
-    uint8_t cur_index = curPageIndex * LISTITEM_PER_PAGE + key_num;
+    uint16_t cur_index = curPageIndex * LISTITEM_PER_PAGE + key_num;
 
     if (cur_index < maxItemCount)
     {
@@ -197,10 +193,12 @@ uint16_t listViewGetSelectedIndex(void)
   // check function keypress
   switch (key_num)
   {
+    case KEY_DECREASE:
     case KEY_INDEX_PAGEUP:
       listViewPreviousPage();
       return KEY_PAGEUP;
 
+    case KEY_INCREASE:
     case KEY_INDEX_PAGEDOWN:
       listViewNextPage();
       return KEY_PAGEDOWN;
@@ -211,23 +209,6 @@ uint16_t listViewGetSelectedIndex(void)
       return KEY_BACK;
 
     default:
-      #if LCD_ENCODER_SUPPORT
-        if (encoderPosition)  // if a page scrolling is requested
-        {
-          if (encoderPosition < 0)  // if page up
-          {
-            encoderPosition = 0;
-            listViewPreviousPage();
-            return KEY_PAGEUP;
-          }
-          else  // if page down
-          {
-            encoderPosition = 0;
-            listViewNextPage();
-            return KEY_PAGEDOWN;
-          }
-        }
-      #endif
       return KEY_IDLE;  // if no key is pressed and no page scrolling is requested
   }
 }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -62,9 +62,7 @@ bool storeCmd(const char * format, ...)
 {
   if (strlen(format) == 0) return false;
 
-  GCODE_QUEUE * pQueue = &infoCmd;
-
-  if (pQueue->count >= CMD_QUEUE_SIZE)
+  if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
     return false;
@@ -72,7 +70,7 @@ bool storeCmd(const char * format, ...)
 
   va_list va;
   va_start(va, format);
-  commonStoreCmd(pQueue, format, va);
+  commonStoreCmd(&infoCmd, format, va);
   va_end(va);
 
   return true;
@@ -86,18 +84,15 @@ void mustStoreCmd(const char * format, ...)
 {
   if (strlen(format) == 0) return;
 
-  GCODE_QUEUE * pQueue = &infoCmd;
-
-  if (pQueue->count >= CMD_QUEUE_SIZE)
+  if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
-
     loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
   }
 
   va_list va;
   va_start(va, format);
-  commonStoreCmd(pQueue, format, va);
+  commonStoreCmd(&infoCmd, format, va);
   va_end(va);
 }
 
@@ -138,19 +133,17 @@ bool storeCmdFromUART(SERIAL_PORT_INDEX portIndex, const CMD cmd)
 {
   if (strlen(cmd) == 0) return false;
 
-  GCODE_QUEUE * pQueue = &infoCmd;
-
-  if (pQueue->count >= CMD_QUEUE_SIZE)
+  if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
     return false;
   }
 
-  strncpy(pQueue->queue[pQueue->index_w].gcode, cmd, CMD_MAX_SIZE);
+  strncpy(infoCmd.queue[infoCmd.index_w].gcode, cmd, CMD_MAX_SIZE);
 
-  pQueue->queue[pQueue->index_w].port_index = portIndex;
-  pQueue->index_w = (pQueue->index_w + 1) % CMD_QUEUE_SIZE;
-  pQueue->count++;
+  infoCmd.queue[infoCmd.index_w].port_index = portIndex;
+  infoCmd.index_w = (infoCmd.index_w + 1) % CMD_QUEUE_SIZE;
+  infoCmd.count++;
 
   return true;
 }
@@ -160,18 +153,15 @@ bool storeCmdFromUART(SERIAL_PORT_INDEX portIndex, const CMD cmd)
 // This function is used only to restore the printing status after a power failed.
 void mustStoreCacheCmd(const char * format, ...)
 {
-  GCODE_QUEUE * pQueue = &infoCacheCmd;
-
-  if (pQueue->count >= CMD_QUEUE_SIZE)
+  if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
     reminderMessage(LABEL_BUSY, STATUS_BUSY);
-
     loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
   }
 
   va_list va;
   va_start(va, format);
-  commonStoreCmd(pQueue, format, va);
+  commonStoreCmd(&infoCmd, format, va);
   va_end(va);
 }
 

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -392,7 +392,9 @@ MENU_TYPE getMenuType(void)
   return menuType;
 }
 
-void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_RECT * menuRect, void(*action_redraw)(uint8_t position, uint8_t is_press), void (* menu_redraw)(void))
+void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_RECT * menuRect,
+             void(*action_redraw)(uint8_t position, uint8_t is_press),
+             void (*menu_redraw)(void))
 {
   menuType = menu_type;
   curRect = menuRect;
@@ -400,6 +402,10 @@ void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_R
   curTitle = title;
   TSC_ReDrawIcon = action_redraw;
   curMenuRedrawHandle = menu_redraw;
+
+  #if LCD_ENCODER_SUPPORT
+    encoderPosition = 0;
+  #endif
 }
 
 void reminderSetUnConnected(void)
@@ -608,11 +614,16 @@ void menuDrawPage(const MENUITEMS *menuItems)
 
   menuClearGaps();  // Use this function instead of GUI_Clear to eliminate the splash screen when clearing the screen.
   menuDrawTitle(labelGetAddress(&menuItems->title));
+
   for (i = 0; i < ITEM_PER_PAGE; i++)
   {
     menuDrawItem(&menuItems->items[i], i);
     RAPID_PRINTING_COMM()  // perform backend printing loop between drawing icons to avoid printer idling
   }
+
+  #if LCD_ENCODER_SUPPORT
+    encoderPosition = 0;
+  #endif
 }
 
 // Draw the entire interface
@@ -639,6 +650,10 @@ void menuDrawListPage(const LISTITEMS *listItems)
       menuDrawListItem(&curListItems->items[i], i);
     RAPID_PRINTING_COMM()  // perform backend printing loop between drawing icons to avoid printer idling
   }
+
+  #if LCD_ENCODER_SUPPORT
+    encoderPosition = 0;
+  #endif
 }
 
 // Show live info text on icons
@@ -848,6 +863,11 @@ KEY_VALUES menuKeyGetValue(void)
     titleBarPress();
     tempkey = KEY_IDLE;
   }
+
+  #if LCD_ENCODER_SUPPORT
+    if (tempkey == KEY_IDLE)
+      tempkey = LCD_Enc_KeyValue();
+  #endif
 
   return tempkey;
 }

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -45,6 +45,8 @@ typedef enum
   KEY_LABEL_7,
   KEY_TITLEBAR,
   KEY_INFOBOX,
+  KEY_INCREASE = IDLE_TOUCH - 5,
+  KEY_DECREASE = IDLE_TOUCH - 4,
   KEY_PAGEUP   = IDLE_TOUCH - 3,
   KEY_PAGEDOWN = IDLE_TOUCH - 2,
   KEY_BACK     = IDLE_TOUCH - 1,
@@ -182,7 +184,9 @@ GUI_POINT getIconStartPoint(int index);
 
 void GUI_RestoreColorDefault(void);
 uint8_t *labelGetAddress(const LABEL * label);
-void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_RECT * menuRect, void(*action_redraw)(uint8_t position, uint8_t is_press),  void (* menu_redraw)(void));
+void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_RECT * menuRect,
+             void(*action_redraw)(uint8_t position, uint8_t is_press),
+             void (*menu_redraw)(void));
 void menuDrawItem (const ITEM * menuItem, uint8_t position);
 void menuDrawIconOnly(const ITEM *item, uint8_t position);
 void menuDrawIconText(const ITEM *item, uint8_t position);
@@ -190,7 +194,7 @@ void menuDrawListItem(const LISTITEM *item, uint8_t position);
 void menuRefreshListPage(void);
 void menuDrawTitle(const uint8_t *content);  //(const MENUITEMS * menuItems);
 void menuReDrawCurTitle(void);
-void menuDrawPage (const MENUITEMS * menuItems);
+void menuDrawPage(const MENUITEMS * menuItems);
 void menuDrawListPage(const LISTITEMS *listItems);
 
 void showLiveInfo(uint8_t index, const LIVE_INFO * liveicon, const ITEM * item);

--- a/TFT/src/User/Hal/LCD_Encoder.c
+++ b/TFT/src/User/Hal/LCD_Encoder.c
@@ -187,4 +187,18 @@ void LCD_Enc_CheckSteps(void)
   }
 }
 
+KEY_VALUES LCD_Enc_KeyValue(void)
+{
+  if (encoderPosition == 0)
+  {
+    return KEY_IDLE;
+  }
+  else
+  {
+    int16_t encPosTemp = encoderPosition;
+    encoderPosition = 0;
+    return (encPosTemp > 0) ? KEY_INCREASE : KEY_DECREASE;
+  }
+}
+
 #endif  // LCD_ENCODER_SUPPORT

--- a/TFT/src/User/Hal/LCD_Encoder.h
+++ b/TFT/src/User/Hal/LCD_Encoder.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "menu.h"
 #include "variants.h"  // for ENC_ACTIVE_SIGNAL, LCD_ENCODER_SUPPORT etc...
 
 #if ENC_ACTIVE_SIGNAL
@@ -23,6 +24,7 @@ extern "C" {
   void LCD_Enc_SendPulse(uint8_t num);      // send a pulse to the encoder
   bool LCD_Enc_CheckState(void);
   void LCD_Enc_CheckSteps(void);
+  KEY_VALUES LCD_Enc_KeyValue(void);  // return a value from provided variables based on encoder position
 #endif
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -119,26 +119,23 @@ void menuBabystep(void)
   menuDrawPage(&babyStepItems);
   babyReDraw(now_babystep, now_z_offset, force_z_offset, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuBabystep)
   {
+    key_num = menuKeyGetValue();
     unit = moveLenSteps[moveLenSteps_index];
-
     babystep = babystepGetValue();  // always load current babystep
 
-    key_num = menuKeyGetValue();
     switch (key_num)
     {
       // decrease babystep / Z offset
       case KEY_ICON_0:
+      case KEY_DECREASE:
         babystep = babystepUpdateValue(unit, -1);
         break;
 
       // increase babystep / Z offset
       case KEY_ICON_3:
+      case KEY_INCREASE:
         babystep = babystepUpdateValue(unit, 1);
         break;
 
@@ -156,7 +153,6 @@ void menuBabystep(void)
       // change unit
       case KEY_ICON_5:
         moveLenSteps_index = (moveLenSteps_index + 1) % ITEM_FINE_MOVE_LEN_NUM;
-
         babyStepItems.items[key_num] = itemMoveLen[moveLenSteps_index];
 
         menuDrawItem(&babyStepItems.items[key_num], key_num);
@@ -177,14 +173,6 @@ void menuBabystep(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            babystep = babystepUpdateValue(unit, encoderPosition < 0 ? -1 : 1);
-
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -59,18 +59,16 @@ void menuExtrude(void)
   menuDrawPage(&extrudeItems);
   extruderReDraw(curExtruder_index, extrKnownCoord, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
 
   while (infoMenu.menu[infoMenu.cur] == menuExtrude)
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         extrNewCoord -= extlenSteps[extlenSteps_index];
         break;
 
@@ -85,6 +83,7 @@ void menuExtrude(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         extrNewCoord += extlenSteps[extlenSteps_index];
         break;
 
@@ -123,13 +122,6 @@ void menuExtrude(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            extrNewCoord += extlenSteps[extlenSteps_index] * encoderPosition;
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -42,16 +42,14 @@ void menuFan(void)
   menuDrawPage(&fanItems);
   fanReDraw(fan_index, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuFan)
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         if (fanGetSetSpeed(fan_index) > 0)
         {
           if (infoSettings.fan_percentage == 1)
@@ -86,6 +84,7 @@ void menuFan(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         if (fanGetSetSpeed(fan_index) < infoSettings.fan_max[fan_index])
         {
           if (infoSettings.fan_percentage == 1)
@@ -125,27 +124,6 @@ void menuFan(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (fanGetSetSpeed(fan_index) < infoSettings.fan_max[fan_index] && encoderPosition > 0)
-            {
-              if (infoSettings.fan_percentage == 1)
-                fanSetPercent(fan_index, fanGetSetPercent(fan_index) + 1);
-              else
-                fanSetSpeed(fan_index, fanGetSetSpeed(fan_index) + 1);
-            }
-
-            if (fanGetSetSpeed(fan_index) > 0 && encoderPosition < 0)
-            {
-              if (infoSettings.fan_percentage == 1)
-                fanSetPercent(fan_index, fanGetSetPercent(fan_index) - 1);
-              else
-                fanSetSpeed(fan_index, fanGetSetSpeed(fan_index) - 1);
-            }
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -42,19 +42,17 @@ void menuHeat(void)
   menuDrawPage(&heatItems);
   temperatureReDraw(tool_index, NULL, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuHeat)
   {
     actCurrent = heatGetCurrentTemp(tool_index);
     actTarget = heatGetTargetTemp(tool_index);
 
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         heatSetTargetTemp(tool_index, actTarget - degreeSteps[degreeSteps_index]);
         break;
 
@@ -71,6 +69,7 @@ void menuHeat(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         heatSetTargetTemp(tool_index, actTarget + degreeSteps[degreeSteps_index]);
         break;
 
@@ -102,16 +101,6 @@ void menuHeat(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (encoderPosition > 0)
-              heatSetTargetTemp(tool_index, actTarget + degreeSteps[degreeSteps_index]);
-            else  // if < 0)
-              heatSetTargetTemp(tool_index, actTarget - degreeSteps[degreeSteps_index]);
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -28,6 +28,8 @@ typedef enum
   LED_KEY_CANCEL,
   LED_KEY_OK,
   // no need to declare key numbers if no special task is performed by the key
+  LED_KEY_INCREASE = KEY_INCREASE,
+  LED_KEY_DECREASE = KEY_DECREASE,
   LED_KEY_IDLE = IDLE_TOUCH,
 } LED_KEY_VALUES;
 
@@ -386,10 +388,6 @@ void menuLEDColorCustom(void)
 
   ledDrawMenu();
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuLEDColorCustom)
   {
     key_num = menuKeyGetValue();
@@ -400,7 +398,6 @@ void menuLEDColorCustom(void)
         if (ledPage > 0)
         {
           ledPage--;
-
           updateForced = true;
         }
         break;
@@ -410,7 +407,6 @@ void menuLEDColorCustom(void)
         if (ledPage < (PAGE_NUM - 1))
         {
           ledPage++;
-
           updateForced = true;
         }
         break;
@@ -433,18 +429,19 @@ void menuLEDColorCustom(void)
         break;
 
       // use rotary encoder to update LED component value
-      case LED_KEY_IDLE:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            curValue = ledUpdateComponentValue(ledIndex, 1, (encoderPosition > 0) ? 1 : -1);
+      case LED_KEY_INCREASE:
+        curValue = ledUpdateComponentValue(ledIndex, 1, 1);
+        break;
 
-            encoderPosition = 0;
-          }
-        #endif
+      case LED_KEY_DECREASE:
+        curValue = ledUpdateComponentValue(ledIndex, 1, -1);
+        break;
+
+      case LED_KEY_IDLE:
         break;
 
       default:
+      {
         ledIndex = ledGetControlIndex(key_num);  // get control index
 
         switch (ledGetControlSubIndex(key_num))  // get control sub index
@@ -452,7 +449,6 @@ void menuLEDColorCustom(void)
           case 1:
           {
             curValue = ledEditComponentValue(ledIndex);
-
             sendingNeeded = true;
 
             ledDrawMenu();
@@ -473,6 +469,7 @@ void menuLEDColorCustom(void)
             break;
         }
         break;
+      }
     }
 
     if (updateForced)

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -172,21 +172,17 @@ void menuMBL(void)
   mblDrawHeader(!mblRunning ? NULL : &mblPoint);
   mblDrawValue(now);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuMBL)
   {
     unit = moveLenSteps[curUnit_index];
-
     curValue = coordinateGetAxisActual(Z_AXIS);
-
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       // decrease Z height
       case KEY_ICON_0:
+      case KEY_DECREASE:
         if (!mblRunning)
           mblNotifyError(false);
         else
@@ -202,6 +198,7 @@ void menuMBL(void)
 
       // increase Z height
       case KEY_ICON_3:
+      case KEY_INCREASE:
         if (!mblRunning)
           mblNotifyError(false);
         else
@@ -260,17 +257,6 @@ void menuMBL(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (!mblRunning)
-              mblNotifyError(false);
-            else
-              probeHeightMove(unit, encoderPosition < 0 ? -1 : 1);
-
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -86,6 +86,8 @@ typedef enum
   ME_KEY_NEXT,
   ME_KEY_DOWN,
   ME_KEY_NUM,                                              // number of keys
+  ME_KEY_INCREASE = KEY_INCREASE,
+  ME_KEY_DECREASE = KEY_DECREASE,
   ME_KEY_IDLE = IDLE_TOUCH,
 } MESH_KEY_VALUES;
 
@@ -835,16 +837,13 @@ void menuMeshEditor(void)
 
   meshDrawMenu();
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuMeshEditor)
   {
     curStatus = meshGetStatus();                           // always load current status
     curIndex = meshGetIndex();                             // always load current index
 
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case ME_KEY_UP:
@@ -856,10 +855,12 @@ void menuMeshEditor(void)
         break;
 
       case ME_KEY_PREV:
+      case ME_KEY_DECREASE:
         curIndex = meshSetIndex(curIndex - 1);
         break;
 
       case ME_KEY_NEXT:
+      case ME_KEY_INCREASE:
         curIndex = meshSetIndex(curIndex + 1);
         break;
 
@@ -904,14 +905,6 @@ void menuMeshEditor(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            curIndex = meshSetIndex(curIndex + encoderPosition);
-
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/MeshTuner.c
+++ b/TFT/src/User/Menu/MeshTuner.c
@@ -101,10 +101,6 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
   menuDrawPage(&meshItems);
   meshDraw(col, row, now);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (true)
   {
     unit = moveLenSteps[curUnit_index];
@@ -112,15 +108,18 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
     curValue = coordinateGetAxisActual(Z_AXIS);
 
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       // decrease Z height
       case KEY_ICON_0:
+      case KEY_DECREASE:
         probeHeightMove(unit, -1);
         break;
 
       // increase Z height
       case KEY_ICON_3:
+      case KEY_INCREASE:
         probeHeightMove(unit, 1);
         break;
 
@@ -153,14 +152,6 @@ float menuMeshTuner(uint16_t col, uint16_t row, float value)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            probeHeightMove(unit, encoderPosition < 0 ? -1 : 1);
-
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -126,10 +126,6 @@ void menuMove(void)
   menuDrawPage(&moveItems);
   drawXYZ();
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuMove)
   {
     key_num = menuKeyGetValue();
@@ -168,14 +164,16 @@ void menuMove(void)
 
         case KEY_ICON_7: infoMenu.cur--; break;
       #endif
+
+        case KEY_INCREASE:
+          storeMoveCmd(nowAxis, 1);
+          break;
+
+        case KEY_DECREASE:
+          storeMoveCmd(nowAxis, -1);
+          break;
+
         default:
-          #if LCD_ENCODER_SUPPORT
-            if (encoderPosition)
-            {
-              storeMoveCmd(nowAxis, encoderPosition > 0 ? 1 : -1);
-              encoderPosition = 0;
-            }
-          #endif
           break;
     }
 

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -217,16 +217,14 @@ void menuPid(void)
   menuDrawPage(&pidItems);
   temperatureReDraw(curTool_index, &pidHeaterTarget[curTool_index], false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuPid)
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         if (pidHeaterTarget[curTool_index] > 0)
           pidHeaterTarget[curTool_index] =
               NOBEYOND(0, pidHeaterTarget[curTool_index] - degreeSteps[degreeSteps_index],
@@ -248,6 +246,7 @@ void menuPid(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         if (pidHeaterTarget[curTool_index] < infoSettings.max_temp[curTool_index])
           pidHeaterTarget[curTool_index] =
               NOBEYOND(0, pidHeaterTarget[curTool_index] + degreeSteps[degreeSteps_index],
@@ -301,28 +300,6 @@ void menuPid(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (encoderPosition > 0)
-            {
-              if (pidHeaterTarget[curTool_index] < infoSettings.max_temp[curTool_index])
-                pidHeaterTarget[curTool_index] =
-                    NOBEYOND(0, pidHeaterTarget[curTool_index] + degreeSteps[degreeSteps_index],
-                             infoSettings.max_temp[curTool_index]);
-            }
-            else  // if < 0
-            {
-              if (pidHeaterTarget[curTool_index] > 0)
-                pidHeaterTarget[curTool_index] =
-                    NOBEYOND(0, pidHeaterTarget[curTool_index] - degreeSteps[degreeSteps_index],
-                             infoSettings.max_temp[curTool_index]);
-            }
-
-            temperatureReDraw(curTool_index, &pidHeaterTarget[curTool_index], true);
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -167,6 +167,7 @@ void menuPrintFromSource(void)
 
   KEY_VALUES key_num = KEY_IDLE;
   uint8_t update = 1;
+  uint8_t pageCount = (infoFile.folderCount + infoFile.fileCount + (NUM_PER_PAGE - 1)) / NUM_PER_PAGE;
 
   GUI_Clear(infoSettings.bg_color);
   GUI_DispStringInRect(0, 0, LCD_WIDTH, LCD_HEIGHT, LABEL_LOADING);
@@ -193,19 +194,20 @@ void menuPrintFromSource(void)
     infoMenu.cur--;
   }
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
 
   while (infoMenu.menu[infoMenu.cur] == menuPrintFromSource)
   {
-    if (list_mode != true) // select item from icon view
+    if (list_mode != true)  // select item from icon view
     {
       key_num = menuKeyGetValue();
+      pageCount = (infoFile.folderCount + infoFile.fileCount + (NUM_PER_PAGE - 1)) / NUM_PER_PAGE;
+
+      // read encoder position and change key index to page up/down
 
       switch (key_num)
       {
         case KEY_ICON_5:
+        case KEY_DECREASE:
           if (infoFile.cur_page > 0)
           {
             infoFile.cur_page--;
@@ -214,7 +216,8 @@ void menuPrintFromSource(void)
           break;
 
         case KEY_ICON_6:
-          if (infoFile.cur_page + 1 < (infoFile.folderCount + infoFile.fileCount + (NUM_PER_PAGE - 1)) / NUM_PER_PAGE)
+        case KEY_INCREASE:
+          if (infoFile.cur_page + 1 < pageCount)
           {
             infoFile.cur_page++;
             update = 1;
@@ -223,6 +226,7 @@ void menuPrintFromSource(void)
 
         case KEY_ICON_7:
           infoFile.cur_page = 0;
+
           if (IsRootDir() == true)
           {
             clearInfoFile();
@@ -238,29 +242,6 @@ void menuPrintFromSource(void)
           break;
 
         case KEY_IDLE:
-          #if LCD_ENCODER_SUPPORT
-            if (encoderPosition)  // if a page scrolling is requested
-            {
-              if (encoderPosition < 0)  // if page up
-              {
-                if (infoFile.cur_page > 0)
-                {
-                  infoFile.cur_page--;
-                  update = 1;
-                }
-              }
-              else  // if page down
-              {
-                if (infoFile.cur_page + 1 < (infoFile.folderCount + infoFile.fileCount + (NUM_PER_PAGE - 1)) / NUM_PER_PAGE)
-                {
-                  infoFile.cur_page++;
-                  update = 1;
-                }
-              }
-
-              encoderPosition = 0;
-            }
-          #endif
           break;
 
         default:
@@ -288,8 +269,8 @@ void menuPrintFromSource(void)
           }
           break;
 
-        case KEY_PAGEUP:
-        case KEY_PAGEDOWN:
+        case KEY_DECREASE:
+        case KEY_INCREASE:
         case KEY_IDLE:
           break;
 

--- a/TFT/src/User/Menu/SelectMode.c
+++ b/TFT/src/User/Menu/SelectMode.c
@@ -73,10 +73,6 @@ void menuMode(void)
       ;  // wait for touch release
   #endif
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuMode)
   {
     MKEY_VALUES key_num = MKeyGetValue();

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -55,16 +55,14 @@ void menuSpeed(void)
   menuDrawPage(&percentageItems);
   percentageReDraw(item_index, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuSpeed)
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         if (speedGetSetPercent(item_index) > SPEED_MIN)
           speedSetPercent(item_index, speedGetSetPercent(item_index) - percentSteps[percentSteps_index]);
         break;
@@ -82,6 +80,7 @@ void menuSpeed(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         if (speedGetSetPercent(item_index) < SPEED_MAX)
           speedSetPercent(item_index, speedGetSetPercent(item_index) + percentSteps[percentSteps_index]);
         break;
@@ -112,16 +111,6 @@ void menuSpeed(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (speedGetSetPercent(item_index) < SPEED_MAX && encoderPosition > 0)
-              speedSetPercent(item_index, speedGetSetPercent(item_index) + percentSteps[percentSteps_index]);
-            else if (speedGetSetPercent(item_index) > SPEED_MIN && encoderPosition < 0)
-              speedSetPercent(item_index, speedGetSetPercent(item_index) - percentSteps[percentSteps_index]);
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -94,19 +94,16 @@ void menuTuneExtruder(void)
   menuDrawPage(&tuneExtruderItems);
   temperatureReDraw(tool_index, NULL, false);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuTuneExtruder)
   {
+    key_num = menuKeyGetValue();
     actCurrent = heatGetCurrentTemp(tool_index);
     actTarget = heatGetTargetTemp(tool_index);
 
-    key_num = menuKeyGetValue();
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         heatSetTargetTemp(tool_index, actTarget - degreeSteps[degreeSteps_index]);
         break;
 
@@ -123,6 +120,7 @@ void menuTuneExtruder(void)
       }
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         heatSetTargetTemp(tool_index, actTarget + degreeSteps[degreeSteps_index]);
         break;
 
@@ -155,14 +153,7 @@ void menuTuneExtruder(void)
         }
         break;
 
-      default :
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            heatSetTargetTemp(tool_index, actTarget + degreeSteps[degreeSteps_index] * encoderPosition);
-            encoderPosition = 0;
-          }
-        #endif
+      default:
         break;
     }
 
@@ -242,20 +233,19 @@ void menuNewExtruderESteps(void)
   menuDrawPage(&newExtruderESteps);
   showNewESteps(measured_length, old_esteps, &new_esteps);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuNewExtruderESteps)
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
+      case KEY_DECREASE:
         measured_length -= moveLenSteps[extStep_index];
         break;
 
       case KEY_ICON_3:
+      case KEY_INCREASE:
         measured_length += moveLenSteps[extStep_index];
         break;
 
@@ -285,14 +275,7 @@ void menuNewExtruderESteps(void)
         infoMenu.cur--;
         break;
 
-      default :
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            measured_length += moveLenSteps[extStep_index] * encoderPosition;
-            encoderPosition = 0;
-          }
-        #endif
+      default:
         break;
     }
 

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -131,21 +131,17 @@ void menuZOffset(void)
   menuDrawPage(&zOffsetItems);
   zOffsetDraw(offsetGetStatus(), now);
 
-  #if LCD_ENCODER_SUPPORT
-    encoderPosition = 0;
-  #endif
-
   while (infoMenu.menu[infoMenu.cur] == menuZOffset)
   {
+    key_num = menuKeyGetValue();
     unit = moveLenSteps[curUnit_index];
-
     z_offset = offsetGetValue();  // always load current Z offset
 
-    key_num = menuKeyGetValue();
     switch (key_num)
     {
       // decrease Z offset
       case KEY_ICON_0:
+      case KEY_DECREASE:
         if (!offsetGetStatus())
           zOffsetNotifyError(false);
         else
@@ -161,6 +157,7 @@ void menuZOffset(void)
 
       // increase Z offset
       case KEY_ICON_3:
+      case KEY_INCREASE:
         if (!offsetGetStatus())
           zOffsetNotifyError(false);
         else
@@ -239,17 +236,6 @@ void menuZOffset(void)
         break;
 
       default:
-        #if LCD_ENCODER_SUPPORT
-          if (encoderPosition)
-          {
-            if (!offsetGetStatus())
-              zOffsetNotifyError(false);
-            else
-              z_offset = offsetUpdateValue(unit, encoderPosition < 0 ? -1 : 1);
-
-            encoderPosition = 0;
-          }
-        #endif
         break;
     }
 


### PR DESCRIPTION
- Remove duplicate code and reduce program memory.
- Remove the need to reset encoder values on every menu.
- The encoder rotation is now converted to Increase/decrease key values using the same `menuKeyGetValue` function, making it easier to use in future.
- Remove unnecessary local variable declaration in **interfaceCmd.c**.