### PR TITLE
Add time conversion macros and remove duplicate code

### DIFF
--- a/TFT/src/User/API/LCD_Dimming.c
+++ b/TFT/src/User/API/LCD_Dimming.c
@@ -4,7 +4,7 @@
 
 #ifdef LCD_LED_PWM_CHANNEL
 
-const uint32_t lcd_brightness[LCD_BRIGHTNESS_COUNT] = {
+const uint8_t lcd_brightness[LCD_BRIGHTNESS_COUNT] = {
   BRIGHTNESS_0,
   BRIGHTNESS_5,
   BRIGHTNESS_10,
@@ -19,7 +19,7 @@ const uint32_t lcd_brightness[LCD_BRIGHTNESS_COUNT] = {
   BRIGHTNESS_100
 };
 
-const uint32_t lcd_idle_times[LCD_IDLE_TIME_COUNT] = {
+const uint16_t lcd_idle_times[LCD_IDLE_TIME_COUNT] = {
   IDLE_TIME_OFF,
   IDLE_TIME_5,
   IDLE_TIME_10,
@@ -115,7 +115,7 @@ void LCD_CheckDimming(void)
   }
   else
   {
-    if (OS_GetTimeMs() - lcd_dim.idle_ms < (lcd_idle_times[infoSettings.lcd_idle_time] * 1000))
+    if (OS_GetTimeMs() - lcd_dim.idle_ms < SEC_TO_MS(lcd_idle_times[infoSettings.lcd_idle_time]))
       return;
 
     if (!lcd_dim.dimmed)

--- a/TFT/src/User/API/LCD_Dimming.h
+++ b/TFT/src/User/API/LCD_Dimming.h
@@ -62,9 +62,9 @@ extern "C" {
     LCD_IDLE_TIME_COUNT
   } LCD_IDLE_TIME_;
 
-  extern const uint32_t lcd_brightness[LCD_BRIGHTNESS_COUNT];
+  extern const uint8_t lcd_brightness[LCD_BRIGHTNESS_COUNT];
 
-  extern const uint32_t lcd_idle_times[LCD_IDLE_TIME_COUNT];
+  extern const uint16_t lcd_idle_times[LCD_IDLE_TIME_COUNT];
   extern const LABEL lcd_idle_time_names[LCD_IDLE_TIME_COUNT];
 
   bool LCD_IsBlocked(void);

--- a/TFT/src/User/API/Language/utf8_decode.h
+++ b/TFT/src/User/API/Language/utf8_decode.h
@@ -38,10 +38,10 @@ uint16_t getUTF8Length(const uint8_t *const str);
 uint16_t GUI_StrPixelWidth_str(const uint8_t *str);
 uint16_t GUI_StrPixelWidth_label(int16_t index);
 
-#define GUI_StrPixelWidth(X) _Generic(((X+0)),        const uint8_t*: GUI_StrPixelWidth_str, \
-                                                const uint8_t* const: GUI_StrPixelWidth_str, \
-                                                            uint8_t*: GUI_StrPixelWidth_str, \
-                                                             default: GUI_StrPixelWidth_label)(X)
+#define GUI_StrPixelWidth(X) _Generic(((X+0)), const uint8_t* const: GUI_StrPixelWidth_str, \
+                                                     const uint8_t*: GUI_StrPixelWidth_str, \
+                                                           uint8_t*: GUI_StrPixelWidth_str, \
+                                                            default: GUI_StrPixelWidth_label)(X)
 #ifdef __cplusplus
 }
 #endif

--- a/TFT/src/User/API/Notification.c
+++ b/TFT/src/User/API/Notification.c
@@ -102,7 +102,7 @@ void drawToast(bool redraw)
 
     // set new timer if notification is new
     if (!redraw)
-      nextToastTime = OS_GetTimeMs() + TOAST_DURATION;
+      nextToastTime = OS_GetTimeMs() + SEC_TO_MS(TOAST_DURATION);
 
     GUI_RestoreColorDefault();
   }

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -106,13 +106,6 @@ uint32_t getPrintTime(void)
   return infoPrinting.time;
 }
 
