### PR TITLE
Extruders zero

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -344,7 +344,7 @@ marlin_type:0
 #--------------------------------------------------------------------
 
 #### Hotend Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 hotend_count:1
 
 #### Heated Bed Support
@@ -357,7 +357,7 @@ heated_bed:1
 heated_chamber:0
 
 #### Extruder Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 ext_count:1
 
 #### Fan Count

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -339,7 +339,7 @@ marlin_type:0
 #--------------------------------------------------------------------
 
 #### Hotend Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 hotend_count:1
 
 #### Heated Bed Support
@@ -352,7 +352,7 @@ heated_bed:1
 heated_chamber:0
 
 #### Extruder Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 ext_count:1
 
 #### Fan Count

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -244,7 +244,11 @@ void setupMachine(FW_TYPE fwType)
   }
 
   mustStoreCmd("M503 S0\n");
-  mustStoreCmd("M82\n");  // Set extruder to absolute mode
+  if (infoSettings.hotend_count > 0)
+  {
+      // This is good, but we need to set the extruder number first, and it's defaulting to 1.
+      mustStoreCmd("M82\n");  // Set extruder to absolute mode
+  }
   mustStoreCmd("G90\n");  // Set to Absolute Positioning
 }
 

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -246,8 +246,8 @@ void setupMachine(FW_TYPE fwType)
   mustStoreCmd("M503 S0\n");
   if (infoSettings.hotend_count > 0)
   {
-      // This is good, but we need to set the extruder number first, and it's defaulting to 1.
-      mustStoreCmd("M82\n");  // Set extruder to absolute mode
+    // This is good, but we need to set the extruder number first, and it's defaulting to 1.
+    mustStoreCmd("M82\n");  // Set extruder to absolute mode
   }
   mustStoreCmd("G90\n");  // Set to Absolute Positioning
 }

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -59,6 +59,13 @@ void speedQuery(void)
 {
   if (infoHost.connected && !infoHost.wait && !speedQueryWait && infoMachineSettings.firmwareType != FW_REPRAPFW)
   {
-    speedQueryWait = storeCmd("M220\nM221\n");
+    if (infoSettings.ext_count > 0)
+    {
+      speedQueryWait = storeCmd("M220\nM221\n");
+    }
+    else
+    {
+      speedQueryWait = storeCmd("M220\n");
+    }
   }
 }

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -40,8 +40,8 @@ void loopSpeed(void)
   {
     if (infoSettings.ext_count == 0 && i > 0)
     {
-        // Don't poll M221 if there are no extruders
-        continue;
+      // Don't poll M221 if there are no extruders
+      continue;
     }
 
     if (GET_BIT(needSetPercent, i) && (OS_GetTimeMs() > nextSpeedTime))

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -38,6 +38,12 @@ void loopSpeed(void)
 {
   for (uint8_t i = 0; i < SPEED_NUM; i++)
   {
+    if (infoSettings.ext_count == 0 && i > 0)
+    {
+        // Don't poll M221 if there are no extruders
+        continue;
+    }
+
     if (GET_BIT(needSetPercent, i) && (OS_GetTimeMs() > nextSpeedTime))
     {
       if (storeCmd("%s S%d D%d\n", speedCmd[i], setPercent[i], heatGetCurrentTool()))

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -704,7 +704,7 @@ void parseConfigKey(uint16_t index)
     //----------------------------Printer / Machine Settings
 
     case C_INDEX_HOTEND_COUNT:
-      SET_VALID_INT_VALUE(infoSettings.hotend_count, 1, MAX_HOTEND_COUNT);
+      SET_VALID_INT_VALUE(infoSettings.hotend_count, 0, MAX_HOTEND_COUNT);
       break;
 
     case C_INDEX_HEATED_BED:
@@ -716,7 +716,7 @@ void parseConfigKey(uint16_t index)
       break;
 
     case C_INDEX_EXT_COUNT:
-      SET_VALID_INT_VALUE(infoSettings.ext_count, 1, MAX_EXT_COUNT);
+      SET_VALID_INT_VALUE(infoSettings.ext_count, 0, MAX_EXT_COUNT);
       break;
 
     case C_INDEX_FAN_COUNT:

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -426,7 +426,7 @@ void parseACK(void)
         storeCmd("M115\n");  // as last command to identify the FW type!
         coordinateQuerySetWait(true);
       }
-	  else if (infoMachineSettings.firmwareType == FW_NOT_DETECTED)  // if never connected to the printer since boot
+      else if (infoMachineSettings.firmwareType == FW_NOT_DETECTED)  // if never connected to the printer since boot
       {
         storeCmd("M503\n");  // Query detailed printer capabilities
         storeCmd("M92\n");   // Steps/mm of extruder is an important parameter for Smart filament runout

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -414,7 +414,6 @@ void parseACK(void)
       {
         if (!ack_seen(heaterID[i])) break;
       }
-      infoSettings.hotend_count = i ? i : 1;
       if (infoSettings.ext_count < infoSettings.hotend_count) infoSettings.ext_count = infoSettings.hotend_count;
       if (ack_seen(heaterID[BED])) infoSettings.bed_en = ENABLED;
       if (ack_seen(heaterID[CHAMBER])) infoSettings.chamber_en = ENABLED;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -406,7 +406,7 @@ void parseACK(void)
       if (ack_seen(magic_error)) ackPopupInfo(magic_error);
 
       // the first response should be such as "T:25/50\n"
-      if (!(ack_seen("@") && ack_seen("T:")) && !ack_seen("T0:")) goto parse_end;
+      if (!(ack_seen("@") && ack_seen("T:")) && !ack_seen("T0:") && !ack_seen("T:0")) goto parse_end;
 
       // find hotend count and setup heaters
       uint8_t i;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -406,6 +406,7 @@ void parseACK(void)
       if (ack_seen(magic_error)) ackPopupInfo(magic_error);
 
       // the first response should be such as "T:25/50\n"
+      // The "T:0" response is specifically for Marlin when EXTRUDER_COUNT:0
       if (!(ack_seen("@") && ack_seen("T:")) && !ack_seen("T0:") && !ack_seen("T:0")) goto parse_end;
 
       // find hotend count and setup heaters

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -84,7 +84,10 @@ void menuSpeed(void)
         break;
 
       case KEY_ICON_4:
-        item_index = (item_index + 1) % SPEED_NUM;
+        if (infoSettings.ext_count > 0)
+        {
+          item_index = (item_index + 1) % SPEED_NUM;
+        }
         percentageItems.title.index = itemPercentTypeTitle[item_index];
         percentageItems.items[key_num] = itemPercentType[item_index];
 

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -42,8 +42,7 @@ void menuSpeed(void)
   KEY_VALUES key_num = KEY_IDLE;
   LASTSPEED lastSpeed;
 
-  if (infoMachineSettings.firmwareType != FW_REPRAPFW)
-    storeCmd("M220\nM221\n");  // RRF has current settings via periodic polling (fanQuery)
+  speedQuery();
 
   speedSetPercent(item_index, speedGetCurPercent(item_index));
   lastSpeed = (LASTSPEED) {speedGetCurPercent(item_index), speedGetSetPercent(item_index)};

--- a/TFT/src/User/SanityCheck.h
+++ b/TFT/src/User/SanityCheck.h
@@ -65,12 +65,12 @@ extern "C" {
   #define MARLIN_TITLE "Marlin Mode"
 #endif
 
-#if HOTEND_COUNT < 1 || HOTEND_COUNT > MAX_HOTEND_COUNT
-  #error "HOTEND_COUNT cannot be less than 1 or greater than 6"
+#if HOTEND_COUNT < 0 || HOTEND_COUNT > MAX_HOTEND_COUNT
+  #error "HOTEND_COUNT cannot be less than 0 or greater than 6"
 #endif
 
-#if EXTRUDER_COUNT < 1 || EXTRUDER_COUNT > MAX_EXT_COUNT
-  #error "EXTRUDER_COUNT cannot be less than 1 or greater than 6"
+#if EXTRUDER_COUNT < 0 || EXTRUDER_COUNT > MAX_EXT_COUNT
+  #error "EXTRUDER_COUNT cannot be less than 0 or greater than 6"
 #endif
 
 #if FAN_COUNT < 1 || FAN_COUNT > MAX_FAN_COUNT

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -344,7 +344,7 @@ marlin_type:0
 #--------------------------------------------------------------------
 
 #### Hotend Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 hotend_count:1
 
 #### Heated Bed Support
@@ -357,7 +357,7 @@ heated_bed:1
 heated_chamber:0
 
 #### Extruder Count
-#   Value range: [min: 1, max: 6]
+#   Value range: [min: 0, max: 6]
 ext_count:1
 
 #### Fan Count


### PR DESCRIPTION
### Requirements

* Allow configurations that will work with Marlin when it has the setting `EXTRUDERS=0`

### Description

There are many CNC and laser machines that have no extruders or hotends, but still use Marlin. One place where these machines are very popular is V1Engineering.com (@V1EngineeringInc)

These changes allow ext_count to be zero, as well as hotend_count to be zero. There are a few places where gcode is sent that is specific to extruders (M221 for flow rate, M82 for extruder steps). Those are now gated on having _some_ extruder count.

FYI, If you want to see a configuration that would have EXTRUDERS=0, check out the `V1CNC_SkrPro_Dual_...` from here: 
https://github.com/V1EngineeringInc/MarlinBuilder/releases

The print from Marlin in that configuration is (Notice the `EXTRUDER_COUNT:0`): 

```
FIRMWARE_NAME:Marlin 513D 2.0.9.2 (Oct 24 2021 13:37:49) SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:V1CNC 513D EXTRUDER_COUNT:0 UUID:cede2a2f-41a2-4748-9b12-c55c62f367ff
Cap:SERIAL_XON_XOFF:0
Cap:BINARY_FILE_TRANSFER:0
Cap:EEPROM:1
Cap:VOLUMETRIC:0
Cap:AUTOREPORT_POS:0
Cap:AUTOREPORT_TEMP:0
Cap:PROGRESS:0
Cap:PRINT_JOB:1
Cap:AUTOLEVEL:0
Cap:RUNOUT:0
Cap:Z_PROBE:0
Cap:LEVELING_DATA:0
Cap:BUILD_PERCENT:0
Cap:SOFTWARE_POWER:0
Cap:TOGGLE_LIGHTS:0
Cap:CASE_LIGHT_BRIGHTNESS:0
Cap:EMERGENCY_PARSER:0
Cap:HOST_ACTION_COMMANDS:0
Cap:PROMPT_SUPPORT:0
Cap:SDCARD:1
Cap:REPEAT:0
Cap:SD_WRITE:1
Cap:AUTOREPORT_SD_STATUS:0
Cap:LONG_FILENAME:0
Cap:THERMAL_PROTECTION:1
Cap:MOTION_MODES:1
Cap:ARCS:1
Cap:BABYSTEPPING:0
Cap:CHAMBER_TEMPERATURE:0
Cap:COOLER_TEMPERATURE:0
Cap:MEATPACK:0
```
### Benefits

This is going to be a lot better for people using this screen with machines without extruders. Specifically CNC or Laser machines running Marlin.

### Related Issues

None. Although I do see some CNC mode things in the todo list. Those seem to be aimed at GRBL.