### PR TITLE
Load/Unload menu - direct nozzle temperature select, Numpad float input overhaul

### DIFF
--- a/TFT/src/User/API/UI/Numpad.c
+++ b/TFT/src/User/API/UI/Numpad.c
@@ -212,7 +212,7 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
   NUM_KEY_VALUES key_num = NUM_KEY_IDLE;
   touchSound = false;
 
-  uint8_t nowIndex = 0;
+  uint8_t nowIndex;
   uint8_t lastIndex = 0;
   char ParameterBuf[FLOAT_BUF_LENGTH + 1] = {0};
   uint8_t prec = (old_val == 0) ? 0 : 3;
@@ -242,22 +242,32 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
         return old_val;
 
       case NUM_KEY_DEL:
-        if (nowIndex)
+        if (nowIndex == 1)  // last character deleted
         {
-          ParameterBuf[--nowIndex] = 0;
-          valueFirstPress = false;
-          BUZZER_PLAY(SOUND_KEYPRESS);
+          if (ParameterBuf[0] == '0')
+          {// '0' cannot be deleted
+            BUZZER_PLAY(SOUND_DENY);
+            break;
+          }
+          else
+          {
+            ParameterBuf[0] = '0';
+            lastIndex = 0;  // this will trigger a value redraw
+          }
         }
         else
         {
-          BUZZER_PLAY(SOUND_DENY);
+          ParameterBuf[--nowIndex] = 0;
         }
+
+        BUZZER_PLAY(SOUND_KEYPRESS);
+        valueFirstPress = false;
         break;
 
       case NUM_KEY_RESET:
         sprintf(ParameterBuf, "%.*f", prec, reset_val);
         nowIndex = strlen(ParameterBuf);
-        lastIndex = nowIndex + 1;
+        lastIndex = 0;
         valueFirstPress = true;
         BUZZER_PLAY(SOUND_KEYPRESS);
         break;
