### PR TITLE
Rename these config values so they don't create strange icons.

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -148,7 +148,7 @@ status_screen:1
 # Set colors used in Touch Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
@@ -304,7 +304,7 @@ serial_always_on:0
 # Set colors used in Marlin Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -143,7 +143,7 @@ status_screen:1
 # Set colors used in Touch Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
@@ -299,7 +299,7 @@ serial_always_on:1
 # Set colors used in Marlin Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]

--- a/TFT/src/User/API/Language/Language.c
+++ b/TFT/src/User/API/Language/Language.c
@@ -2,47 +2,47 @@
 #include "includes.h"
 #include "language_keywords.h"
 
-#if DEFAULT_LANGUAGE == ENGLISH
+#if SYSTEM_LANGUAGE == ENGLISH
 #include "language_en.h"
-#elif DEFAULT_LANGUAGE == CHINESE
+#elif SYSTEM_LANGUAGE == CHINESE
 #include "language_cn.h"
-#elif DEFAULT_LANGUAGE == RUSSIAN
+#elif SYSTEM_LANGUAGE == RUSSIAN
 #include "language_ru.h"
-#elif DEFAULT_LANGUAGE == JAPANESE
+#elif SYSTEM_LANGUAGE == JAPANESE
 #include "language_jp.h"
-#elif DEFAULT_LANGUAGE == GERMAN
+#elif SYSTEM_LANGUAGE == GERMAN
 #include "language_de.h"
-#elif DEFAULT_LANGUAGE == ARMENIAN
+#elif SYSTEM_LANGUAGE == ARMENIAN
 #include "language_am.h"
-#elif DEFAULT_LANGUAGE == CZECH
+#elif SYSTEM_LANGUAGE == CZECH
 #include "language_cz.h"
-#elif DEFAULT_LANGUAGE == SPANISH
+#elif SYSTEM_LANGUAGE == SPANISH
 #include "language_es.h"
-#elif DEFAULT_LANGUAGE == FRENCH
+#elif SYSTEM_LANGUAGE == FRENCH
 #include "language_fr.h"
-#elif DEFAULT_LANGUAGE == PORTUGUESE
+#elif SYSTEM_LANGUAGE == PORTUGUESE
 #include "language_pt.h"
-#elif DEFAULT_LANGUAGE == ITALIAN
+#elif SYSTEM_LANGUAGE == ITALIAN
 #include "language_it.h"
-#elif DEFAULT_LANGUAGE == POLISH
+#elif SYSTEM_LANGUAGE == POLISH
 #include "language_pl.h"
-#elif DEFAULT_LANGUAGE == SLOVAK
+#elif SYSTEM_LANGUAGE == SLOVAK
 #include "language_sk.h"
-#elif DEFAULT_LANGUAGE == DUTCH
+#elif SYSTEM_LANGUAGE == DUTCH
 #include "language_nl.h"
-#elif DEFAULT_LANGUAGE == HUNGARIAN
+#elif SYSTEM_LANGUAGE == HUNGARIAN
 #include "language_hu.h"
-#elif DEFAULT_LANGUAGE == TURKISH
+#elif SYSTEM_LANGUAGE == TURKISH
 #include "language_tr.h"
-#elif DEFAULT_LANGUAGE == GREEK
+#elif SYSTEM_LANGUAGE == GREEK
 #include "language_gr.h"
-#elif DEFAULT_LANGUAGE == SLOVENIAN
+#elif SYSTEM_LANGUAGE == SLOVENIAN
 #include "language_sl.h"
-#elif DEFAULT_LANGUAGE == CATALAN
+#elif SYSTEM_LANGUAGE == CATALAN
 #include "language_ca.h"
-#elif DEFAULT_LANGUAGE == TRAD_CHINESE
+#elif SYSTEM_LANGUAGE == TRAD_CHINESE
 #include "language_tc.h"
-#elif DEFAULT_LANGUAGE == UKRAINIAN
+#elif SYSTEM_LANGUAGE == UKRAINIAN
 #include "language_uk.h"
 #else
   #error "Error: invalid language defined"

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -27,7 +27,7 @@ void initSettings(void)
 
 // UI Settings
   infoSettings.rotated_ui             = ROTATED_UI;
