### PR TITLE
Some code reduction + cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,15 +237,12 @@ So, make sure to use the firmware matching your TFT screen.
 
 Themes are available on [`Copy to SD Card root directory to update`](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/tree/master/Copy%20to%20SD%20Card%20root%20directory%20to%20update) folder.
 
-For **BTT TFTs**, the root folder for fonts and icons is `TFT*`, where `*` is the size of the TFT (e.g. `TFT24`, `TFT35`, `TFT50` etc). Fonts and icons folder structure:
+The root folder for fonts and icons is `TFT*`, where `*` is the size of the TFT (e.g. `TFT24`, `TFT35`, `TFT50` etc). Fonts and icons folder structure:
 
 - `TFT*/font`: Includes the fonts in .fon format and a readme.md
 - `TFT*/bmp`: Includes the icons in .bmp format and a readme.md
 
-For **MKS TFTs**, the root folder for fonts and icons **MUST** be renamed to `MKS` in order it can be recognized and installed by the TFT. Fonts and icons folder structure:
-
-- `MKS/font`: Includes the fonts in .fon format and a readme.md
-- `MKS/bmp`: Includes the icons in .bmp format and a readme.md
+For **MKS TFT32**, the `TFT28` folder has to be used and **MUST** be renamed to `TFT32` in order it can be recognized and installed by the TFT.
 
 #### Configuration File
 

--- a/TFT/src/User/API/Vfs/vfs.c
+++ b/TFT/src/User/API/Vfs/vfs.c
@@ -137,9 +137,7 @@ char * isSupportedFile(char * filename)
   char * extPos = strrchr(filename, '.');  // check last "." in the name where extension is supposed to start
 
   if (extPos != NULL && extPos[1] != 'g' && extPos[1] != 'G')
-  {
     extPos = NULL;
-  }
 
   return extPos;
 }
@@ -189,24 +187,20 @@ char * restoreExtension(char * filename)
 
 char * hideFilenameExtension(uint8_t index)
 {
-  char * filename = NULL;
+  char * filename = hideExtension(infoFile.file[index]);
 
   if (infoFile.longFile[index] != NULL)
     filename = hideExtension(infoFile.longFile[index]);
-  else
-    filename = hideExtension(infoFile.file[index]);
 
   return filename;
 }
 
 char * restoreFilenameExtension(uint8_t index)
 {
-  char * filename = NULL;
+  char * filename = restoreExtension(infoFile.file[index]);
 
   if (infoFile.longFile[index] != NULL)
     filename = restoreExtension(infoFile.longFile[index]);
-  else
-    filename = restoreExtension(infoFile.file[index]);
 
   return filename;
 }

--- a/TFT/src/User/API/boot.c
+++ b/TFT/src/User/API/boot.c
@@ -17,7 +17,7 @@ const uint32_t fontAddrList[] = {
   _8X16_FONT_ADDR
 };
 
