### PR TITLE
Optional value change on the status screen

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1267,10 +1267,10 @@
 /**
  * The color of the values on the status screen
  * Some topics require the inverse display of color values on live status screen icons.
- * For example: THEME_Rep Rap Firmware Dark  - options 1
- *   Options: [ Black: 0, White: 1 ]
+ * Uncomment for example: THEME_Rep Rap Firmware Dark 
+ * Comment for standard color
  */
-#define VALUE_COLOR 0 // Default: 0
+//#define VALUE_COLOR // Default: commented (disabled)
 
 /**
  * Progress Bar Layout (Printing menu)

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1265,6 +1265,14 @@
 #define PROGRESS_BAR_COLOR 0  // Default: 0
 
 /**
+ * The color of the values on the status screen
+ * Some topics require the inverse display of color values on live status screen icons.
+ * For example: THEME_Rep Rap Firmware Dark  - options 1
+ *   Options: [ Black: 0, White: 1 ]
+ */
+#define VALUE_COLOR 0 // Default: 0
+
+/**
  * Progress Bar Layout (Printing menu)
  * Uncomment to enable a progress bar with 10% markers.
  * Comment to enable a standard progress bar.

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1265,19 +1265,19 @@
 #define PROGRESS_BAR_COLOR 0  // Default: 0
 
 /**
+ * Progress Bar Layout (Printing menu)
+ * Uncomment to enable a progress bar with 10% markers.
+ * Comment to enable a standard progress bar.
+ */
+//#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
+
+/**
  * The color of the values on the status screen
  * Some topics require the inverse display of color values on live status screen icons.
  * Uncomment for example: THEME_Rep Rap Firmware Dark 
  * Comment for standard color
  */
 //#define VALUE_COLOR // Default: commented (disabled)
-
-/**
- * Progress Bar Layout (Printing menu)
- * Uncomment to enable a progress bar with 10% markers.
- * Comment to enable a standard progress bar.
- */
-//#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
 
 /**
  * Live Text Background Color Rendering Technique (Printing menu and Status Screen menu)

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -243,7 +243,15 @@ void drawStatus(void)
   lvIcon.lines[1].v_align = CENTER;
   lvIcon.lines[1].pos = ss_val_point;
   lvIcon.lines[1].font = VAL_LARGE_FONT;
-  lvIcon.lines[1].fn_color = SSICON_VAL_COLOR;
+  if (VALUE_COLOR == 0) 
+  {
+    lvIcon.lines[1].fn_color = SSICON_VAL_COLOR;
+  }
+  else
+  {
+    lvIcon.lines[1].fn_color = SSICON_NAME_COLOR;
+  }
+  
   lvIcon.lines[1].text_mode = GUI_TEXTMODE_TRANS;  // default value
 
   #ifndef TFT70_V3_0

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -243,14 +243,12 @@ void drawStatus(void)
   lvIcon.lines[1].v_align = CENTER;
   lvIcon.lines[1].pos = ss_val_point;
   lvIcon.lines[1].font = VAL_LARGE_FONT;
-  if (VALUE_COLOR == 0) 
-  {
-    lvIcon.lines[1].fn_color = SSICON_VAL_COLOR;
-  }
-  else
-  {
+  
+  #ifdef VALUE_COLOR
     lvIcon.lines[1].fn_color = SSICON_NAME_COLOR;
-  }
+  #else
+    lvIcon.lines[1].fn_color = SSICON_VAL_COLOR;
+  #endif  
   
   lvIcon.lines[1].text_mode = GUI_TEXTMODE_TRANS;  // default value
 


### PR DESCRIPTION
Added the ability to change the color of the values on the live icons on the status screen in the configuration.h file.
Some topics require the inverse display of color values on live status screen icons.
For example: THEME_Rep Rap Firmware Dark
resolves #2272 