### PR TITLE
Auto resume by host action command

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -715,11 +715,11 @@ void setPrintPause(HOST_STATUS hostStatus, PAUSE_TYPE pauseType)
   // in case print was completed or printAbort() is aborting the print,
   // nothing to do (infoHost.status must be set to "HOST_STATUS_IDLE"
   // in case it is "HOST_STATUS_STOPPING" just to finalize the print abort)
-  if (infoHost.status <= HOST_STATUS_STOPPING)
-  {
-    infoHost.status = HOST_STATUS_IDLE;  // wakeup printAbort() if waiting for print completion
-    return;
-  }
+  // if (infoHost.status <= HOST_STATUS_STOPPING)
+  // {
+  //   infoHost.status = HOST_STATUS_IDLE;  // wakeup printAbort() if waiting for print completion
+  //   return;
+  // }
 
   if (infoPrinting.printing)
   {
@@ -740,8 +740,8 @@ void setPrintResume(HOST_STATUS hostStatus)
 {
   // in case print was completed or printAbort() is aborting the print,
   // nothing to do (infoHost.status must never be changed)
-  if (infoHost.status <= HOST_STATUS_STOPPING)
-    return;
+  // if (infoHost.status <= HOST_STATUS_STOPPING)
+  //   return;
 
   // no need to check it is printing when setting the value to "false"
   infoPrinting.pause = false;


### PR DESCRIPTION
### Description


When filament runout sensor is inserted to motherboard, And printing start from TFT SD or USB, TFT sends `M75` to the mainboard to notify the motherboard to start detecting filament runout sensor.

After the motherboard detects the filament runout, it will notifies TFT by `host action command` and TFT printing will be paused by `setRunoutAlarmTrue()`.  since `infoHost.status` of TFT is always `HOST_STATUS_IDLE`, printing cannot be resumed automatically by  `setPrintResume()`
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
