### PR TITLE
Fix progress bar maxed out at print start

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -818,8 +818,6 @@ void loopPrintFromTFT(void)
         continue;  // "continue" will force also to execute "ip_cur++" in the "for" statement
       }
 
-      infoPrinting.offset++;  // count non-gcode size
-
       if (read_char == '\n')  // '\n' is command end flag
       {
         if (comment_parsing && comment_count != 0)  // if a comment was found, finalize the comment data structure
@@ -846,6 +844,8 @@ void loopPrintFromTFT(void)
             comment_parsing = false;
         }
       }
+
+      infoPrinting.offset++;  // count non-gcode size
     }
   }
 

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -145,10 +145,9 @@ const char *stripHead(const char *str)
 {
   // example: " :/test/cap2.gcode\n" -> "test/cap2.gcode\n"
 
-  for (; *str != '\0'; str++)
+  while (*str == ':' || *str == '/' || *str == ' ')
   {
-    if (*str != ' ' && *str != ':' && *str != '/')
-      break;
+    str++;
   }
 
   return str;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

If printing from TFT than at print start the progress bar was maxed out and remained like that until a menu refresh was done (after a popup, returning from More menu, Babystep menu, etc).

It is fixed in this PR.