### PR TITLE
Fix screen freeze and wrong icon draw in heat menu after #2448

### DIFF
--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -94,7 +94,7 @@ void bmpToBuffer(uint16_t *buf, GUI_POINT startPoint, GUI_POINT endPoint, BMP_IN
 
 void getBMPsize(BMP_INFO *bmp)
 {
-  if (!bmp->address && bmp->index)
+  if (!bmp->address && bmp->index < ICON_NULL)
     bmp->address = ICON_ADDR(bmp->index);
 
   W25Qxx_ReadBuffer((uint8_t*)&bmp->width, bmp->address, COLOR_BYTE_SIZE);
@@ -106,7 +106,7 @@ void getBMPsize(BMP_INFO *bmp)
 // draw an image from specific address on flash (sx & sy cordinates for top left of image, w width, h height, addr flash byte address)
 void IMAGE_ReadDisplay(uint16_t sx, uint16_t sy, uint32_t address)
 {
-  BMP_INFO bmpInfo = {.address = address};
+  BMP_INFO bmpInfo = {.index = ICON_NULL,.address = address};
 
   getBMPsize(&bmpInfo);
   lcd_frame_display(sx, sy, bmpInfo.width, bmpInfo.height, bmpInfo.address);

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -19,12 +19,12 @@ static inline void drawProbeAccuracyIcon(MENUITEMS * levelItems)
   uint8_t index = 4;
   GUI_POINT loc;
   LIVE_INFO lvIcon;
-  const ITEM * menuitem = &levelItems->items[valIconIndex[index]];
   char * str = "M48";
 
   loc.x = 5;
   loc.y = ICON_HEIGHT - 5;
 
+  lvIcon.iconIndex = levelItems->items[valIconIndex[index]].icon;
   lvIcon.enabled[0] = true;
   lvIcon.enabled[1] = true;
   lvIcon.enabled[2] = false;
@@ -46,7 +46,7 @@ static inline void drawProbeAccuracyIcon(MENUITEMS * levelItems)
   lvIcon.lines[0].text = (uint8_t *)str;
   lvIcon.lines[1].text = (uint8_t *)str;
 
-  showLiveInfo(valIconIndex[index], &lvIcon, menuitem);
+  showLiveInfo(valIconIndex[index], &lvIcon, false);
 }
 
 void menuLevelCorner(void)

--- a/TFT/src/User/Menu/MeshValid.c
+++ b/TFT/src/User/Menu/MeshValid.c
@@ -27,7 +27,7 @@ void menuMeshValid(void)
 
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
-    refreshPreheatIcon(&preheatStore, i, &meshValidItems.items[i]);
+    refreshPreheatIcon(&preheatStore, i, false);
   }
 
   while (MENU_IS(menuMeshValid))
@@ -51,7 +51,7 @@ void menuMeshValid(void)
         mustStoreCmd("G26 H%u B%u R99\n", preheatStore.preheat_temp[key_num], preheatStore.preheat_bed[key_num]);
         mustStoreCmd("G1 Z10 F%d\n", infoSettings.level_feedrate[FEEDRATE_Z]);
         mustStoreCmd("G1 X0 F%d\n", infoSettings.level_feedrate[FEEDRATE_XY]);
-        refreshPreheatIcon(&preheatStore, key_num, &meshValidItems.items[key_num]);
+        refreshPreheatIcon(&preheatStore, key_num, false);
         break;
 
       case KEY_ICON_7:

--- a/TFT/src/User/Menu/PreheatMenu.c
+++ b/TFT/src/User/Menu/PreheatMenu.c
@@ -18,9 +18,10 @@ const ITEM itemToolPreheat[] = {
 };
 
 // Redraw Preheat icon details
-void refreshPreheatIcon(PREHEAT_STORE * preheatStore, int8_t index, const ITEM * menuitem)
+void refreshPreheatIcon(PREHEAT_STORE * preheatStore, uint8_t index, bool redrawIcon)
 {
   LIVE_INFO lvIcon;
+  lvIcon.iconIndex = ICON_PREHEAT;
   lvIcon.enabled[0] = true;
   lvIcon.enabled[1] = true;
   lvIcon.enabled[2] = true;
@@ -58,7 +59,7 @@ void refreshPreheatIcon(PREHEAT_STORE * preheatStore, int8_t index, const ITEM *
   lvIcon.lines[1].text = (uint8_t *)temptool;
   lvIcon.lines[2].text = (uint8_t *)tempbed;
 
-  showLiveInfo(index, &lvIcon, menuitem);
+  showLiveInfo(index, &lvIcon, redrawIcon);
 }
 
 void menuPreheat(void)
@@ -90,7 +91,7 @@ void menuPreheat(void)
 
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
-    refreshPreheatIcon(&preheatStore, i, &preheatItems.items[i]);
+    refreshPreheatIcon(&preheatStore, i, false);
   }
 
   while (MENU_IS(menuPreheat))
@@ -119,7 +120,7 @@ void menuPreheat(void)
             heatSetTargetTemp(heatGetCurrentHotend(), preheatStore.preheat_temp[key_num]);
             break;
         }
-        refreshPreheatIcon(&preheatStore, key_num, &preheatItems.items[key_num]);
+        refreshPreheatIcon(&preheatStore, key_num, false);
         break;
 
       case KEY_ICON_6:

--- a/TFT/src/User/Menu/PreheatMenu.h
+++ b/TFT/src/User/Menu/PreheatMenu.h
@@ -16,7 +16,7 @@ typedef enum
   NOZZLE0_PREHEAT = 2,
 } TOOLPREHEAT;
 
-void refreshPreheatIcon(PREHEAT_STORE * preheatStore, int8_t index, const ITEM * menuitem);
+void refreshPreheatIcon(PREHEAT_STORE * preheatStore, uint8_t index, bool redrawIcon);
 void menuPreheat(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
- Fix outdated live info code in preheat menu and level cornet menu resulting in freeze after #2448.
- Fix wrong icon draw while pressing heat icon.

Resolves: #2468 