### PR TITLE
Leveling edge distance count from zero position

### DIFF
--- a/TFT/src/User/API/LevelingControl.c
+++ b/TFT/src/User/API/LevelingControl.c
@@ -6,10 +6,10 @@ float probedZ = 0.0f;                         // last Z offset measured by probe
 
 void levelingGetPointCoords(LEVELING_POINT_COORDS coords)
 {
-  int16_t x_left = infoSettings.machine_size_min[X_AXIS] + infoSettings.level_edge;
-  int16_t x_right = infoSettings.machine_size_max[X_AXIS] - infoSettings.level_edge;
-  int16_t y_bottom = infoSettings.machine_size_min[Y_AXIS] + infoSettings.level_edge;
-  int16_t y_top = infoSettings.machine_size_max[Y_AXIS] - infoSettings.level_edge;
+  int16_t x_left = infoSettings.machine_size_min[X_AXIS] - infoSettings.machine_size_min[X_AXIS] + infoSettings.level_edge;
+  int16_t x_right = infoSettings.machine_size_max[X_AXIS] - infoSettings.machine_size_min[X_AXIS] - infoSettings.level_edge;
+  int16_t y_bottom = infoSettings.machine_size_min[Y_AXIS] - infoSettings.machine_size_min[Y_AXIS] + infoSettings.level_edge;
+  int16_t y_top = infoSettings.machine_size_max[Y_AXIS] - infoSettings.machine_size_min[Y_AXIS] - infoSettings.level_edge;
 
   if (GET_BIT(infoSettings.inverted_axis, X_AXIS))
   {


### PR DESCRIPTION
### Description
Currently, during manual bed leveling the edge bed coordinates are counted from the minimum value (Home position). Unfortunately, when we have coordinates other than 0 at the Home position (e.g. size_min:X-10 Y-5), the edge positioning is faulty. With level edge distance value at 20, the lower left corner will be at  position X10 Y15, not X20 Y20.

### Benefits
This solution calculates the correct bed edge coordinates for manual leveling.
The `level_edge_distance` will be counted from true 0 position. For example, if you have `size_min: X-5 Y18` and `level_edge_distance: 30`, the lower left leveling point would be at X30 Y30. This applies to all corners and center point too (if you have the correct `size_max`).

#### Note:
When you have enabled `M115_GEOMETRY_REPORT` option in Marlin (`Configuration_adv.h`), then don't need to set `size_min` and `size_max` in file(s): `config.ini` and/or `Configuration.h`.

### Related Issues
#1151