-  infoSettings.language               = LANGUAGE;
+  infoSettings.language               = LANGUAGE_MODE;
   infoSettings.status_screen          = STATUS_SCREEN;
   infoSettings.title_bg_color         = lcd_colors[TITLE_BACKGROUND_COLOR];
   infoSettings.bg_color               = lcd_colors[MENU_BACKGROUND_COLOR];
@@ -69,7 +69,7 @@ void initSettings(void)
   infoSettings.ctrl_fan_en            = CONTROLLER_FAN;
   infoSettings.min_ext_temp           = MIN_TEMP;
   infoSettings.auto_load_leveling     = AUTO_LOAD_LEVELING;
-  infoSettings.onboard_sd             = ONBOARD_SD;  // ENABLED / DISABLED / AUTO
+  infoSettings.onboard_sd             = DEFAULT_ONBOARD_SD;  // ENABLED / DISABLED / AUTO
   infoSettings.m27_refresh_time       = M27_REFRESH_TIME;
   infoSettings.m27_active             = M27_ALWAYS_ACTIVE;
   infoSettings.long_filename          = LONG_FILENAME;  // ENABLED / DISABLED / AUTO

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -27,7 +27,7 @@ void initSettings(void)
 
 // UI Settings
   infoSettings.rotated_ui             = ROTATED_UI;
-  infoSettings.language               = LANGUAGE_MODE;
+  infoSettings.language               = DEFAULT_LANGUAGE;
   infoSettings.status_screen          = STATUS_SCREEN;
   infoSettings.title_bg_color         = lcd_colors[TITLE_BACKGROUND_COLOR];
   infoSettings.bg_color               = lcd_colors[MENU_BACKGROUND_COLOR];

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -86,7 +86,7 @@
  *
  *   Options: [Primary Language (english): 0, Secondary Language: 1]
  */
-#define LANGUAGE 0  // Default: 0
+#define LANGUAGE_MODE 0  // Default: 0
 
 /**
  * Status Screen
@@ -455,7 +455,7 @@
  * Auto-detect is not available for other firmwares like Smoothieware.
  *   Options: [disable: 0, enable: 1, auto-detect: 2]
  */
-#define ONBOARD_SD 2  // Default: 2
+#define DEFAULT_ONBOARD_SD 2  // Default: 2
 
 /**
  * M27 Printing Status Refresh Time

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -86,7 +86,7 @@
  *
  *   Options: [Primary Language (english): 0, Secondary Language: 1]
  */
-#define LANGUAGE_MODE 0  // Default: 0
+#define DEFAULT_LANGUAGE 0  // Default: 0
 
 /**
  * Status Screen
@@ -106,7 +106,7 @@
  * Set colors used in Touch Mode.
  *
  * NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
- *       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+ *       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
  *
  *   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
  *             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
@@ -272,7 +272,7 @@
  * Set colors used in Marlin Mode.
  *
  * NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
- *       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+ *       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
  *
  *   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
  *             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
@@ -359,7 +359,7 @@
 /**
  * Bed / Extruder / Chamber Maximum Temperatures
  *   Format: [max_temp: T0:<max temp> T1:<max temp> T2:<max temp> T3:<max temp> T4:<max temp> T5:<max temp> BED:<max temp> CHAMBER:<max temp>]
- *   Unit: [temperature in °C]
+ *   Unit: [temperature in Â°C]
  *   Value range: hotend:  [min: 20, max: 1000]
  *                bed:     [min: 20, max: 400]
  *                chamber: [min: 20, max: 200]
@@ -370,7 +370,7 @@
  * Cold Extrusion Minimum Temperature
  * Minimum temperature needed to extrude/retract.
  * Any extrusion/retraction below this temperature will be prevented.
- *   Unit: [temperature in °C]
+ *   Unit: [temperature in Â°C]
  *   Value range: [min: 20, max: 1000]
  */
 #define MIN_TEMP 180  // Default: 180
