### PR TITLE
Fix - layer number display glitch

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -272,6 +272,9 @@ prog_disp_type:2
 #     also shown, it can be done by introducing a comment at the
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
+#   - If the total number of layers exceeds 999, this information
+#     will not be displayed because there's no room for both current
+#     and total layer number to be shown.
 #
 #    For PrusaSlicer users, if the layer number/count display
 # feature is wanted, some comment lines must be added in 

--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -273,6 +273,12 @@ prog_disp_type:2
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
 #
+#    For PrusaSlicer users, if the layer number/count display
+# feature is wanted, some comment lines must be added in 
+# Printer Settings -> Custom G-code section such as:
+#    - ";LAYER:[layer_num]" in "After layer change G-code"
+#    - ";LAYER_COUNT:[total_layer_count]" in "Start G-code"
+#
 #   Options: [Layer height: 0, Layer number: 1, Both - height & number: 2]
 layer_disp_type:0
 

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -267,6 +267,9 @@ prog_disp_type:2
 #     also shown, it can be done by introducing a comment at the
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
+#   - If the total number of layers exceeds 999, this information
+#     will not be displayed because there's no room for both current
+#     and total layer number to be shown.
 #
 #    For PrusaSlicer users, if the layer number/count display
 # feature is wanted, some comment lines must be added in 

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -268,6 +268,12 @@ prog_disp_type:2
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
 #
+#    For PrusaSlicer users, if the layer number/count display
+# feature is wanted, some comment lines must be added in 
+# Printer Settings -> Custom G-code section such as:
+#    - ";LAYER:[layer_num]" in "After layer change G-code"
+#    - ";LAYER_COUNT:[total_layer_count]" in "Start G-code"
+#
 #   Options: [Layer height: 0, Layer number: 1, Both - height & number: 2]
 layer_disp_type:0
 

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -71,9 +71,14 @@ void parseComment()
         else if (temp_char[0] >= '0' && temp_char[0] <= '9')  // check if a number is found
         {
           temp_value = strtoul(temp_char, NULL, 0);
-
-          // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
-          layerNumber = (layerNumber == temp_value) ? temp_value + 1: temp_value;
+          if (temp_value == 0)
+          { //  for object by object printing, when print goes to the next object
+            layerNumber = 1;
+          }
+          else
+          { // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
+            layerNumber = (layerNumber == temp_value) ? temp_value + 1: temp_value;
+          }
         }
       }
       // continue here with "else if" for another token that starts with "l" or "L"

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -52,13 +52,13 @@ void parseComment()
     if (gCode_comment.handled == true)
       return;
 
