### PR TITLE
Fix Tune Extruder menu with Delta printers

### DIFF
--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -55,13 +55,18 @@ static inline void extrudeFilament(void)
     storeCmd("%s\n", tool_change[tool_index]);
 
   // Raise Z axis to pause height
-  mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) + infoSettings.pause_z_raise,
-               infoSettings.pause_feedrate[FEEDRATE_Z]);
+  #if DELTA_PROBE_TYPE != 0
+    mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) - infoSettings.pause_z_raise,
+                 infoSettings.pause_feedrate[FEEDRATE_Z]);
+  #else
+    mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) + infoSettings.pause_z_raise,
+                 infoSettings.pause_feedrate[FEEDRATE_Z]);
+  #endif        
   // Move to pause location
   mustStoreCmd("G0 X%.3f Y%.3f F%d\n", infoSettings.pause_pos[X_AXIS], infoSettings.pause_pos[Y_AXIS],
                infoSettings.pause_feedrate[FEEDRATE_XY]);
   // extrude 100MM
-  mustStoreScript("M83\nG1 F50 E%.2f\nM82\n", EXTRUDE_LEN);
+  mustStoreScript("M83\nG1 F100 E%.2f\nM82\n", EXTRUDE_LEN);
 
   OPEN_MENU(menuNewExtruderESteps);
 }


### PR DESCRIPTION
Fixed issue with Tune Extruder menu and Delta printers, before start to extrude a homing is done and then raising Z axis to pause heigh, but this causes a crash at the top of the towers with the motors forcing.
Also improved extrusion speed from 50 to 100 because 50 is really very slow.