@@ -578,7 +578,7 @@
  * Preheat Temperatures
  *   Format: [preheat_name_X:<name>]
  *           [preheat_temp_X:T<hotend temp> B<bed temp>]
- *   Unit: [temperature in °C]
+ *   Unit: [temperature in Â°C]
  *   Value range: name:        [min: 3, max: 20 characters]
  *                hotend temp: [min: 20, max: 1000]
  *                bed temp:    [min: 20, max: 400]
@@ -615,7 +615,7 @@
  * The printer will shutdown automatically if the hotend temperature is below this value.
  * If the hotend temperature is higher than this value the fans will be turned on to cooldown and it
  * will wait for the hotend temperature to drop below this value before shutting down automatically.
- *   Unit: [temperature in °C]
+ *   Unit: [temperature in Â°C]
  *   Value range: [min: 20, max: 1000]
  */
 #define PS_AUTO_SHUTDOWN_TEMP 50  // Default: 50
@@ -1065,7 +1065,7 @@
  *             SPANISH,    FRENCH,   PORTUGUESE,  ITALIAN,    POLISH,    SLOVAK,        DUTCH,
  *             HUNGARIAN,  TURKISH,  GREEK,       SLOVENIAN,  CATALAN,   TRAD_CHINESE,  UKRAINIAN]
  */
-#define DEFAULT_LANGUAGE ENGLISH  // Default: ENGLISH
+#define SYSTEM_LANGUAGE ENGLISH  // Default: ENGLISH
 
 /**
  * Rapid Serial Communication

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -148,7 +148,7 @@ status_screen:1
 # Set colors used in Touch Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]
@@ -304,7 +304,7 @@ serial_always_on:0
 # Set colors used in Marlin Mode.
 #
 # NOTE: Select an option from the provided list or set the color (RGB888 format) hex value directly
-#       (start with “0x”), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
+#       (start with "0x"), such as: Red: 0xFF0000, Green: 0x00FF00, Blue: 0x0000FF.
 #
 #   Options: [ WHITE: 0,  BLACK: 1,  RED: 2,  GREEN: 3,      BLUE: 4,       CYAN: 5,  MAGENTA: 6,    YELLOW: 7,
 #             ORANGE: 8, PURPLE: 9, LIME: 10, BROWN: 11, DARKBLUE: 12, DARKGREEN: 13,    GRAY: 14, DARKGRAY: 15]


### PR DESCRIPTION
### Requirements

There is an issue where names of icons are being expanded by macros before being converted into file names. This affects `LANGUAGE` and `ONBOARD_SD`.

### Description

This issue makes anyone working on master require a 0.bmp and 2.bmp because of those settings:

Configuration.h:
```c
/**
 * Touch Mode Language
 * Select the language to use on the LCD while in Touch Mode.
 *
 * NOTE: To add/flash a second language copy the required "language_xx.ini" file from
 *       "Language Packs" folder to the SD root folder.
 *       Then press the reset button to load/flash the copied language file.
 *
 *   Options: [Primary Language (english): 0, Secondary Language: 1]
 */
#define LANGUAGE  0  // Default: 0
```
icon_list.inc:
```c
X_ICON (LANGUAGE)
```
That is expanding to need `0.bmp` instead of `language.bmp`

The solution that I think is the simplest is to rename the config parameter to `LANGUAGE_MODE` and `ONBOARD_SD` to `DEFAULT_ONBOARD_SD`. This fixes the conflict and they are no longer needed.

I used a pretty convoluted way to test this, since I don't have a debugger, and I don't really know what I'm doing :)

I made it print over the serial console what icons it had in the list:
```c
      for (int i = 57; i < COUNT(iconBmpNames); i++)
      {
          storeCmd("; %d icon: %s\nM105\n", i, iconBmpNames[i]);
      }
```
If you're wondering where that 57 comes in, it is another hack. Because I was filling the buffer when I sent 140 messages at once. So I would move the starting position a few times until I found the offending values. 

It's not great, but it worked, and I can tell you that after this fix, the LANGUAGE and ONBOARD_SD icon names came out fine.

### Benefits

It fixes the problem with master.

### Related Issues

#2237 