### PR TITLE
Moved BLTouch HS mode query

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -253,7 +253,12 @@ void setupMachine(FW_TYPE fwType)
     mustStoreCmd("M552\n");  // query network state, populate IP if the screen boots up after RRF
     return;
   }
-
+  else if (infoMachineSettings.firmwareType == FW_MARLIN)
+  {
+    mustStoreCmd("M401 H\n");  // check the state of BLTouch HighSpeed mode
+    mustStoreCmd("M402\n");    // if Marlin version has no BLTouch HS mode report capability the probe will deploy by "M401 H" so it needs to be stowed back
+  }
+  
   mustStoreCmd("M503 S0\n");
 
   if (infoSettings.hotend_count > 0)

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -435,8 +435,6 @@ void parseACK(void)
                                // avoid can't getting this parameter due to disabled M503 in Marlin
         storeCmd("M211\n");    // retrieve the software endstops state
         storeCmd("M115\n");    // as last command to identify the FW type!
-        storeCmd("M401 H\n");  // check the state of BLTouch HighSpeed mode
-        storeCmd("M402\n");    // if Marlin is older than 12.III.2022 BLTouch probe will deploy by "M401 H" so it needs to be stowed back
       }
 
       infoHost.connected = true;


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

Moved BLTouch HS mode query so it takes place only if FW type is Marlin.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Non Marlin firmware wouldn't benefit from BLTouch HS mode query.