### PR TITLE
Fix Compiling issue when any of the debug options is enabled in Configuration.h 

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -998,7 +998,7 @@
  * Generic Debug
  * Uncomment/Enable to enable arbitrary debug serial communication to SERIAL_DEBUG_PORT defined in board specific Pin_xx.h file.
  */
-#define DEBUG_SERIAL_GENERIC  // Default: commented (disabled)
+//#define DEBUG_SERIAL_GENERIC  // Default: commented (disabled)
 
 /**
  * Serial Communication Debug

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -998,7 +998,7 @@
  * Generic Debug
  * Uncomment/Enable to enable arbitrary debug serial communication to SERIAL_DEBUG_PORT defined in board specific Pin_xx.h file.
  */
-//#define DEBUG_SERIAL_GENERIC  // Default: commented (disabled)
+#define DEBUG_SERIAL_GENERIC  // Default: commented (disabled)
 
 /**
  * Serial Communication Debug

--- a/TFT/src/User/Hal/stm32f10x/Serial.c
+++ b/TFT/src/User/Hal/stm32f10x/Serial.c
@@ -113,7 +113,7 @@ void UART5_IRQHandler(void)
   USART_IRQHandler(_UART5);
 }
 
-void Serial_Puts(uint8_t port, char *s)
+void Serial_Puts(uint8_t port, const char *s)
 {
   while (*s)
   {
@@ -122,7 +122,7 @@ void Serial_Puts(uint8_t port, char *s)
   }
 }
 
-void Serial_Putchar(uint8_t port, char ch)
+void Serial_Putchar(uint8_t port, const char ch)
 {
   while ((Serial[port].uart->SR & USART_FLAG_TC) == (uint16_t)RESET);
   Serial[port].uart->DR = (uint8_t) ch;

--- a/TFT/src/User/Hal/stm32f10x/Serial.h
+++ b/TFT/src/User/Hal/stm32f10x/Serial.h
@@ -17,7 +17,7 @@ extern DMA_CIRCULAR_BUFFER dmaL1Data[_UART_CNT];
 
 void Serial_Config(uint8_t port, uint16_t cacheSize, uint32_t baudrate);
 void Serial_DeConfig(uint8_t port);
-void Serial_Puts(uint8_t port, char *s);
-void Serial_Putchar(uint8_t port, char ch);
+void Serial_Puts(uint8_t port, const char *s);
+void Serial_Putchar(uint8_t port, const char ch);
 
 #endif

--- a/TFT/src/User/Hal/stm32f2_f4xx/Serial.c
+++ b/TFT/src/User/Hal/stm32f2_f4xx/Serial.c
@@ -148,7 +148,7 @@ void USART6_IRQHandler(void)
   USART_IRQHandler(_USART6);
 }
 
-void Serial_Puts(uint8_t port, char *s)
+void Serial_Puts(uint8_t port, const char *s)
 {
   while (*s)
   {
@@ -157,7 +157,7 @@ void Serial_Puts(uint8_t port, char *s)
   }
 }
 
-void Serial_Putchar(uint8_t port, char ch)
+void Serial_Putchar(uint8_t port, const char ch)
 {
   while ((Serial[port].uart->SR & USART_FLAG_TC) == (uint16_t)RESET);
   Serial[port].uart->DR = (uint8_t) ch;

--- a/TFT/src/User/Hal/stm32f2_f4xx/Serial.h
+++ b/TFT/src/User/Hal/stm32f2_f4xx/Serial.h
@@ -17,7 +17,7 @@ extern DMA_CIRCULAR_BUFFER dmaL1Data[_UART_CNT];
 
 void Serial_Config(uint8_t port, uint16_t cacheSize, uint32_t baudrate);
 void Serial_DeConfig(uint8_t port);
-void Serial_Puts(uint8_t port, char *s);
-void Serial_Putchar(uint8_t port, char ch);
+void Serial_Puts(uint8_t port, const char *s);
+void Serial_Putchar(uint8_t port, const char ch);
 
 #endif


### PR DESCRIPTION
- Fix Compiling issue when any one of the debug options is enabled in Configuration.h due to undefined variable after #2292.
- Fix preview search by predefined offset not running if `THUMBNAIL_PARSER` is set to 1 (RGB565 Bitmap) or 2 (Base64 PNG) in Configuration.h.