### PR TITLE
Controller fan

### DIFF
--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -381,7 +381,7 @@ static inline void toggleInfo(void)
     {
       do
       {
-        currentFan = (currentFan + 1) % MAX_FAN_COUNT;
+        currentFan = (currentFan + 1) % MAX_COOLING_FAN_COUNT;
       } while (!fanIsValid(currentFan));
 
       RAPID_SERIAL_LOOP();  // perform backend printing loop before drawing to avoid printer idling


### PR DESCRIPTION
If I enable the controller fan, the speed is displayed on the status screen along with the speed of the cooling fan.
This is fine, I can see the speed of all the fans and I can edit them.

But if they start printing, I'm only interested in the speed of the cooling fan and I don't need to see information about the speed of the controller fan on the print screen. This information is confusing.
This PR eliminates cycling between the speed of the chiller and the controller fan on the print screen.