### PR TITLE
Numpad menu redraw bugfix

### DIFF
--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -267,8 +267,7 @@ void percentageReDraw(uint8_t itemIndex, bool skipHeader)
 }
 
 static void redrawMenu(MENU_TYPE menuType)
-{// used only when exiting from keypad
-  setMenuType(menuType);
+{// used only when exiting from numpad
   if (menuType == MENU_TYPE_ICON)
     menuDrawPage(getCurMenuItems());
   else if(menuType == MENU_TYPE_LISTVIEW)


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

After exiting the numpad the menu became garbage. This PR fixes it, the numpad exits cleanly and the previous menu is restored.

### Benefits

Usable numpad again.