-void getPrintTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec)
-{
-  *hour = infoPrinting.time / 3600;
-  *min = infoPrinting.time % 3600 / 60;
-  *sec = infoPrinting.time % 60;
-}
-
 void setPrintRemainingTime(int32_t remainingTime)
 {
   float speedFactor = (float) (speedGetCurPercent(0)) / 100;  // speed (feed rate) factor (e.g. 50% -> 0.5)
@@ -137,13 +130,6 @@ void parsePrintRemainingTime(char * buffer)
 uint32_t getPrintRemainingTime()
 {
   return infoPrinting.remainingTime;
-}
-
-void getPrintRemainingTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec)
-{
-  *hour = infoPrinting.remainingTime / 3600;
-  *min = infoPrinting.remainingTime % 3600 / 60;
-  *sec = infoPrinting.remainingTime % 60;
 }
 
 void setPrintLayerNumber(uint16_t layerNumber)
@@ -891,7 +877,7 @@ void loopPrintFromOnboard(void)
   if (MENU_IS(menuTerminal)) return;
 
   static uint32_t nextCheckPrintTime = 0;
-  uint32_t update_M27_time = infoSettings.m27_refresh_time * 1000;
+  uint32_t update_M27_time = SEC_TO_MS(infoSettings.m27_refresh_time);
 
   do
   { // WAIT FOR M27

--- a/TFT/src/User/API/Printing.h
+++ b/TFT/src/User/API/Printing.h
@@ -54,12 +54,10 @@ uint32_t getPrintExpectedTime(void);
 
 void setPrintTime(uint32_t elapsedTime);
 uint32_t getPrintTime(void);
-void getPrintTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec);
 
 void setPrintRemainingTime(int32_t remainingTime);  // used for M73 Rxx and M117 Time Left xx
 void parsePrintRemainingTime(char * buffer);        // used for M117 Time Left xx
 uint32_t getPrintRemainingTime();
-void getPrintRemainingTimeDetail(uint8_t * hour, uint8_t * min, uint8_t * sec);
 
 void setPrintLayerNumber(uint16_t layerNumber);
 uint16_t getPrintLayerNumber();

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -188,7 +188,7 @@ void ParseACKJsonParser::value(const char *value)
       strcpy(m291_title, value);
       break;
     case mbox_timeo:
-      m291_timeo = strtod((char *)value, NULL) * 1000;
+      m291_timeo = SEC_TO_MS(strtod((char *)value, NULL));
       break;
     case resp:
       if (strstr(value, (char *)"Steps/"))       //parse M92

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -235,7 +235,7 @@ bool heatGetSendWaiting(uint8_t index)
 
 void updateNextHeatCheckTime(void)
 {
-  nextHeatCheckTime = OS_GetTimeMs() + heat_update_seconds * 1000;
+  nextHeatCheckTime = OS_GetTimeMs() + SEC_TO_MS(heat_update_seconds);
 }
 
 void loopCheckHeater(void)

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1273,7 +1273,7 @@
  * Toast Notification Duration (in MilliSeconds)
  * Set the duration for displaying toast notification on top of the screen.
  */
