### PR TITLE
Reduced path to start ABL for Delta printers

### DIFF
--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -95,7 +95,18 @@ void menuBedLeveling(void)
     switch (key_num)
     {
       case KEY_ICON_0:
-        OPEN_MENU(menuBedLevelingLayer2);
+        #if DELTA_PROBE_TYPE == 0
+          OPEN_MENU(menuBedLevelingLayer2);
+        #else
+        {
+          #if DELTA_PROBE_TYPE != 2  // if not removable probe
+            ablStart();
+          #else  // if removable probe
+            setDialogText(LABEL_WARNING, LABEL_CONNECT_PROBE, LABEL_CONTINUE, LABEL_CANCEL);
+            showDialog(DIALOG_TYPE_ALERT, ablStart, NULL, NULL);
+          #endif
+        } 
+        #endif
         break;
 
       case KEY_ICON_1:


### PR DESCRIPTION
With Delta printers there is no need for a second layer/page for ABL because on second layer/page there is only one icon to start ABL.

This PR reduce path to start ABL only for Delta printers, now ABL is starting when clicking on ABL button for ease of use. Before, you had to click on ABL and then on Start on the 2nd layer/page.