### PR TITLE
Avoid sending multiple commands at once

### DIFF
--- a/TFT/src/User/API/MachineParameters.c
+++ b/TFT/src/User/API/MachineParameters.c
@@ -406,7 +406,7 @@ void sendParameterCmd(PARAMETER_NAME name, uint8_t elementIndex, float Value)
 {
   char tempCmd[30];
   sprintf(tempCmd, "%s %s", parameterCode[name], parameterCmd[name][elementIndex]);
-  storeCmd(tempCmd, Value);
+  storeCmdScript(tempCmd, Value);  // storeCmdScript() used because there are elements in parameterCmd[] with extra command
 }
 
 void saveEepromSettings(void)

--- a/TFT/src/User/API/MachineParameters.c
+++ b/TFT/src/User/API/MachineParameters.c
@@ -406,7 +406,7 @@ void sendParameterCmd(PARAMETER_NAME name, uint8_t elementIndex, float Value)
 {
   char tempCmd[30];
   sprintf(tempCmd, "%s %s", parameterCode[name], parameterCmd[name][elementIndex]);
-  storeCmdScript(tempCmd, Value);  // storeCmdScript() used because there are elements in parameterCmd[] with extra command
+  storeScript(tempCmd, Value);  // storeScript() used because there are elements in parameterCmd[] with extra command
 }
 
 void saveEepromSettings(void)

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -67,7 +67,7 @@ void speedQuery(void)
   {
     if (infoSettings.ext_count > 0)
     {
-      speedQueryWait = storeCmdScript("M220\nM221\n");
+      speedQueryWait = storeScript("M220\nM221\n");
     }
     else
     {

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -67,7 +67,7 @@ void speedQuery(void)
   {
     if (infoSettings.ext_count > 0)
     {
-      speedQueryWait = storeCmd("M220\nM221\n");
+      speedQueryWait = storeCmdScript("M220\nM221\n");
     }
     else
     {

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -62,7 +62,7 @@ void commonStoreCmd(GCODE_QUEUE * pQueue, const char * format, va_list va)
 // If the infoCmd queue is full, a reminder message is displayed and the command is discarded.
 bool storeCmd(const char * format, ...)
 {
-  if (strlen(format) == 0) return false;
+  if (format[0] == 0) return false;
 
   if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
@@ -84,7 +84,7 @@ bool storeCmd(const char * format, ...)
 // No partial/incomplete commands (not terminated with '\n') are allowed in the script, they will be ignored.
 bool storeCmdScript(const char * format, ...)
 {
-  if (strlen(format) == 0) return false;
+  if (format[0] == 0) return false;
 
   if (infoCmd.count >= CMD_QUEUE_SIZE)  // command queue is full
   {
@@ -140,7 +140,7 @@ bool storeCmdScript(const char * format, ...)
 // and it will for wait the queue to be able to store the command.
 void mustStoreCmd(const char * format, ...)
 {
-  if (strlen(format) == 0) return;
+  if (format[0] == 0) return false;
 
   if (infoCmd.count >= CMD_QUEUE_SIZE)
   {
@@ -158,7 +158,7 @@ void mustStoreCmd(const char * format, ...)
 // For example: "M502\nM500\n" will be split into two commands "M502\n", "M500\n".
 void mustStoreScript(const char * format, ...)
 {
-  if (strlen(format) == 0) return;
+  if (format[0] == 0) return false;
 
   char script[256];
   va_list va;
@@ -189,7 +189,7 @@ void mustStoreScript(const char * format, ...)
 // If the infoCmd queue is full, a reminder message is displayed and the command is discarded.
 bool storeCmdFromUART(SERIAL_PORT_INDEX portIndex, const CMD cmd)
 {
-  if (strlen(cmd) == 0) return false;
+  if (cmd[0] == 0) return false;
 
   if (infoCmd.count >= CMD_QUEUE_SIZE)
   {

--- a/TFT/src/User/API/interfaceCmd.h
+++ b/TFT/src/User/API/interfaceCmd.h
@@ -18,6 +18,7 @@ bool isNotEmptyCmdQueue(void);  // also usable as condition callback for loopPro
 bool isEnqueued(const CMD cmd);
 
 bool storeCmd(const char * format, ...);
+bool storeCmdScript(const char * format, ...);
 void mustStoreCmd(const char * format, ...);
 void mustStoreScript(const char * format, ...);
 bool storeCmdFromUART(SERIAL_PORT_INDEX portIndex, const CMD cmd);

--- a/TFT/src/User/API/interfaceCmd.h
+++ b/TFT/src/User/API/interfaceCmd.h
@@ -18,7 +18,7 @@ bool isNotEmptyCmdQueue(void);  // also usable as condition callback for loopPro
 bool isEnqueued(const CMD cmd);
 
 bool storeCmd(const char * format, ...);
-bool storeCmdScript(const char * format, ...);
+bool storeScript(const char * format, ...);
 void mustStoreCmd(const char * format, ...);
 void mustStoreScript(const char * format, ...);
 bool storeCmdFromUART(SERIAL_PORT_INDEX portIndex, const CMD cmd);


### PR DESCRIPTION
### Requirements

BTT or MKS TFT.

### Description

   This PR eliminates the sending of multiple commands at once. At the moment of sending commands from the queue it is not known if there are more than one slot free in the mainboard's buffer so sending multiple ones at once can lead to missed/not received commands.
   A new procedure was implemented that deals with these command groups that need to be sent together. It puts them into the command queue one by one so they will be sent one by one. If there is no room for all of them none is sent. There's a feedback of success if all of them were queued or a feedback of failure if there was an error, in which case none of them is sent. With the existing procedure it was impossible to send all of them or none of them if there was no room in the command queue. 
   A lot of approaches were tested to find the right balance between speed, code size and memory usage. There were techniques that gained fraction of nanoseconds but used more code or memory and there were others with less code but three times slower and so on.

### Related issues

Sending commands separately could avoid the bug discussed in issue #2295.

### Notes

   For those concerned about speed here are some numbers on a BTT TFT35 v3:
 Sending "M220\nM221\n" with the new procedure (5.534 microseconds) is 3.32% slower than sending separated "M220\n" and "M221\n" with the old procedure (5.356 microseconds). This means 0.178 microseconds more to put "M220\nM221\n" into the command send buffer. Just as an observation, it takes around 400 microseconds to send "M220\nM221\n" to the mainboard on UART at 250000 b/s.