-#define TOAST_DURATION (3 * 1000)  // in ms. Default: 3 * 1000
+#define TOAST_DURATION 3  // in sec. Default: 3
 
 /**
  * Keyboard On Left Side (Mesh Editor, LED Color Custom)

--- a/TFT/src/User/Menu/Popup.h
+++ b/TFT/src/User/Menu/Popup.h
@@ -37,9 +37,9 @@ void _setDialogCancelTextLabel(int16_t index);
 #define setDialogOkText(x) _Generic(((x+0)), const uint8_t*: _setDialogOkTextStr, \
                                                    uint8_t*: _setDialogOkTextStr, \
                                                     default: _setDialogOkTextLabel)(x)
-#define setDialogCancelText(x)  _Generic(((x+0)), const uint8_t*: _setDialogCancelTextStr, \
-                                                        uint8_t*: _setDialogCancelTextStr, \
-                                                         default: _setDialogCancelTextLabel)(x)
+#define setDialogCancelText(x) _Generic(((x+0)), const uint8_t*: _setDialogCancelTextStr, \
+                                                       uint8_t*: _setDialogCancelTextStr, \
+                                                        default: _setDialogCancelTextLabel)(x)
 
 //set text from LABEL index or pointer (uint8_t*)
 #define setDialogText(title, msg, oktext, canceltext) \

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -52,10 +52,11 @@ const uint8_t printingIcon2nd[] = {ICON_PRINTING_CHAMBER, ICON_PRINTING_FLOW};
 
 const char *const speedId[2] = {"Speed", "Flow "};
 
-#define TOGGLE_TIME    2000  // 1 seconds is 1000
-#define LAYER_DELTA    0.1   // minimal layer height change to update the layer display (avoid congestion in vase mode)
-#define LAYER_TITLE    "Layer"
-#define MAX_TITLE_LEN  70
+#define TOGGLE_TIME     2000  // 1 seconds is 1000
+#define LAYER_DELTA     0.1  // minimal layer height change to update the layer display (avoid congestion in vase mode)
+#define LAYER_TITLE     "Layer"
+#define MAX_TITLE_LEN   70
+#define TIME_FORMAT_STR "%02u:%02u:%02u"
 
 bool hasFilamentData;
 PROGRESS_DISPLAY progDisplayType;
@@ -228,21 +229,11 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
         break;
 
       case ICON_POS_TIM:
-      {
         if ((getPrintRemainingTime() == 0) || (progDisplayType != ELAPSED_REMAINING))
-        {
-          uint8_t printProgress = getPrintProgress();
-          snprintf(tempstrTop, 9, "%d%%      ", printProgress);
-        }
+          snprintf(tempstrTop, 9, "%d%%      ", getPrintProgress());
         else
-        {
-          uint8_t hour, min, sec;
-
-          getPrintTimeDetail(&hour, &min, &sec);
-          sprintf(tempstrTop, "%02u:%02u:%02u", hour, min, sec);
-        }
+          timeToString(tempstrTop, TIME_FORMAT_STR, getPrintTime());
         break;
-      }
 
       case ICON_POS_Z:
         if (layerDisplayType == SHOW_LAYER_BOTH)
@@ -293,16 +284,10 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
         break;
 
       case ICON_POS_TIM:
-        {
-          uint8_t hour, min, sec;
-
-          if ((getPrintRemainingTime() == 0) || (progDisplayType == PERCENTAGE_ELAPSED))
-            getPrintTimeDetail(&hour, &min, &sec);
-          else
-            getPrintRemainingTimeDetail(&hour, &min, &sec);
-
-          sprintf(tempstrBottom, "%02u:%02u:%02u", hour, min, sec);
-        }
+        if ((getPrintRemainingTime() == 0) || (progDisplayType == PERCENTAGE_ELAPSED))
+          timeToString(tempstrBottom, TIME_FORMAT_STR, getPrintTime());
+        else
+          timeToString(tempstrBottom, TIME_FORMAT_STR, getPrintRemainingTime());
         break;
 
       case ICON_POS_Z:
@@ -367,7 +352,7 @@ static inline void toggleInfo(void)
     speedQuery();
 
     if (infoFile.source >= FS_ONBOARD_MEDIA)
-      coordinateQuery(TOGGLE_TIME / 1000);
+      coordinateQuery(MS_TO_SEC(TOGGLE_TIME));
 
     if (!hasFilamentData && isPrinting())
       updatePrintUsedFilament();
@@ -458,13 +443,10 @@ void stopConfirm(void)
 
 void printSummaryPopup(void)
 {
-  uint8_t hour = infoPrintSummary.time / 3600;
-  uint8_t min = infoPrintSummary.time % 3600 / 60;
-  uint8_t sec = infoPrintSummary.time % 60;
   char showInfo[150];
   char tempstr[30];
 
-  sprintf(showInfo, (char*)textSelect(LABEL_PRINT_TIME), hour, min, sec);
+  timeToString(showInfo, (char*)textSelect(LABEL_PRINT_TIME), infoPrintSummary.time);
 
   if (infoPrintSummary.length + infoPrintSummary.weight + infoPrintSummary.cost == 0)  // all  equals 0
   {
@@ -534,9 +516,9 @@ void menuPrinting(void)
   }
   else  // returned to this menu after a print was done (ex: after a popup)
   {
-    printingItems.items[KEY_ICON_4] = itemIsPrinting[1];  // MainScreen
-    printingItems.items[KEY_ICON_5] = itemIsPrinting[0];  // BackGround
-    printingItems.items[KEY_ICON_6] = itemIsPrinting[0];  // BackGround
+    printingItems.items[KEY_ICON_4] = itemIsPrinting[1];  // Main Screen
+    printingItems.items[KEY_ICON_5] = itemIsPrinting[0];  // Background
+    printingItems.items[KEY_ICON_6] = itemIsPrinting[0];  // Background
     printingItems.items[KEY_ICON_7] = itemIsPrinting[2];  // Back
   }
 

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -273,7 +273,7 @@ static inline void toggleTool(void)
     drawStatus();
 
     // gcode queries must be call after drawStatus
-    coordinateQuery(UPDATE_TOOL_TIME / 1000);
+    coordinateQuery(MS_TO_SEC(UPDATE_TOOL_TIME));
     speedQuery();
     ctrlFanQuery();
   }

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -3,6 +3,7 @@
 #include "my_misc.h"
 #include <stddef.h>
 #include <string.h>
+#include "printf/printf.h"
 
 uint8_t inRange(int cur, int tag , int range)
 {
@@ -138,6 +139,16 @@ double stringToDouble(char *str, char **endptr)
     *endptr = p;  // asign pointer to remaining string
 
   return val * sign;
+}
+
+// convert time to string with given formatting
+void timeToString(char * buf, char *strFormat, uint32_t time)
+{
+  uint8_t hour = HOURS(time);
+  uint8_t min = MINUTES(time);
+  uint8_t sec = SECONDS(time);
+
+  sprintf(buf,strFormat, hour, min, sec);
 }
 
 // strip out any leading " ", "/" or ":" character that might be in the string

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -55,6 +55,10 @@ extern "C" {
 #define MIN_TO_SEC(t) (t * 60)             // minute to seconds
 #define MIN_TO_MS(t)  (SEC_TO_MS(t) * 60)  // minute to milliseconds
 
+#define HOURS(t)   (t / (60 * 60))      // hours completed
+#define MINUTES(t) (t % (60 * 60) / 60) // minutes remaining to next hour
+#define SECONDS(t) (t % 60)             // seconds remaining to next minute
+
 #define strtod stringToDouble  // enable light weight string to double function without exponential support
 
 uint8_t inRange(int cur, int tag , int range);
@@ -65,6 +69,8 @@ uint8_t *uint8_2_string(uint8_t num, uint8_t *string);
 uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);
 uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string);
 double stringToDouble(char *str, char **endptr);
+void timeToString(char * buf, char *strFormat, uint32_t time);
+
 const char *stripHead(const char *str);  // strip out any leading " ", "/" or ":" character that might be in the string
 void stripChecksum(char *str);           // strip out any trailing checksum that might be in the string
 uint8_t getChecksum(char *str);

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -49,6 +49,12 @@ extern "C" {
 // Flip all bits
 #define FLIP_BITS(num) ~num
 
+// Time conversion
+#define SEC_TO_MS(t)  (t * 1000)           // seconds to milliseconds
+#define MS_TO_SEC(t)  (t / 1000)           // milliseconds to seconds
+#define MIN_TO_SEC(t) (t * 60)             // minute to seconds
+#define MIN_TO_MS(t)  (SEC_TO_MS(t) * 60)  // minute to milliseconds
+
 #define strtod stringToDouble  // enable light weight string to double function without exponential support
 
 uint8_t inRange(int cur, int tag , int range);


### PR DESCRIPTION
- Add macros for converting time durations to/from milliseconds, instead of using *1000 or /1000 every time. 
- Add function to convert time duration to a formatted time string.
- Remove duplicate code and reduce the size of some const.
- Misc clean up.