### PR TITLE
Avoid redrawing confused or wrong title, which will freeze the pop-up menu

### DIFF
--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -95,6 +95,7 @@ void popupDrawPage(DIALOG_TYPE type, BUTTON * btn, const uint8_t * title, const 
 
 void menuDialog(void)
 {
+  menuSetTitle(NULL);
   while (MENU_IS(menuDialog))
   {
     uint16_t key_num = KEY_GetValue(buttonNum, cur_btn_rect);

--- a/TFT/src/User/Menu/PrintRestore.c
+++ b/TFT/src/User/Menu/PrintRestore.c
@@ -6,6 +6,7 @@ void menuPrintRestore(void)
   uint16_t key_num = IDLE_TOUCH;
 
   GUI_Clear(infoSettings.bg_color);
+  menuSetTitle(NULL);
 
   GUI_DispString((LCD_WIDTH - GUI_StrPixelWidth(LABEL_LOADING)) / 2, LCD_HEIGHT / 2 - BYTE_HEIGHT, LABEL_LOADING);
 


### PR DESCRIPTION
### Description
* Avoid redrawing confused or wrong title, which will freeze the pop-up menu
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
