### PR TITLE
M401 H moved from parseACK.c to BLTouch.c

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -430,12 +430,11 @@ void parseACK(void)
       }
       else if (infoMachineSettings.firmwareType == FW_NOT_DETECTED)  // if never connected to the printer since boot
       {
-        storeCmd("M503\n");    // query detailed printer capabilities
-        storeCmd("M92\n");     // steps/mm of extruder is an important parameter for Smart filament runout
-                               // avoid can't getting this parameter due to disabled M503 in Marlin
-        storeCmd("M211\n");    // retrieve the software endstops state
-        storeCmd("M115\n");    // as last command to identify the FW type!
-        storeCmd("M401 H\n");  // check the state of BLTouch HighSpeed mode
+        storeCmd("M503\n");  // query detailed printer capabilities
+        storeCmd("M92\n");   // steps/mm of extruder is an important parameter for Smart filament runout
+                             // avoid can't getting this parameter due to disabled M503 in Marlin
+        storeCmd("M211\n");  // retrieve the software endstops state
+        storeCmd("M115\n");  // as last command to identify the FW type!
       }
 
       infoHost.connected = true;

--- a/TFT/src/User/Menu/BLTouch.c
+++ b/TFT/src/User/Menu/BLTouch.c
@@ -29,7 +29,10 @@ MENUITEMS BLTouchItems = {
 void menuBLTouch(void)
 {
   KEY_VALUES key_num = KEY_IDLE;
-  uint8_t hsModeOld = HS_DISABLED;
+  BLT_HS_MODE hsModeOld = bltHSmode;
+
+  if (infoMachineSettings.firmwareType == FW_MARLIN)
+    storeCmd("M401 H\n");  // get the BLTouch HS Mode state (bltHSmode will be updated in parseACK())
 
   menuDrawPage(&BLTouchItems);
 
@@ -60,11 +63,8 @@ void menuBLTouch(void)
         break;
 
       case KEY_ICON_5:
-        if (infoMachineSettings.firmwareType == FW_MARLIN && bltHSmode != HS_DISABLED)
-        {
-          bltHSmode = HS_ON - bltHSmode;
-          storeCmd("M401 S%u\n", bltHSmode);
-        }
+        if (bltHSmode != HS_DISABLED)
+          storeCmd("M401 S%u\n", HS_ON - bltHSmode);  // set the BLTouch HS Mode state (bltHSmode will be updated in parseACK())
         break;
 
       case KEY_ICON_7:
@@ -75,7 +75,7 @@ void menuBLTouch(void)
         break;
     }
 
-    if (infoMachineSettings.firmwareType == FW_MARLIN && bltHSmode != hsModeOld)
+    if (bltHSmode != hsModeOld)
     {
       hsModeOld = bltHSmode;
       BLTouchItems.items[5].icon = (bltHSmode == HS_ON) ? ICON_FAST_SPEED : ICON_SLOW_SPEED;


### PR DESCRIPTION
**BUGFIXES:**
* M401 H moved from parseACK.c to BLTouch.c: M401 is now executed in BLTouch menu (so in case BLTouch is configured/supported by mainboard fw) and in case of Marlin fw (currently the only fw supporting HS mode).

**PR STATE:** Ready for merge.
