### PR TITLE
Fixed base64PNG thumbnail search

### DIFF
--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -280,6 +280,9 @@ uint32_t modelFileSeekToThumbnailBase64PNG(FIL *fp, uint16_t width, uint16_t hei
   snprintf(buf, sizeof(buf), "; thumbnail begin %hux%hu ", width, height);
   dbg_print("Start search\n");
 
+  // Seek to the beginning of the file as the file pointer was moved during the RGB565 thumbnail search
+  f_lseek(fp, 0);
+
   if (!modelFileFind(fp, buf))
     return 0;
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

This is a fix for the embedded base64PNG thumbnail search.
Due to the nature of the thumbnail search order, base64PNG thumbnails were never displayed. While we try to locate an RGB565 thumbnail in the comments, the file pointer moves to the end of the MAX_THUMBNAIL_SEARCH_BLOCKS. The original code tried to locate the base64PNG thumbnail from this position onward, which meant that it was never found.

The fix is to simply seek back to the beginning of the gcode file at the start of the modelFileSeekToThumbnailBase64PNG function.

### Benefits

Base64PNG thumbnails (e.g. PrusaSlicer generated ones) are now displayed correctly.

### Related Issues

#2398 
