### PR TITLE
Fix Bug of coordinateQueryTurnOff function

### DIFF
--- a/TFT/src/User/API/coordinate.c
+++ b/TFT/src/User/API/coordinate.c
@@ -142,5 +142,8 @@ void coordinateQueryTurnOff(void)
   coordinateQueryWait = false;
 
   if (infoMachineSettings.autoReportPos == 1)  // if auto report is enabled, turn it off
+  {
     storeCmd("M154 S0\n");
+    curQuerySeconds = 0;
+  }
 }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT with ONBOARD_SD enabled setup 

### Description

coordinateQueryTurnOff function does not update the saved coordinate query period. This causes the coordinates not being auto reported by Marlin. As a result during prints from onboard sd, the layer height is not updated on the printing menu.

### Benefits

Layer height is updated on printing menu as intended.

### Related Issues

Check description.
