### PR TITLE
RRF: add support for sending gcode checksums

### DIFF
--- a/TFT/src/User/API/RRFSendCmd.c
+++ b/TFT/src/User/API/RRFSendCmd.c
@@ -1,0 +1,57 @@
+#include "RRFSendCmd.h"
+#include "Serial.h"
+#include <stdio.h>
+
+static uint8_t n_sent = 0;
+static uint32_t line_number = 0;
+static uint8_t checksum = 0;
+
+void sendCharAndChecksum(const char c)
+{
+  checksum ^= c;
+  Serial_Putchar(SERIAL_PORT, c);
+  n_sent++;
+}
+
+void sendChar(const char c)
+{
+  if (c == '\n')
+  {
+    if (n_sent != 0)
+    {
+      Serial_Putchar(SERIAL_PORT, '*');
+      char digit0 = checksum % 10 + '0';
+      checksum /= 10;
+      char digit1 = checksum % 10 + '0';
+      checksum /= 10;
+      if (checksum != 0)
+      {
+        Serial_Putchar(SERIAL_PORT, checksum + '0');
+      }
+      Serial_Putchar(SERIAL_PORT, digit1);
+      Serial_Putchar(SERIAL_PORT, digit0);
+    }
+    Serial_Putchar(SERIAL_PORT, c);
+    n_sent = 0;
+  }
+  else
+  {
+    if (n_sent == 0)
+    {
+      char number[11];
+      checksum = 0;
+      sendCharAndChecksum('N');
+      snprintf(number, 11, "%lu", line_number++);
+      rrfSendCmd(number);
+      sendCharAndChecksum(' ');
+    }
+    sendCharAndChecksum(c);
+  }
+}
+
+void rrfSendCmd(const char* cmd_ptr) {
+  while (*cmd_ptr != 0)
+  {
+    sendChar(*cmd_ptr++);
+  }
+}

--- a/TFT/src/User/API/RRFSendCmd.h
+++ b/TFT/src/User/API/RRFSendCmd.h
@@ -1,0 +1,5 @@
+#ifndef _RRF_SEND_CMD_H_
+#define _RRF_SEND_CMD_H_
+
+void rrfSendCmd(const char* cmd_ptr);
+#endif

--- a/TFT/src/User/API/RRFSendCmd.h
+++ b/TFT/src/User/API/RRFSendCmd.h
@@ -1,5 +1,6 @@
 #ifndef _RRF_SEND_CMD_H_
 #define _RRF_SEND_CMD_H_
 
-void rrfSendCmd(const char* cmd_ptr);
+  void rrfSendCmd(const char* cmd_ptr);
+
 #endif

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1,5 +1,6 @@
 #include "interfaceCmd.h"
 #include "includes.h"
+#include "RRFSendCmd.h"
 
 #define CMD_QUEUE_SIZE 20
 
@@ -221,7 +222,14 @@ bool sendCmd(bool purge, bool avoidTerminal)
 
   if (!purge)  // if command is not purged, send it to printer
   {
-    Serial_Puts(SERIAL_PORT, cmd_ptr);
+    if (infoMachineSettings.firmwareType != FW_REPRAPFW && infoMachineSettings.firmwareType != FW_NOT_DETECTED)
+    {
+      Serial_Puts(SERIAL_PORT, cmd_ptr);
+    }
+    else
+    {
+      rrfSendCmd(cmd_ptr);
+    }
     setCurrentAckSrc(cmd_port_index);
   }
 


### PR DESCRIPTION
### Requirements

No new requirements.

Testing help on Marlin and other firmware beside RRF would be appreciated.

### Description

When the firmware type is not yet detected, or RRF, send gcode commands with checksums.

Background:

RepRapFirmware 3.4beta4 changed the behavior of checksum handling and now works best when all host gcode is sent with checksums.

### Benefits

Allows using checksum-mode on RRF in 3.4beta4 and later.

### PR Status

Ready to merge pending code review and testing on other firmware.

### Testing

Verified to work on my MKS TFT28 with RRF 3.3 (I have not yet updated my printers to 3.4 betas)
