### PR TITLE
RRF:M575 no longer requires RRF compatible marlin

### DIFF
--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -434,7 +434,7 @@ M27_refresh_time:3
 #### M27 Always Active
 # Keep polling M27 even if not printing.
 #   Options: [disable: 0, enable: 1]
-M27_always_active:1
+M27_always_active:0
 
 #### Long File Names Support
 # On Marlin firmware, the TFT will auto-detect Long File Name support.

--- a/TFT/src/User/API/BabystepControl.c
+++ b/TFT/src/User/API/BabystepControl.c
@@ -14,6 +14,12 @@ float babystepReset(void)
   return babystep_value;
 }
 
+// Set current babystep value
+void babystepSetValue(float babystep)
+{
+  babystep_value = babystep;
+}
+
 // Get current babystep value
 float babystepGetValue(void)
 {

--- a/TFT/src/User/API/BabystepControl.h
+++ b/TFT/src/User/API/BabystepControl.h
@@ -10,6 +10,9 @@ extern "C" {
 // Reset only babystep value to default value
 float babystepReset(void);
 
+// Set current babystep value
+void babystepSetValue(float babystep);
+
 // Get current babystep value
 float babystepGetValue(void);
 

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -67,12 +67,8 @@ static void resetRequestCommandInfo(
 */
 bool request_M21(void)
 {
-  const char * sdString = (infoMachineSettings.firmwareType == FW_REPRAPFW) ? "card mounted " : "SD card ";
-  const char * endstring = (infoMachineSettings.firmwareType == FW_REPRAPFW) ? "capacity" : "ok";
-
-
-  resetRequestCommandInfo(sdString,               // The magic to identify the start
-                          endstring,                   // The magic to identify the stop
+  resetRequestCommandInfo("SD card ",               // The magic to identify the start
+                          "ok",                   // The magic to identify the stop
                           "No SD card",             // The first magic to identify the error response
                           "SD init fail",         // The second error magic
                           "volume.init failed");  // The third error magic

--- a/TFT/src/User/API/Gcode/gcode.c
+++ b/TFT/src/User/API/Gcode/gcode.c
@@ -68,11 +68,12 @@ static void resetRequestCommandInfo(
 bool request_M21(void)
 {
   const char * sdString = (infoMachineSettings.firmwareType == FW_REPRAPFW) ? "card mounted " : "SD card ";
-  const char * errString1 = (infoMachineSettings.firmwareType == FW_REPRAPFW) ? "Error" : "No SD card";
+  const char * endstring = (infoMachineSettings.firmwareType == FW_REPRAPFW) ? "capacity" : "ok";
+
 
   resetRequestCommandInfo(sdString,               // The magic to identify the start
-                          "ok",                   // The magic to identify the stop
-                          errString1,             // The first magic to identify the error response
+                          endstring,                   // The magic to identify the stop
+                          "No SD card",             // The first magic to identify the error response
                           "SD init fail",         // The second error magic
                           "volume.init failed");  // The third error magic
 

--- a/TFT/src/User/API/Gcode/mygcodefs.c
+++ b/TFT/src/User/API/Gcode/mygcodefs.c
@@ -12,6 +12,10 @@ bool mountGcodeSDCard(void)
 SENDING:M21
 echo:SD card ok
 */
+  if (infoMachineSettings.firmwareType == FW_REPRAPFW)
+  {
+    return true;
+  }
   return request_M21();
 }
 

--- a/TFT/src/User/API/ModeSwitching.c
+++ b/TFT/src/User/API/ModeSwitching.c
@@ -17,6 +17,10 @@ void Mode_Switch(void)
     case MODE_SERIAL_TSC:
       GUI_RestoreColorDefault();
 
+      infoMachineSettings.firmwareType = FW_NOT_DETECTED;
+      infoHost.wait = false;
+      heatSetUpdateWaiting(false);
+
       if (infoSettings.status_screen == 1)  // if Status Screen menu is selected
         infoMenu.menu[infoMenu.cur] = menuStatus;  // status screen as default home screen on boot
       else

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -233,9 +233,12 @@ void ParseACKJsonParser::value(const char *value)
 
       break;
     case result:
-        strcpy(infoFile.title, value);
-        setPrintHost(true);
-        // setPrintResume(false);
+        if (starting_print)
+        {
+          strcpy(infoFile.title, value);
+          setPrintHost(true);
+          starting_print = false;
+        }
       break;
     case none:
       break;

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -110,7 +110,7 @@ void ParseACKJsonParser::value(const char *value)
       rrfStatusSet(value[0]);
       break;
     case heaters:
-      if (index == 0 )
+      if (index == 0)
       {
         heatSetCurrentTemp(BED, strtod((char *)value, NULL) + 0.5f);
       }
@@ -120,7 +120,7 @@ void ParseACKJsonParser::value(const char *value)
       }
       break;
     case active:
-      if (index == 0 )
+      if (index == 0)
       {
         heatSyncTargetTemp(BED, strtod((char *)value, NULL) + 0.5f);
       }
@@ -128,6 +128,8 @@ void ParseACKJsonParser::value(const char *value)
       {
         heatSyncTargetTemp(index - 1, strtod((char *)value, NULL) + 0.5f);
       }
+      break;
+    case standby:
       break;
     case hstat:
       if (strtod((char *)value, NULL) == 3)
@@ -159,11 +161,15 @@ void ParseACKJsonParser::value(const char *value)
       break;
     case tool:
       break;
+    case probe:
+      break;
     case fan_percent:
       if (index != 0 && index <= infoSettings.fan_count) // index 0 is an alias for default tool fan
       {
         fanSetPercent(index - 1, strtod((char *)value, NULL) + 0.5f);
       }
+      break;
+    case fanRPM:
       break;
     case mbox_seq:
       seq = strtod((char *)value, NULL);
@@ -216,30 +222,23 @@ void ParseACKJsonParser::value(const char *value)
         string_end = strstr(string_start, (char *)"/");
         setPrintProgress(atoi(string_start + 14), atoi(string_end + 1));
       }
-      else if (strstr(value, (char *)"Cancelled printing"))    //{"seq":488,"resp":"Cancelled printing file 0:/gcodes/test.gcode, print time was 0h 1m\n"}
-      {
-        setPrintAbort();
-      }
-      else if (strstr(value, (char *)"Finished printing"))   //{"seq":1222,"resp":"Finished printing file 0:/gcodes/text.gcode, print time was 0h 0m\n"}
-      {
-        setPrintHost(false);
-        printComplete();
-      }
       else if (strstr(value, (char *)"Auto tuning heater") && strstr(value, (char *)"completed"))
       {
         pidUpdateStatus(true);
       }
-      else if (strstr(value, (char *)"Error: M303") || strstr(value, (char *)"Auto tune of heater") && strstr(value, (char *)"failed"))
+      else if (strstr(value, (char *)"Error: M303") || (strstr(value, (char *)"Auto tune of heater") && strstr(value, (char *)"failed")))
       {
         pidUpdateStatus(false);
       }
 
       break;
-
+    case result:
+        strcpy(infoFile.title, value);
+        setPrintHost(true);
+        // setPrintResume(false);
+      break;
     case none:
       break;
-    default:
-     break;
   }
   if (in_array)
     ++index;

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -42,7 +42,7 @@ static uint32_t expire_time = 0;
 
 static void m291_confirm(void)
 {
-  if (m291_mode > 1) mustStoreCmd("M292 P0\n");
+  if (m291_mode >= 1) mustStoreCmd("M292 P0\n");
   if (rrfStatusIsMacroBusy())
     rrfShowRunningMacro();
 }
@@ -102,13 +102,51 @@ void ParseACKJsonParser::endDocument()
 void ParseACKJsonParser::value(const char *value)
 {
   uint32_t seq;
+  char *string_end;
+  char *string_start;
   switch (state)
   {
-    case fan_percent:
-      if (index != 0 && index <= infoSettings.fan_count) // index 0 is an alias for default tool fan
+    case status:
+      rrfStatusSet(value[0]);
+      break;
+    case heaters:
+      if (index == 0 )
       {
-        fanSetPercent(index - 1, strtod((char *)value, NULL) + 0.5f);
+        heatSetCurrentTemp(BED, strtod((char *)value, NULL) + 0.5f);
       }
+      else if (index <= INVALID_HEATER)
+      {
+        heatSetCurrentTemp(index - 1, strtod((char *)value, NULL) + 0.5f);
+      }
+      break;
+    case active:
+      if (index == 0 )
+      {
+        heatSyncTargetTemp(BED, strtod((char *)value, NULL) + 0.5f);
+      }
+      else if (index <= INVALID_HEATER)
+      {
+        heatSyncTargetTemp(index - 1, strtod((char *)value, NULL) + 0.5f);
+      }
+      break;
+    case hstat:
+      if (strtod((char *)value, NULL) == 3)
+      {
+        if (index == 0)
+        {
+          heatSetTargetTemp(BED, 0);
+        }
+        else if (index <= INVALID_HEATER)
+        {
+          heatSetTargetTemp(index - 1, 0);
+        }
+      }
+      break;
+    case pos:
+      coordinateSetAxisActual((AXIS)index, strtod((char *)value, NULL));
+      break;
+    case sfactor:
+      speedSetCurPercent(0, strtod((char *)value, NULL));
       break;
     case efactor:
       if (index == heatGetCurrentTool())
@@ -116,11 +154,16 @@ void ParseACKJsonParser::value(const char *value)
         speedSetCurPercent(1, strtod((char *)value, NULL));
       }
       break;
-    case sfactor:
-      speedSetCurPercent(0, strtod((char *)value, NULL));
+    case baby_step:
+      babystepSetValue(strtod((char *)value, NULL));
       break;
-    case status:
-      rrfStatusSet(value[0]);
+    case tool:
+      break;
+    case fan_percent:
+      if (index != 0 && index <= infoSettings.fan_count) // index 0 is an alias for default tool fan
+      {
+        fanSetPercent(index - 1, strtod((char *)value, NULL) + 0.5f);
+      }
       break;
     case mbox_seq:
       seq = strtod((char *)value, NULL);
@@ -141,8 +184,62 @@ void ParseACKJsonParser::value(const char *value)
     case mbox_timeo:
       m291_timeo = strtod((char *)value, NULL) * 1000;
       break;
+    case resp:
+      if (strstr(value, (char *)"Steps/"))       //parse M92
+      {
+        if ((value = strstr(value, (char *)"X: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_X,  atoi(value + 3));
+        if ((value = strstr(value, (char *)"Y: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Y,  atoi(value + 3));
+        if ((value = strstr(value, (char *)"Z: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Z,  atoi(value + 3));
+        if ((value = strstr(value, (char *)"E: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_E0, atoi(value + 3));
+      }
+      else if ((string_start = strstr(value, (char *)"RepRapFirmware")) != NULL)    // parse M115
+      {
+        setupMachine();
+        string_end = strstr(string_start, "ELECTRONICS");
+        infoSetFirmwareName((uint8_t *)string_start, string_end-string_start);
+      }
+      else if ((string_start = strstr(value, (char *)"access point")) != NULL)    //parse M552 
+      {
+        string_end = strstr(string_start, ",");
+        string_start += 13;
+        infoSetAccessPoint((uint8_t *)string_start,  string_end-string_start);
+
+        if ((string_start = strstr(string_start, (char *)"IP address")) != NULL)
+        {
+          string_end = strstr(string_start, "\\n");
+          string_start += 11;
+          infoSetIPAddress((uint8_t *)string_start,  string_end-string_start);
+        }
+      }
+      else if ((string_start = strstr(value, (char *)"printing byte")) != NULL)       // parse M27  {"seq":21,"resp":"SD printing byte 1226/5040433\n"}
+      {
+        string_end = strstr(string_start, (char *)"/");
+        setPrintProgress(atoi(string_start + 14), atoi(string_end + 1));
+      }
+      else if (strstr(value, (char *)"Cancelled printing"))    //{"seq":488,"resp":"Cancelled printing file 0:/gcodes/test.gcode, print time was 0h 1m\n"}
+      {
+        setPrintAbort();
+      }
+      else if (strstr(value, (char *)"Finished printing"))   //{"seq":1222,"resp":"Finished printing file 0:/gcodes/text.gcode, print time was 0h 0m\n"}
+      {
+        setPrintHost(false);
+        printComplete();
+      }
+      else if (strstr(value, (char *)"Auto tuning heater") && strstr(value, (char *)"completed"))
+      {
+        pidUpdateStatus(true);
+      }
+      else if (strstr(value, (char *)"Error: M303") || strstr(value, (char *)"Auto tune of heater") && strstr(value, (char *)"failed"))
+      {
+        pidUpdateStatus(false);
+      }
+
+      break;
+
     case none:
       break;
+    default:
+     break;
   }
   if (in_array)
     ++index;

--- a/TFT/src/User/API/RRFParseACK.hpp
+++ b/TFT/src/User/API/RRFParseACK.hpp
@@ -30,6 +30,7 @@ extern "C"
 #define MBOX_MSG    "msgBox.msg"
 #define MBOX_TITLE  "msgBox.title"
 #define RESP        "resp"
+#define RESULT      "result"
 
 enum DOCUMENT_STATE 
 { 
@@ -40,7 +41,6 @@ enum DOCUMENT_STATE
   standby,
   hstat,
   pos,
-  machine,
   sfactor,
   efactor,
   baby_step,
@@ -48,13 +48,13 @@ enum DOCUMENT_STATE
   probe,
   fan_percent,
   fanRPM,
-  homed,
   mbox_seq, 
   mbox_mode, 
   mbox_timeo, 
   mbox_msg, 
   mbox_title,
-  resp 
+  resp,
+  result
 };
 
 class ParseACKJsonParser : public JsonListener
@@ -149,7 +149,10 @@ public:
     {
       state = resp;
     }
-
+    else if (strcmp(RESULT, key) == 0)
+    {
+      state = result;
+    }
     else
     {
       state = none;

--- a/TFT/src/User/API/RRFParseACK.hpp
+++ b/TFT/src/User/API/RRFParseACK.hpp
@@ -14,17 +14,49 @@ extern "C"
 #include "JsonStreamingParser.hpp"
 #include <string.h>
 
-#define FANS "fanPercent"
-#define SPEED "sfactor"
-#define EXTRUSION "efactor"
-#define STATUS "status"
-#define MBOX_SEQ "msgBox.seq"
-#define MBOX_MODE "msgBox.mode"
-#define MBOX_TIMEO "msgBox.timeout"
-#define MBOX_MSG "msgBox.msg"
-#define MBOX_TITLE "msgBox.title"
+#define STATUS      "status"
+#define HEATERS     "heaters"
+#define ACTIVE      "active"
+#define STANDBY     "standby"
+#define HSTAT       "hstat"
+#define POS         "pos"
+#define SPEED       "sfactor"
+#define EXTRUSION   "efactor"
+#define BABYSTEP    "babystep"
+#define FAN_PERCENT "fanPercent"
+#define MBOX_SEQ    "msgBox.seq"
+#define MBOX_MODE   "msgBox.mode"
+#define MBOX_TIMEO  "msgBox.timeout"
+#define MBOX_MSG    "msgBox.msg"
+#define MBOX_TITLE  "msgBox.title"
+#define RESP        "resp"
 
-enum DOCUMENT_STATE { none, fan_percent, sfactor, efactor, status, mbox_seq, mbox_mode, mbox_timeo, mbox_msg, mbox_title };
+enum DOCUMENT_STATE 
+{ 
+  none, 
+  status,
+  heaters,
+  active,
+  standby,
+  hstat,
+  pos,
+  machine,
+  sfactor,
+  efactor,
+  baby_step,
+  tool,
+  probe,
+  fan_percent,
+  fanRPM,
+  homed,
+  mbox_seq, 
+  mbox_mode, 
+  mbox_timeo, 
+  mbox_msg, 
+  mbox_title,
+  resp 
+};
+
 class ParseACKJsonParser : public JsonListener
 {
 
@@ -57,9 +89,25 @@ public:
 
   inline void key(const char *key)
   {
-    if (strcmp(FANS, key) == 0)
+    if (strcmp(STATUS, key) == 0)
     {
-      state = fan_percent;
+      state = status;
+    }
+    else if (strcmp(HEATERS, key) == 0)
+    {
+      state = heaters;
+    }
+    else if (strcmp(ACTIVE, key) == 0)
+    {
+      state = active;
+    }
+    else if (strcmp(HSTAT, key) == 0)
+    {
+      state = hstat;
+    }
+    else if (strcmp(POS, key) == 0)
+    {
+      state = pos;
     }
     else if (strcmp(SPEED, key) == 0)
     {
@@ -69,9 +117,13 @@ public:
     {
       state = efactor;
     }
-    else if (strcmp(STATUS, key) == 0)
+    else if (strcmp(BABYSTEP, key) == 0)
     {
-      state = status;
+      state = baby_step;
+    }
+    else if (strcmp(FAN_PERCENT, key) == 0)
+    {
+      state = fan_percent;
     }
     else if (strcmp(MBOX_SEQ, key) == 0)
     {
@@ -93,6 +145,11 @@ public:
     {
       state = mbox_timeo;
     }
+    else if (strcmp(RESP, key) == 0)
+    {
+      state = resp;
+    }
+
     else
     {
       state = none;

--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -30,8 +30,6 @@ void rrfStatusSet(char status)
           case 'I':
             // parseACK will take care of going to the print screen
             mustStoreCmd("M409 K\"job.file.fileName\"\n");
-            setPrintHost(true);
-            setPrintResume(false);
             break;
         }
         break;

--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -11,6 +11,7 @@ static char rrf_status = 'I';
 
 static uint16_t rrf_query_interval = RRF_NORMAL_STATUS_QUERY_MS;
 static bool macro_busy = false;
+bool starting_print = false;
 
 void rrfStatusSet(char status)
 {
@@ -28,8 +29,9 @@ void rrfStatusSet(char status)
             setPrintResume(true);
             break;
           case 'I':
-            // parseACK will take care of going to the print screen
+            // RRFParseACK will take care of going to the print screen
             mustStoreCmd("M409 K\"job.file.fileName\"\n");
+            starting_print = true;
             break;
         }
         break;

--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -30,6 +30,8 @@ void rrfStatusSet(char status)
           case 'I':
             // parseACK will take care of going to the print screen
             mustStoreCmd("M409 K\"job.file.fileName\"\n");
+            setPrintHost(true);
+            setPrintResume(false);
             break;
         }
         break;

--- a/TFT/src/User/API/RRFStatusControl.h
+++ b/TFT/src/User/API/RRFStatusControl.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+extern bool starting_print;
 
 void rrfStatusQuery(void);
 void rrfStatusQueryFast(void);

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -234,14 +234,13 @@ void setupMachine(void)
 
   if (infoSettings.long_filename != AUTO)
     infoMachineSettings.longFilename = infoSettings.long_filename;
-
-  mustStoreCmd("M503 S0\n");
-
+    
   if (infoMachineSettings.firmwareType == FW_REPRAPFW)
   {
-    mustStoreCmd("M555 P2\n");  //  Set RRF compatibility behaves similar to 2: Marlin
-    mustStoreCmd("M552\n");     // query network state, populate IP if the screen boots up after RRF
+    mustStoreCmd("M552\n");   // query network state, populate IP if the screen boots up after RRF
+    return;
   }
+  mustStoreCmd("M503 S0\n");
   mustStoreCmd("M82\n");  // Set extruder to absolute mode
   mustStoreCmd("G90\n");  // Set to Absolute Positioning
 }

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -249,7 +249,7 @@ void loopCheckHeater(void)
         break;
       if (requestCommandInfoIsRunning())  // To avoid colision in Gcode response processing
         break;
-      if (storeCmd("M105\n") == false)
+      if ((infoMachineSettings.firmwareType != FW_REPRAPFW) && storeCmd("M105\n") == false)
         break;
       updateNextHeatCheckTime();
       heat_update_waiting = true;

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -249,7 +249,7 @@ void loopCheckHeater(void)
         break;
       if (requestCommandInfoIsRunning())  // To avoid colision in Gcode response processing
         break;
-      if ((infoMachineSettings.firmwareType != FW_REPRAPFW) && storeCmd("M105\n") == false)
+      if ((infoMachineSettings.firmwareType != FW_REPRAPFW) && !storeCmd("M105\n"))
         break;
       updateNextHeatCheckTime();
       heat_update_waiting = true;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -352,7 +352,6 @@ void hostActionCommands(void)
       // pass value "true" to report the host is printing without waiting
       // from Marlin (when notification ack "SD printing byte" is caught)
       setPrintResume(true);
-
       hostAction.prompt_show = false;
       Serial_Puts(SERIAL_PORT, "M876 S0\n");  // auto-respond to a prompt request that is not shown on the TFT
     

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -353,11 +353,9 @@ void hostActionCommands(void)
       // from Marlin (when notification ack "SD printing byte" is caught)
       setPrintResume(true);
 
-      if (infoMachineSettings.firmwareType != FW_REPRAPFW)
-      {
-        hostAction.prompt_show = false;
-        Serial_Puts(SERIAL_PORT, "M876 S0\n");  // auto-respond to a prompt request that is not shown on the TFT
-      }
+      hostAction.prompt_show = false;
+      Serial_Puts(SERIAL_PORT, "M876 S0\n");  // auto-respond to a prompt request that is not shown on the TFT
+    
     }
     else if (ack_seen("Reheating"))
     {
@@ -444,6 +442,7 @@ void parseACK(void)
         infoHost.wait = false;
         storeCmd("M92\n");
         storeCmd("M115\n");
+        coordinateQuerySetWait(true);
       }
 
       if (infoMachineSettings.firmwareType == FW_NOT_DETECTED)  // if never connected to the printer since boot
@@ -534,10 +533,17 @@ void parseACK(void)
 
     if (requestCommandInfo.inJson)
     {
-      rrfParseACK(dmaL2Cache);
+      if (ack_seen(magic_warning))
+      {
+        ackPopupInfo(magic_warning);
+      }
+      else
+      {
+        rrfParseACK(dmaL2Cache);
+      }
+      infoHost.wait = false;  
     }
-
-    if (ack_cmp("ok\n"))
+    else if (ack_cmp("ok\n"))
     {
       infoHost.wait = false;
     }
@@ -662,21 +668,12 @@ void parseACK(void)
         }
         hasFilamentData = true;
       }
-      else if (infoMachineSettings.onboardSD == ENABLED &&
-               ack_seen(infoMachineSettings.firmwareType != FW_REPRAPFW ? "File opened:" : "job.file.fileName"))
+      else if (infoMachineSettings.onboardSD == ENABLED && ack_seen("File opened:"))
       {
         char * fileEndString;
-        if (infoMachineSettings.firmwareType != FW_REPRAPFW)
-        {
-          // Marlin
-          fileEndString = " Size:";  // File opened: 1A29A~1.GCO Size: 6974
-        }
-        else
-        {
-          // RRF
-          ack_seen("result\":\"0:/gcodes/");  // {"key":"job.file.fileName","flags": "","result":"0:/gcodes/pig-4H.gcode"}
-          fileEndString = "\"";
-        }
+
+        // Marlin
+        fileEndString = " Size:";  // File opened: 1A29A~1.GCO Size: 6974
 
         uint16_t start_index = ack_index;
         uint16_t end_index = ack_continue_seen(fileEndString) ? (ack_index - strlen(fileEndString)) : start_index;
@@ -697,8 +694,7 @@ void parseACK(void)
                infoFile.source >= BOARD_SD &&
                ack_seen("SD printing byte"))
       {
-        if (infoMachineSettings.firmwareType != FW_REPRAPFW)
-          setPrintResume(false);
+        setPrintResume(false);
 
         // Parsing printing data
         // Example: SD printing byte 123/12345
@@ -707,7 +703,7 @@ void parseACK(void)
       }
       else if (infoMachineSettings.onboardSD == ENABLED &&
                infoFile.source >= BOARD_SD &&
-               ack_seen(infoMachineSettings.firmwareType != FW_REPRAPFW ? "Done printing file" : "Finished printing file"))
+               ack_seen("Done printing file"))
       {
         setPrintHost(false);
         printComplete();
@@ -798,16 +794,6 @@ void parseACK(void)
       {
         pidUpdateStatus(false);
       }
-      // parse M303, PID Autotune completed message in case of RRF
-      else if ((infoMachineSettings.firmwareType == FW_REPRAPFW) && ack_seen("Auto tuning heater") && ack_seen("completed"))
-      {
-        pidUpdateStatus(true);
-      }
-      // parse M303, PID Autotune failed message in case of RRF
-      else if ((infoMachineSettings.firmwareType == FW_REPRAPFW) && (ack_seen("Error: M303") || (ack_seen("Auto tune of heater") && ack_seen("failed"))))
-      {
-        pidUpdateStatus(false);
-      }
       // parse and store M355, Case light message
       else if (ack_seen("Case light:"))
       {
@@ -888,14 +874,6 @@ void parseACK(void)
 
         uint8_t i = (ack_seen("T")) ? ack_value() : 0;
         if (ack_seen("E")) setParameter(P_STEPS_PER_MM, AXIS_INDEX_E0 + i, ack_value());
-      }
-      // parse and store stepper steps/mm values incase of RepRapFirmware
-      else if ((infoMachineSettings.firmwareType == FW_REPRAPFW) && (ack_seen("Steps")))
-      {
-        if (ack_seen("X: ")) setParameter(P_STEPS_PER_MM, AXIS_INDEX_X, ack_value());
-        if (ack_seen("Y: ")) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Y, ack_value());
-        if (ack_seen("Z: ")) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Z, ack_value());
-        if (ack_seen("E: ")) setParameter(P_STEPS_PER_MM, AXIS_INDEX_E0, ack_value());
       }
       // parse and store Filament settings values
       else if (ack_seen("M200"))
@@ -1121,11 +1099,6 @@ void parseACK(void)
         {
           infoMachineSettings.firmwareType = FW_MARLIN;
         }
-        else if (ack_seen("RepRapFirmware"))
-        {
-          infoMachineSettings.firmwareType = FW_REPRAPFW;
-          setupMachine();
-        }
         else if (ack_seen("Smoothieware"))
         {
           infoMachineSettings.firmwareType = FW_SMOOTHIEWARE;
@@ -1140,8 +1113,6 @@ void parseACK(void)
           string_end = ack_index - sizeof("FIRMWARE_URL:");
         else if (ack_seen("SOURCE_CODE_URL:"))  // For Marlin
           string_end = ack_index - sizeof("SOURCE_CODE_URL:");
-        else if ((infoMachineSettings.firmwareType == FW_REPRAPFW) && ack_seen("ELECTRONICS"))  // For RepRapFirmware
-          string_end = ack_index - sizeof("ELECTRONICS");
 
         infoSetFirmwareName(string, string_end - string_start);  // Set firmware name
 
@@ -1249,38 +1220,6 @@ void parseACK(void)
         if (!processKnownEcho())  // if no known echo was found and processed, then popup the echo message
         {
           ackPopupInfo(magic_echo);
-        }
-      }
-
-      // keep it here and parse it the latest
-      else if (infoMachineSettings.firmwareType == FW_REPRAPFW)
-      {
-        if (ack_seen(magic_warning))
-        {
-          ackPopupInfo(magic_warning);
-        }
-        else if (ack_seen(magic_message))
-        {
-          ackPopupInfo(magic_message);
-        }
-        else if (ack_seen("access point "))
-        {
-          uint8_t * string = (uint8_t *)&dmaL2Cache[ack_index];
-          uint16_t string_start = ack_index;
-          uint16_t string_end = string_start;
-          if (ack_seen(","))
-            string_end = ack_index - 1 ;
-
-          infoSetAccessPoint(string, string_end - string_start);  // Set access poing
-
-          if (ack_seen("IP address "))
-          {
-            string = (uint8_t *)&dmaL2Cache[ack_index];
-            string_start = ack_index;
-            if (ack_seen("\n"))
-              string_end = ack_index - 1;
-            infoSetIPAddress(string, string_end - string_start);  // Set IP address
-          }
         }
       }
       else if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)


### PR DESCRIPTION
### Requirements

Configure SD card config.g file  M575 P1 S1 

### Description

Make the TFT no longer require RRF compatible marlin on the basis of @pfn work. 
Use the M408 S0 to parse most of the information, including temperature, coordinates, and heater status.
synchronize the TFT with the web state.
Separate rrf messages instead of processing them all in parseACK.c,

### Benefits

Reduce unnecessary uart communication,
parseACK.c is not too confusing
