### PR TITLE
Fix Neopixel LED light

### DIFF
--- a/TFT/src/User/API/LED_Event.c
+++ b/TFT/src/User/API/LED_Event.c
@@ -82,7 +82,7 @@ void LED_CheckEvent(void)
       heatingDone = false;   // reset flag to "false"
       printingDone = false;  // reset flag to "false"
 
-      LED_SetColor(0, 0, 0, false);  // set (neopixel) LED light to OFF
+      LED_SetColor(255, 255, 255, false);  // Keep (neopixel) LED light to ON
       LCD_SET_KNOB_LED_IDLE(true);   // restore infoSettings.knob_led_idle and knob LED color to their default values
 
       return;

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -300,7 +300,7 @@ void menuPid(void)
         break;
 
       case KEY_ICON_7:
-        LED_SetColor(0, 0, 0, false);  // set (neopixel) LED light to OFF
+        LED_SetColor(255, 255, 255, false);  // Restore (neopixel) LED light to ON after exit
         LCD_SET_KNOB_LED_IDLE(true);   // restore infoSettings.knob_led_idle and knob LED color to their default values
 
         CLOSE_MENU();


### PR DESCRIPTION
- Fixed LED status after exiting print summary.
- Fixed state of the LED after exiting the PID menu.

### Benefits

LED are no longer off after exiting print summary (LED change from green to white) and LED are no longer off after exiting the PID menu.