-const char *fontPathList[] = {
+const char * fontPathList[] = {
   FONT_UPDATE_DIR "/" FILE_ASCII_FONT,
   FONT_UPDATE_DIR "/" FILE_UNICODE_FONT,
   FONT_UPDATE_DIR "/" FILE_LARGE_ASCII_FONT,
@@ -27,7 +27,7 @@ const char *fontPathList[] = {
 GUI_POINT bmp_size;
 
 // This List is Auto-Generated. Please add new icons in icon_list.inc only
-const char * const  iconBmpName[] = {
+const char * const iconBmpName[] = {
   #define X_ICON(NAME) #NAME ,
     #include "icon_list.inc"
   #undef X_ICON
@@ -35,14 +35,14 @@ const char * const  iconBmpName[] = {
 };
 
 // This List is Auto-Generated. Please add new icons in small_icon_list.inc only
-const char * const  smallIconBmpName[] = {
+const char * const smallIconBmpName[] = {
   #define X_SMALLICON(NAME) #NAME ,
     #include "small_icon_list.inc"
   #undef X_SMALLICON
   // add new icons in small_icon_list.inc only
 };
 
-BMPUPDATE_STAT bmpDecode(char *bmp, uint32_t addr)
+BMPUPDATE_STAT bmpDecode(char * bmp, uint32_t addr)
 {
   FIL bmpFile;
   char magic[2];
@@ -208,7 +208,7 @@ static inline bool updateIcon(char * rootDir)
     return false;
 }
 
-void dispIconFail(uint8_t *lbl, BMPUPDATE_STAT bmpState)
+void dispIconFail(uint8_t * lbl, BMPUPDATE_STAT bmpState)
 {
   char * stat_txt;
   char error_txt[30];
@@ -232,12 +232,12 @@ void dispIconFail(uint8_t *lbl, BMPUPDATE_STAT bmpState)
   }
 
   sprintf(error_txt, "Error: %s", stat_txt);
-  GUI_DispString(labelFailedRect.x0, labelFailedRect.y0 + BYTE_HEIGHT + 2, (uint8_t*)error_txt);
+  GUI_DispString(labelFailedRect.x0, labelFailedRect.y0 + BYTE_HEIGHT + 2, (uint8_t *)error_txt);
   GUI_RestoreColorDefault();
   Delay_ms(1000);  // give some time to the user to read failed icon name.
 }
 
-bool updateFont(char *font, uint32_t addr)
+bool updateFont(char * font, uint32_t addr)
 {
   uint8_t progress = 0;
   UINT rnum = 0;
@@ -256,8 +256,8 @@ bool updateFont(char *font, uint32_t addr)
 
   GUI_Clear(infoSettings.bg_color);
   sprintf((void *)buffer,"%s Size: %dKB",font, (uint32_t)f_size(&myfp) >> 10);
-  GUI_DispString(0, 100, (uint8_t*)buffer);
-  GUI_DispString(0, 140, (uint8_t*)"Updating:   %");
+  GUI_DispString(0, 100, (uint8_t *)buffer);
+  GUI_DispString(0, 140, (uint8_t *)"Updating:   %");
 
   while (!f_eof(&myfp))
   {
@@ -356,7 +356,7 @@ static inline void scanRenameUpdate(char * rootDir)
   replaceOldFile(curPath, renamedPath);
 }
 
-static inline void saveflashSign(uint8_t* buf, uint32_t size)
+static inline void saveflashSign(uint8_t * buf, uint32_t size)
 {
   W25Qxx_EraseSector(FLASH_SIGN_ADDR);
   Delay_ms(100);  // give time for spi flash to settle
@@ -383,7 +383,7 @@ checkupdate:
     bool flash_sign_updated = false;
     uint32_t saved_flash_sign[sign_count];
 
-    W25Qxx_ReadBuffer((uint8_t*)&saved_flash_sign, FLASH_SIGN_ADDR, sizeof(saved_flash_sign));
+    W25Qxx_ReadBuffer((uint8_t *)&saved_flash_sign, FLASH_SIGN_ADDR, sizeof(saved_flash_sign));
 
     // check for font update
     GET_FULL_PATH(curfilePath, rootDir, FONT_UPDATE_DIR);
@@ -394,7 +394,7 @@ checkupdate:
       {
         GET_FULL_PATH(curfilePath, rootDir, fontPathList[i]);
         if (!updateFont(curfilePath, fontAddrList[i]))
-          updateOk = false; // set update to false if any font fails to update
+          updateOk = false;  // set update to false if any font fails to update
       }
 
       if (updateOk && saved_flash_sign[font_sign] != FONT_CHECK_SIGN)
@@ -433,19 +433,19 @@ checkupdate:
     // rename files
     scanRenameUpdate(rootDir);
 
-    // chet for reset file
+    // check for reset file
     scanResetDir(rootDir);
 
-    //update flash sign
+    // update flash sign
     if (flash_sign_updated)
     {
-      saveflashSign((uint8_t*)saved_flash_sign, sizeof(saved_flash_sign));
+      saveflashSign((uint8_t *)saved_flash_sign, sizeof(saved_flash_sign));
     }
   }
 
   #ifdef USB_FLASH_DRIVE_SUPPORT
     // check USB flash drive for update file
-    else if(checkUSBDisk && mountUSBDisk())
+    else if (checkUSBDisk && mountUSBDisk())
     {
       rootDir = USBDISK_ROOT_DIR;
       checkUSBDisk = false;

--- a/TFT/src/User/API/boot.c
+++ b/TFT/src/User/API/boot.c
@@ -345,7 +345,7 @@ static inline void scanRenameUpdate(char * rootDir)
   GET_FULL_PATH(renamedPath, rootDir, renamedFirmwareFile);
   replaceOldFile(curPath, renamedPath);
 
-  //rename firmware file from short to full name
+  // rename firmware file from short to full name
   GET_FULL_PATH(curPath, rootDir, firmwareFileShort);
   GET_FULL_PATH(renamedPath, rootDir, firmwareFile);
   replaceOldFile(curPath, renamedPath);

--- a/TFT/src/User/API/boot.c
+++ b/TFT/src/User/API/boot.c
@@ -303,8 +303,12 @@ static inline void scanResetDir(char * rootDir)
 
 static inline void replaceOldFile(char * curPath, char * newPath)
 {
+  if (!f_file_exists(curPath))  // if source file does not exist, nothing to do
+    return;
+
   if (f_file_exists(newPath))
     f_unlink(newPath);  // remove already existing file first
+
   f_rename(curPath, newPath);
 }
 

--- a/TFT/src/User/API/boot.h
+++ b/TFT/src/User/API/boot.h
@@ -34,7 +34,7 @@ extern "C" {
 #define BYTE_ASCII_ADDR         (WORD_UNICODE_ADDR + WORD_UNICODE_SIZE)        // ascii (+0x1000 4K)
 #define LARGE_FONT_ADDR         (BYTE_ASCII_ADDR + BYTE_ASCII_SIZE)            // Large ascii font
 #define _8X16_FONT_ADDR         (LARGE_FONT_ADDR + LARGE_FONT_SIZE)            // 8 x 16 ascii font
-//#define BYTE_RESERVE_ADDR      0x710000
+//#define BYTE_RESERVE_ADDR       0x710000
 #define FLASH_SIGN_ADDR         (_8X16_FONT_ADDR + _8X16_FONT_SIZE)            // for language label strings from language file
 #define LANGUAGE_ADDR           (FLASH_SIGN_ADDR + FLASH_SIGN_SIZE)            // for label strings from config file
 #define STRINGS_STORE_ADDR      (LANGUAGE_ADDR + LANGUAGE_SIZE)                // for label strings from config file
@@ -112,8 +112,8 @@ typedef union
 } GUI_COLOR;
 
 void scanUpdates(void);
-void dispIconFail(uint8_t *lbl, BMPUPDATE_STAT bmpState);
-BMPUPDATE_STAT bmpDecode(char *bmp, uint32_t addr);
+void dispIconFail(uint8_t * lbl, BMPUPDATE_STAT bmpState);
+BMPUPDATE_STAT bmpDecode(char * bmp, uint32_t addr);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1030,10 +1030,10 @@ void sendQueueCmd(void)
           }
           break;
 
-        // case 420:  // M420
-        //   // ABL state and Z fade height will be set through parsACK.c after receiving confirmation
-        //   // message from the printer to prevent wrong state and/or value in case of error.
-        //   break;
+        //case 420:  // M420
+        //  // ABL state and Z fade height will be set through parsACK.c after receiving confirmation
+        //  // message from the printer to prevent wrong state and/or value in case of error
+        //  break;
 
         case 569:  // M569 TMC stepping mode
         {
@@ -1206,18 +1206,10 @@ void sendQueueCmd(void)
             {
               if (cmd_seen('S'))
               {
-                switch (cmd_value())
+                uint8_t v = cmd_value();
+                if (v == 1 || v == 2)
                 {
-                  case 1:
-                    setParameter(P_ABL_STATE, 0, 1);
-                    break;
-
-                  case 2:
-                    setParameter(P_ABL_STATE, 0, 0);
-                    break;
-
-                  default:
-                    break;
+                  setParameter(P_ABL_STATE, 0, v % 2);  // value will be 1 if v == 1, 0 if v == 2
                 }
               }
             }

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -815,7 +815,9 @@ void parseACK(void)
           setParameter(P_ABL_STATE, 0, DISABLED);
       }
       else if (ack_seen("echo:Fade Height"))
+      {
         setParameter(P_ABL_STATE, 1, ack_value());
+      }
       // parse and store M420 V1 T1 or G29 S0 (mesh. Z offset:) or M503 (G29 S4 Zxx), MBL Z offset value (e.g. from Babystep menu)
       else if (ack_seen("mesh. Z offset:") || ack_seen("G29 S4 Z"))
       {

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -116,7 +116,7 @@ bool scanPrintFilesFatFs(void)
       fileDate[infoFile.fileCount] = ((uint32_t)(finfo.fdate) << 16) | finfo.ftime;
       // copy file name and set the flag for filename extension check
       strncpy(infoFile.file[infoFile.fileCount], finfo.fname, len + 1);  // "+ 1": the flag for filename extension check
-      infoFile.longFile[infoFile.fileCount] = NULL;   // long filename is not supported, so always set it to NULL
+      infoFile.longFile[infoFile.fileCount] = NULL;                      // long filename is not supported, so always set it to NULL
       infoFile.fileCount++;
     }
   }

--- a/TFT/src/User/Menu/ABL.c
+++ b/TFT/src/User/Menu/ABL.c
@@ -17,18 +17,16 @@ void ablUpdateStatus(bool succeeded)
   switch (infoMachineSettings.leveling)
   {
     case BL_BBL:
-    {
       tempTitle.index = LABEL_ABL_SETTINGS_BBL;
       break;
-    }
+
     case BL_UBL:
-    {
       savingEnabled = false;
       tempTitle.index = LABEL_ABL_SETTINGS_UBL;
 
       sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_BL_SMART_FILL));
       break;
-    }
+
     default:
       break;
   }
@@ -121,6 +119,7 @@ void menuUBLSaveLoad(void)
   if (!ublIsSaving)
   {
     UBLSaveLoadItems.title.index = LABEL_ABL_SETTINGS_UBL_LOAD;
+
     for (int i = 0; i < 4; i++)
     {
       UBLSaveLoadItems.items[i].icon = ICON_EEPROM_RESTORE;

--- a/TFT/src/User/Menu/BedLevelingLayer2.c
+++ b/TFT/src/User/Menu/BedLevelingLayer2.c
@@ -37,6 +37,7 @@ void menuBedLevelingLayer2(void)
 
     case BL_MBL:
       bedLevelingLayer2Items.title.index = LABEL_MBL_SETTINGS;
+      break;
 
     default:
       break;

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -600,6 +600,7 @@ void menuPrinting(void)
     printingItems.items[KEY_ICON_7] = itemIsPrinting[2];  // Back
   }
 
+  // hide filename extension if filename extension feature is disabled
   printingItems.title.address = hideFilenameExtension(infoFile.fileIndex);
 
   menuDrawPage(&printingItems);

--- a/TFT/src/User/Menu/UnifiedMove.c
+++ b/TFT/src/User/Menu/UnifiedMove.c
@@ -81,8 +81,9 @@ void menuUnifiedMove(void)
       case KEY_ICON_6:
         if (infoMachineSettings.leveling != BL_DISABLED)
         {
-          if(infoMachineSettings.firmwareType == FW_MARLIN)
+          if (infoMachineSettings.firmwareType == FW_MARLIN)
             storeCmd("M420\n");  // refresh ABL_STATE
+
           OPEN_MENU(menuBedLeveling);
         }
         break;

--- a/TFT/src/User/Variants/pin_GD_TFT35_B1_V3_0.h
+++ b/TFT/src/User/Variants/pin_GD_TFT35_B1_V3_0.h
@@ -1,5 +1,5 @@
-#ifndef _PIN_GD_TFT35_B1_V3_0_H_ // modify to actual filename !!!
-#define _PIN_GD_TFT35_B1_V3_0_H_ // modify to actual filename !!!
+#ifndef _PIN_GD_TFT35_B1_V3_0_H_  // modify to actual filename !!!
+#define _PIN_GD_TFT35_B1_V3_0_H_  // modify to actual filename !!!
 
 // Hardware version config
 #ifndef HARDWARE_VERSION

--- a/TFT/src/User/Variants/pin_GD_TFT43_V3_0.h
+++ b/TFT/src/User/Variants/pin_GD_TFT43_V3_0.h
@@ -1,6 +1,7 @@
 #ifndef _PIN_GD_TFT43_V3_0_H_  // modify to actual filename !!!
 #define _PIN_GD_TFT43_V3_0_H_  // modify to actual filename !!!
 
+// LCD resolution, font and icon size
 #ifndef TFT_RESOLUTION
   #define TFT_RESOLUTION
   #ifdef PORTRAIT_MODE
@@ -21,11 +22,13 @@
 #endif
 
 // LCD interface
+// Supported LCD drivers: [ST7789, SSD1963, RM68042, NT35310, ILI9488, ILI9341, ILI9325, HX8558]
 #ifndef TFTLCD_DRIVER
-  #define TFTLCD_DRIVER       SSD1963  // Type of LCD driver, now support[RM68042, ILI9488, ILI9341, ST7789, HX8558, SSD1963].
+  #define TFTLCD_DRIVER       SSD1963
   #define TFTLCD_DRIVER_SPEED 0x10     // SSD1963 needs slower speed
 #endif
 
+// Only for TFTLCD_DRIVER SSD1963
 #ifndef SSD1963_LCD_PARA
   #define SSD1963_LCD_PARA
   #define SSD_DCLK_FREQUENCY  12  // 12Mhz

--- a/TFT/src/User/Variants/pin_GD_TFT50_V3_0.h
+++ b/TFT/src/User/Variants/pin_GD_TFT50_V3_0.h
@@ -11,6 +11,7 @@
   #define HARDWARE_VERSION "GD_TFT50_V3.0"
 #endif
 
+// Only for TFTLCD_DRIVER SSD1963
 #ifndef SSD1963_LCD_PARA
   #define SSD1963_LCD_PARA
   #define SSD_DCLK_FREQUENCY  9   // 9Mhz

--- a/TFT/src/User/Variants/pin_MKS_TFT28_NEW_GENIUS.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT28_NEW_GENIUS.h
@@ -1,6 +1,11 @@
 #ifndef _PIN_MKS_TFT28_NEW_GENIUS_H_  // modify to actual filename !!!
 #define _PIN_MKS_TFT28_NEW_GENIUS_H_  // modify to actual filename !!!
 
+// Update folder for fonts and icons
+#ifndef UPDATE_DIR
+  #define UPDATE_DIR "TFT28"
+#endif
+
 // Hardware version config
 #ifndef HARDWARE_VERSION
   #define HARDWARE_VERSION "TFT28_NEW_GENIUS"

--- a/TFT/src/User/Variants/pin_MKS_TFT28_V3_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT28_V3_0.h
@@ -1,6 +1,11 @@
 #ifndef _PIN_MKS_TFT28_V3_0_H_  // modify to actual filename !!!
 #define _PIN_MKS_TFT28_V3_0_H_  // modify to actual filename !!!
 
+// Update folder for fonts and icons
+#ifndef UPDATE_DIR
+  #define UPDATE_DIR "TFT28"
+#endif
+
 // Hardware version config
 #ifndef HARDWARE_VERSION
   #define HARDWARE_VERSION "TFT28_V3.0"

--- a/TFT/src/User/Variants/pin_MKS_TFT28_V4_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT28_V4_0.h
@@ -1,6 +1,11 @@
 #ifndef _PIN_MKS_TFT28_V4_0_H_  // modify to actual filename !!!
 #define _PIN_MKS_TFT28_V4_0_H_  // modify to actual filename !!!
 
+// Update folder for fonts and icons
+#ifndef UPDATE_DIR
+  #define UPDATE_DIR "TFT28"
+#endif
+
 // Hardware version config
 #ifndef HARDWARE_VERSION
   #define HARDWARE_VERSION "TFT28_V4.0"

--- a/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT32_V1_4.h
@@ -20,7 +20,7 @@
 
 // Update folder for fonts and icons
 #ifndef UPDATE_DIR
-  #define UPDATE_DIR "MKS"
+  #define UPDATE_DIR "TFT32"
 #endif
 
 // Hardware manufacturer

--- a/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
@@ -20,7 +20,7 @@
 
 // Update folder for fonts and icons
 #ifndef UPDATE_DIR
-  #define UPDATE_DIR "TFT35"
+  #define UPDATE_DIR "MKS"
 #endif
 
 // Hardware manufacturer

--- a/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
@@ -20,7 +20,7 @@
 
 // Update folder for fonts and icons
 #ifndef UPDATE_DIR
-  #define UPDATE_DIR "MKS"
+  #define UPDATE_DIR "TFT35"
 #endif
 
 // Hardware manufacturer

--- a/TFT/src/User/Variants/variants.h
+++ b/TFT/src/User/Variants/variants.h
@@ -56,16 +56,16 @@
   #include "pin_GD_TFT43_V3_0.h"
 #elif defined(GD_TFT50_V3_0)
   #include "pin_GD_TFT50_V3_0.h"
-#elif defined(MKS_TFT32_V1_3)
-  #include "pin_MKS_TFT32_V1_3.h"
-#elif defined(MKS_TFT32_V1_4)
-  #include "pin_MKS_TFT32_V1_4.h"
 #elif defined(MKS_TFT28_V3_0)
   #include "pin_MKS_TFT28_V3_0.h"
 #elif defined(MKS_TFT28_V4_0)
   #include "pin_MKS_TFT28_V4_0.h"
 #elif defined(MKS_TFT28_NEW_GENIUS)
   #include "pin_MKS_TFT28_NEW_GENIUS.h"
+#elif defined(MKS_TFT32_V1_3)
+  #include "pin_MKS_TFT32_V1_3.h"
+#elif defined(MKS_TFT32_V1_4)
+  #include "pin_MKS_TFT32_V1_4.h"
 #elif defined(MKS_TFT35_V1_0)
   #include "pin_MKS_TFT35_V1_0.h"
 #endif


### PR DESCRIPTION
**IMPROVEMENTS:**
* Some code reduction + cleanup after the last merged PRs
* Used TFT* (e.g. TFT28) folder naming convention also for MKS TFTs: There is no more need to rename to MKS folder. README.md file updated accordingly

**BUGFIXES:**
* Fixed missing check on source filename before trying to rename to .CUR during boot: Small bug originated in #2380.

**NOTE:** Reporting #2295 as fixed just to close it (it was fixed by other merged PRs).

fixes #2403
fixes #2295

**PR STATE:** Ready for merge
