### PR TITLE
fix 'printAbort' loopDetected useless bug & 'printPause' M0/M1 have not set 'infoPrinting.pauseType' bug

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -588,16 +588,11 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
 
       if (isPause)  // pause
       {
-        // restore status before pause
-        // if pause was triggered through M0/M1 then break
         if (pauseType == PAUSE_M0)
         {
           popupReminder(DIALOG_TYPE_ALERT, LABEL_PAUSE, LABEL_PAUSE);
-          break;
         }
-
-        // do not send any command if the pause originated outside TFT
-        if (pauseType < PAUSE_EXTERNAL)
+        else if (pauseType == PAUSE_NORMAL)  // send command only if the pause originated from TFT
         {
           coordinateGetAll(&tmp);
 
@@ -629,11 +624,8 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType)
         if (infoPrinting.pauseType == PAUSE_M0)
         {
           breakAndContinue();  // clear the queue and send a break and continue
-          break;
         }
-
-        // do not send any command if the pause originated outside TFT
-        if (infoPrinting.pauseType < PAUSE_EXTERNAL)
+        else if (pauseType == PAUSE_NORMAL)  // send command only if the pause originated from TFT
         {
           if (isCoorRelative == true)    mustStoreCmd("G90\n");
           if (isExtrudeRelative == true) mustStoreCmd("M82\n");

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -491,6 +491,8 @@ void printAbort(void)
   if (loopDetected) return;
   if (!infoPrinting.printing) return;
 
+  loopDetected = true;
+
   switch (infoFile.source)
   {
     case REMOTE_HOST:  // nothing to do

--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -8,15 +8,6 @@
 COMMENT gCode_comment = {0, true};
 bool M73R_presence = false;
 
-void lowerCase(char * tempChar)
-{
-  for (uint8_t i=0; i < strlen(tempChar); i++)
-  {
-    if (tempChar[i] >= 'A' && tempChar[i] <= 'Z')
-      tempChar[i] = tempChar[i] + HIGH_TO_LOW_CASE;
-  }
-}
-
 void setM73R_presence(bool present)
 {
   M73R_presence = present;
@@ -33,11 +24,11 @@ void parseComment(void)
   if (gCode_comment.content[0] == 'l' || gCode_comment.content[0] == 'L')
   {
     temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
-    lowerCase(temp_char);
+    strlwr(temp_char);
     if (strcmp(temp_char, "layer") == 0)
     { // check for "layer" keyword in comment (layer number or layer count)
       temp_char = strtok(NULL, TOKEN_DELIMITERS);
-      lowerCase(temp_char);
+      strlwr(temp_char);
       if (strcmp(temp_char, "count") == 0)  // check if next word is "count"
       {
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
@@ -60,12 +51,12 @@ void parseComment(void)
   else if (gCode_comment.content[0] == 't' || gCode_comment.content[0] == 'T')
   {
     temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
-    lowerCase(temp_char);
+    strlwr(temp_char);
     // check for "time" keyword in comment to retrieve total or elapsed time, Cura specific
     if (strcmp(temp_char, "time") == 0 && M73R_presence == false)  // check if first word is "time"
     {
       temp_char = strtok(NULL, TOKEN_DELIMITERS);
-      lowerCase(temp_char);
+      strlwr(temp_char);
       if (strcmp(temp_char, "elapsed") == 0 && getPrintExpectedTime() > 0)  // check if next word is "elapsed"
       {
         temp_char = strtok(NULL, TOKEN_DELIMITERS);
@@ -85,12 +76,12 @@ void parseComment(void)
   else if (gCode_comment.content[0] == 'r' || gCode_comment.content[0] == 'R')
   {
     temp_char = strtok(gCode_comment.content, TOKEN_DELIMITERS);
-    lowerCase(temp_char);
+    strlwr(temp_char);
     // check for "remaining" keyword in comment to retrieve remaining time, IdeaMaker specific
     if (strcmp(temp_char, "remaining") == 0 && M73R_presence == false)  // check if first word is "remaining"
     {
       temp_char = strtok(NULL, TOKEN_DELIMITERS);
-      lowerCase(temp_char);
+      strlwr(temp_char);
       if (strcmp(temp_char, "time") == 0)  // check if next word is "time"
       {
         temp_char = strtok(NULL, TOKEN_DELIMITERS);

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -3,6 +3,8 @@
 #include "ListItem.h"
 #include "Notification.h"
 
+#define STATUS_BAR_REFRESH_TIME 2000 // refresh time in ms
+
 const GUI_RECT exhibitRect = {
 #ifdef PORTRAIT_MODE
   // exhibitRect is 2 ICON Space in the Lowest Row and 2 Center column.
@@ -661,7 +663,7 @@ void reminderMessage(int16_t inf, SYS_STATUS status)
 
   reminder.inf = inf;
   reminder.status = status;
-  reminder.time = OS_GetTimeMs() + 2000;  // 2 seconds
+  reminder.time = OS_GetTimeMs() + STATUS_BAR_REFRESH_TIME;
 
   if (menuType != MENU_TYPE_FULLSCREEN)
   {
@@ -680,7 +682,7 @@ void volumeReminderMessage(int16_t inf, SYS_STATUS status)
 
   volumeReminder.inf = inf;
   volumeReminder.status = status;
-  volumeReminder.time = OS_GetTimeMs() + 2000;
+  volumeReminder.time = OS_GetTimeMs() + STATUS_BAR_REFRESH_TIME;
 
   if (menuType != MENU_TYPE_FULLSCREEN)
   {
@@ -700,7 +702,7 @@ void busyIndicator(SYS_STATUS status)
     GUI_SetColor(infoSettings.font_color);
   }
   busySign.status = status;
-  busySign.time = OS_GetTimeMs() + 2000;
+  busySign.time = OS_GetTimeMs() + STATUS_BAR_REFRESH_TIME;
 }
 
 void loopReminderClear(void)


### PR DESCRIPTION
### Description
* Fixed a bug with M0, M1 when printing from TFT (SD or USB). In case of M0 or M1 present in the gcode file, upon resume it would dive the nozzle into the bed - and make a nice tattoo there
* Fixed a bug in "printAbort()" function, a loop avoidance was implemented there but it was inactive
* use standard library function 'strlwr' instead of 'lowerCase'
* Reduce the use of magic number

Separated according to the PR of kisslorand https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/2291
All the work was done by kisslorand and thank you.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
