### PR TITLE
Improve Tune Extruder for Delta printers

### DIFF
--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -56,8 +56,7 @@ static inline void extrudeFilament(void)
 
   // Raise Z axis to pause height
   #if DELTA_PROBE_TYPE != 0
-    mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) - infoSettings.pause_z_raise,
-                 infoSettings.pause_feedrate[FEEDRATE_Z]);
+    mustStoreCmd("G0 Z200 F%d\n", infoSettings.pause_feedrate[FEEDRATE_Z]);
   #else
     mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) + infoSettings.pause_z_raise,
                  infoSettings.pause_feedrate[FEEDRATE_Z]);


### PR DESCRIPTION
For better accessibility and better access to measurement (with Vernier caliper or a ruler), hotend is now moved at 200 mm height when tune extruder for Delta printers.