@@ -275,13 +285,19 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
         if (valueFirstPress == true)
         {
           valueFirstPress = false;
-          ParameterBuf[0] = '0';
-          nowIndex = 1;
+          nowIndex = lastIndex = 0;
         }
         if (nowIndex < FLOAT_BUF_LENGTH - 1)
         {
-          if (ParameterBuf[0] == '0' && nowIndex == 1)
+          if (ParameterBuf[0] == '0' && nowIndex == 1)  // avoid "0x", change to "x"
+          {
             nowIndex = lastIndex = 0;
+          }
+          else if(ParameterBuf[0] == '-' && ParameterBuf[1] == '0' && nowIndex == 2)  // avoid "-0x", change to "-x"
+          {
+            nowIndex = lastIndex = 1;
+          }
+
           ParameterBuf[nowIndex++] = numPadKeyChar[key_num][0];
           ParameterBuf[nowIndex] = 0;
           BUZZER_PLAY(SOUND_KEYPRESS);
@@ -296,14 +312,16 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
         if (valueFirstPress == true)
         {
           valueFirstPress = false;
-          ParameterBuf[0] = 0;
-          nowIndex = lastIndex = 0;
+          ParameterBuf[0] = '0';
+          nowIndex = lastIndex = 1;
         }
         if (!strchr((const char *)ParameterBuf, numPadKeyChar[key_num][0]) && nowIndex < (FLOAT_BUF_LENGTH - 1))
         {
-          if (nowIndex == 0 || (nowIndex == 1 && strchr((const char *)ParameterBuf, '-')))  // check if no number exits or only minus exists
-            ParameterBuf[nowIndex++] = '0';                                                 // add zero before decimal sign if it is the first character
-          ParameterBuf[nowIndex++] = numPadKeyChar[key_num][0];
+          if (nowIndex == 1 && ParameterBuf[0] == '-')  // check if minus sign and no other number
+          {
+            ParameterBuf[nowIndex++] = '0';             // add zero between minus and decimal sign
+          }
+          ParameterBuf[nowIndex++] = '.';
           ParameterBuf[nowIndex] = 0;
           BUZZER_PLAY(SOUND_KEYPRESS);
         }
@@ -319,13 +337,14 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
           if (valueFirstPress == true)
           {
             valueFirstPress = false;
-            ParameterBuf[0] = 0;
-            nowIndex = lastIndex = 0;
+            ParameterBuf[0] = '0';
+            nowIndex = 1;
           }
-          if (!strchr((const char *)ParameterBuf, numPadKeyChar[key_num][0]) && nowIndex == 0)
+          if (nowIndex == 1 && ParameterBuf[0] == '0')
           {
-            ParameterBuf[nowIndex++] = numPadKeyChar[key_num][0];
-            ParameterBuf[nowIndex] = 0;
+            ParameterBuf[0] = '-';
+            ParameterBuf[1] = 0;
+            lastIndex = 0;  // this will trigger a value redraw
             BUZZER_PLAY(SOUND_KEYPRESS);
           }
           else
@@ -336,17 +355,14 @@ double numPadFloat(uint8_t * title, double old_val, double reset_val, bool negat
         break;
 
       case NUM_KEY_OK:
-        if (nowIndex > 0)
+        if (nowIndex == 1 && ParameterBuf[0] == '-')
         {
-          if (nowIndex == 1 && (strchr((const char *)ParameterBuf, '.') || strchr((const char *)ParameterBuf, '-')))
-          {
-            BUZZER_PLAY(SOUND_DENY);
-            break;
-          }
-          BUZZER_PLAY(SOUND_OK);
-          touchSound = true;
-          return strtod(ParameterBuf, NULL);
+          BUZZER_PLAY(SOUND_DENY);
+          break;
         }
+        BUZZER_PLAY(SOUND_OK);
+        touchSound = true;
+        return strtod(ParameterBuf, NULL);
 
       default:
         break;

--- a/TFT/src/User/API/coordinate.h
+++ b/TFT/src/User/API/coordinate.h
@@ -28,7 +28,7 @@ typedef struct
   float coordinate;
   uint32_t feedrate;
   bool relative;
-  bool backedUp;
+  bool handled;
 } E_AXIS_BACKUP;
 
 extern const char axis_id[TOTAL_AXIS];

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -819,13 +819,14 @@ KEY_VALUES menuKeyGetValue(void)
               tempkey = KEY_TITLEBAR;
           }
           else if ((MENU_IS(menuHeat)) ||
-                  (MENU_IS(menuPid)) ||
-                  (MENU_IS(menuTuneExtruder)) ||
-                  (MENU_IS(menuFan)) ||
-                  (MENU_IS(menuExtrude)) ||
-                  (MENU_IS(menuSpeed)) ||
-                  (MENU_IS(menuZOffset)) ||
-                  (MENU_IS(menuMBL)))
+                   (MENU_IS(menuLoadUnload)) ||
+                   (MENU_IS(menuPid)) ||
+                   (MENU_IS(menuTuneExtruder)) ||
+                   (MENU_IS(menuFan)) ||
+                   (MENU_IS(menuExtrude)) ||
+                   (MENU_IS(menuSpeed)) ||
+                   (MENU_IS(menuZOffset)) ||
+                   (MENU_IS(menuMBL)))
           {
             tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keysIN), rect_of_keysIN);
           }

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -94,6 +94,7 @@ void menuExtrude(void)
         }
         else
         {
+          heatSetCurrentIndex(currentTool);  // preselect current nozzle for "Heat" menu
           OPEN_MENU(menuHeat);
           eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
         }

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -36,14 +36,14 @@ void menuExtrude(void)
   float extrNewCoord  = 0.0f;
   float extrKnownCoord = 0.0f;
 
-  if (eAxisBackup.backedUp == false)
+  if (eAxisBackup.handled == false)
   {
     loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
 
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
     eAxisBackup.feedrate = coordinateGetFeedRate();
     eAxisBackup.relative = eGetRelative();
-    eAxisBackup.backedUp = true;
+    eAxisBackup.handled = true;
   }
 
   extrKnownCoord = extrNewCoord = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
@@ -95,7 +95,7 @@ void menuExtrude(void)
         else
         {
           OPEN_MENU(menuHeat);
-          eAxisBackup.backedUp = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
+          eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
         }
         break;
 
@@ -116,7 +116,7 @@ void menuExtrude(void)
       case KEY_ICON_7:
         cooldownTemperature();
         CLOSE_MENU();