-    // check for "layer" keyword in comment (layer number or layer count)
+    // check for words starting with "l" or "L"
     if (gCode_comment.content[0] == 'l' || gCode_comment.content[0] == 'L')
     {
       temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
       lowerCase(temp_char);
       if (strcmp(temp_char, "layer") == 0)
-      {
+      { // check for "layer" keyword in comment (layer number or layer count)
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
         if (strcmp(temp_char, "count") == 0)  // check if next word is "count"
@@ -79,13 +79,14 @@ void parseComment()
       // continue here with "else if" for another token that starts with "l" or "L"
     }
 
-    // check for "time" keyword in comment to retrieve total or elapsed time
+    // check for words starting with "t" or "T"
     else if (gCode_comment.content[0] == 't' || gCode_comment.content[0] == 'T')
     {
       temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
       lowerCase(temp_char);
-      if (strcmp(temp_char, "time") == 0 && M73R_presence == false)// check if first word is "time"
-      {// Cura specific
+      // check for "time" keyword in comment to retrieve total or elapsed time, Cura specific
+      if (strcmp(temp_char, "time") == 0 && M73R_presence == false) // check if first word is "time"
+      { 
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
         if (strcmp(temp_char, "elapsed") == 0 && totalTime > 0)  // check if next word is "elapsed"
@@ -103,13 +104,14 @@ void parseComment()
       // continue here with "else if" for another token that starts with "t" or "T"
     }
 
-    // check for "remaining" keyword in comment to retrieve remaining time
+    // check for words starting with "r" or "R"
     else if (gCode_comment.content[0] == 'r' || gCode_comment.content[0] == 'R')
     {
       temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
       lowerCase(temp_char);
+      // check for "remaining" keyword in comment to retrieve remaining time, IdeaMaker specific
       if (strcmp(temp_char, "remaining") == 0 && M73R_presence == false)// check if first word is "remaining"
-      {// IdeaMaker specific
+      {
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
         lowerCase(temp_char);
         if (strcmp(temp_char, "time") == 0)  // check if next word is "time"

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -588,7 +588,7 @@ void menuReDrawCurTitle(void)
   {
     if (curMenuItems == NULL)
       return;
-    menuDrawTitle(labelGetAddress(&curMenuItems->title));
+    configlabelGetAddress(&curMenuItems->title));
   }
   else if (menuType == MENU_TYPE_FULLSCREEN)
   {

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -588,7 +588,7 @@ void menuReDrawCurTitle(void)
   {
     if (curMenuItems == NULL)
       return;
-    configlabelGetAddress(&curMenuItems->title));
+    menuDrawTitle(labelGetAddress(&curMenuItems->title));
   }
   else if (menuType == MENU_TYPE_FULLSCREEN)
   {

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -109,13 +109,13 @@ static void setLayerNumberTxt(char * layer_number_txt)
   uint16_t layerCount = getLayerCount();
   if (layerNumber > 0)
   {
-    if (layerCount > 0)
-    {
+    if (layerCount > 0 && layerCount < 1000)
+    { // there's no space to display layer number & count if the layer count is above 999
       sprintf(layer_number_txt, " %u/%u ", layerNumber, layerCount);
     }
     else
     {
-      sprintf(layer_number_txt, "% u ", layerNumber);
+      sprintf(layer_number_txt, "%s%u%s", "  ", layerNumber, "  ");
     }
   }
   else

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -105,15 +105,16 @@ static void setLayerHeightText(char * layer_height_txt)
 
 static void setLayerNumberTxt(char * layer_number_txt)
 {
-  if (getLayerNumber() > 0)
+  uint16_t layerNumber = getLayerNumber();
+  if (layerNumber > 0)
   {
     if (getLayerCount() > 0)
     {
-      sprintf(layer_number_txt, "%u/%u", getLayerNumber(), getLayerCount());
+      sprintf(layer_number_txt, " %u/%u ", layerNumber, getLayerCount());
     }
     else
     {
-      sprintf(layer_number_txt, "%u", getLayerNumber());
+      sprintf(layer_number_txt, "% u ", layerNumber);
     }
   }
   else

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -106,11 +106,12 @@ static void setLayerHeightText(char * layer_height_txt)
 static void setLayerNumberTxt(char * layer_number_txt)
 {
   uint16_t layerNumber = getLayerNumber();
+  uint16_t layerCount = getLayerCount();
   if (layerNumber > 0)
   {
-    if (getLayerCount() > 0)
+    if (layerCount > 0)
     {
-      sprintf(layer_number_txt, " %u/%u ", layerNumber, getLayerCount());
+      sprintf(layer_number_txt, " %u/%u ", layerNumber, layerCount);
     }
     else
     {

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -272,6 +272,9 @@ prog_disp_type:2
 #     also shown, it can be done by introducing a comment at the
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
+#   - If the total number of layers exceeds 999, this information
+#     will not be displayed because there's no room for both current
+#     and total layer number to be shown.
 #
 #    For PrusaSlicer users, if the layer number/count display
 # feature is wanted, some comment lines must be added in 

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -273,6 +273,12 @@ prog_disp_type:2
 #     beginning of the gCode file in the format "; Layer count: xx".
 #     Separators can be " ", ":", "_" or "=".
 #
+#    For PrusaSlicer users, if the layer number/count display
+# feature is wanted, some comment lines must be added in 
+# Printer Settings -> Custom G-code section such as:
+#    - ";LAYER:[layer_num]" in "After layer change G-code"
+#    - ";LAYER_COUNT:[total_layer_count]" in "Start G-code"
+#
 #   Options: [Layer height: 0, Layer number: 1, Both - height & number: 2]
 layer_disp_type:0
 


### PR DESCRIPTION
### Requirements

BTT or MKS TFT.

### Description

This little PR fixes a GUI glitch with Layer Number display during print. It occurred when the total layer number was unknown and only the printing layer number  was displayed. For the first 10 layers unwanted or extra characters were also displayed. This could also occur if the printing project contained multiple objects and the printing order was object by object and not layer by layer.

"Config.ini" is updated with info for PrusaSlicer users to have layer number info displayed on the TFT during print.

### Related Issues

Fixes #2184