-        eAxisBackup.backedUp = false;  // exiting from Extrude menu, no need for it anymore
+        eAxisBackup.handled = false;  // exiting from Extrude menu, no need for it anymore
         break;
 
       default:
@@ -151,7 +151,7 @@ void menuExtrude(void)
     loopProcess();
   }
 
-  if (eAxisBackup.backedUp == false)  // the user exited from menu (not any other process/popup/etc)
+  if (eAxisBackup.handled == false)  // the user exited from menu (not any other process/popup/etc)
   { // restore E axis coordinate, feedrate and relativeness to pre-extrude state
     mustStoreCmd("G92 E%.5f\n", eAxisBackup.coordinate);
     mustStoreCmd("G0 F%d\n", eAxisBackup.feedrate);

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -106,6 +106,7 @@ void menuLoadUnload(void)
           break;
 
         case KEY_ICON_5:  // heat menu
+          heatSetCurrentIndex(currentTool);  // preselect current nozzle for "Heat" menu
           OPEN_MENU(menuHeat);
           eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
           lastCmd = NONE;

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -40,12 +40,12 @@ void menuLoadUnload(void)
 {
   KEY_VALUES key_num = KEY_IDLE;
 
-  if (eAxisBackup.backedUp == false)
+  if (eAxisBackup.handled == false)
   {
     loopProcessToCondition(&isNotEmptyCmdQueue);  // wait for the communication to be clean
 
     eAxisBackup.coordinate = ((infoFile.source >= BOARD_SD) ? coordinateGetAxisActual(E_AXIS) : coordinateGetAxisTarget(E_AXIS));
-    eAxisBackup.backedUp = true;
+    eAxisBackup.handled = true;
   }
 
   menuDrawPage(&loadUnloadItems);
@@ -85,6 +85,19 @@ void menuLoadUnload(void)
           lastCmd = LOAD_REQUESTED;
           break;
 
+        case KEY_INFOBOX:  // edit nozzle temp
+        {
+          int16_t actTarget = heatGetTargetTemp(tool_index);
+          int16_t val = editIntValue(0, infoSettings.max_temp[tool_index], 0, actTarget);
+
+          if (val != actTarget)
+            heatSetTargetTemp(tool_index, val);
+
+          temperatureReDraw(tool_index, NULL, false);
+          lastCmd = NONE;
+          break;
+        }
+
         case KEY_ICON_4:  // nozzle select
           tool_index = (tool_index + 1) % infoSettings.hotend_count;
 
@@ -94,7 +107,7 @@ void menuLoadUnload(void)
 
         case KEY_ICON_5:  // heat menu
           OPEN_MENU(menuHeat);
-          eAxisBackup.backedUp = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
+          eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
           lastCmd = NONE;
           break;
 
@@ -107,7 +120,7 @@ void menuLoadUnload(void)
           cooldownTemperature();
           lastCmd = NONE;
           CLOSE_MENU();
-          eAxisBackup.backedUp = false;  // the user exited from menu (not any other process/popup/etc)
+          eAxisBackup.handled = false;  // the user exited from menu (not any other process/popup/etc)
           break;
 
         default:
@@ -160,7 +173,7 @@ void menuLoadUnload(void)
     loopProcess();
   }
 
-  if (eAxisBackup.backedUp == false)  // the user exited from menu (not any other process/popup/etc)
+  if (eAxisBackup.handled == false)  // the user exited from menu (not any other process/popup/etc)
   {
     mustStoreCmd("G92 E%.5f\n", eAxisBackup.coordinate);  // reset E axis position in Marlin to pre - load/unload state
   }


### PR DESCRIPTION
### Description

   As I use very often the Load/Unload menu, I found myself many times hitting the temp display zone to set up the nozzle temp but obviously nothing happened... This PR lets you directly select the nozzle desired temperature via numpad right from the menu itself.  Just hit the temperature display zone as you would do in the "Heat" menu.
   Another thing done in this PR is the overhaul of the float number input via numpad. Nothing fancy done, just made some changes in the logic behind the input and avoided empty number display field. Maybe easier for users and lighter on MCU and memory.
