### PR TITLE
Added Layer Left in Printing from Host API

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ OctoPrint, ESP3D, Pronterface etc, connected to a TFT's or mainboard's serial po
 | **pause**                   | `M118 A1 P0 action:pause`                                                                                                                                                                                   |
 | **resume**                  | `M118 A1 P0 action:resume`                                                                                                                                                                                  |
 | **time remaining progress** | `M118 A1 P0 action:notification Time Left <XX>h<YY>m<ZZ>s`<br>or<br>`M117 Time Left <XX>h<YY>m<ZZ>s`<br><br>Examples:<br>`M118 A1 P0 action:notification Time Left 02h04m06s`<br>`M117 Time Left 02h04m06s` |
+| **print layer progress**    | `M118 A1 P0 action:notification Layer Left <XXXX>/<YYYY>`<br>or<br>`M117 Layer Left <XXXX>/<YYYY>`<br><br>Examples:<br>`M118 A1 P0 action:notification Layer Left 51/940`<br>`M117 Layer Left 51/940`       |
 | **file data progress**      | `M118 A1 P0 action:notification Data Left <XXXX>/<YYYY>`<br>or<br>`M117 Data Left <XXXX>/<YYYY>`<br><br>Examples:<br>`M118 A1 P0 action:notification Data Left 123/12345`<br>`M117 Data Left 123/12345`     |
 
 When the trigger `print_start` is received, the TFT switches to **Printing** menu.
@@ -558,7 +559,9 @@ Once on Printing menu, the **pause**, **resume** and **stop** buttons on the men
 That means, only the remote host will control the print.
 Only on print end or cancel (with triggers `print_end` or `cancel`) the TFT Printing menu is finalized (statistics available etc.) and unlocked (the menu can be closed).
 
-**NOTE:** A new plugin on OctoPrint implementing the above protocol should be the preferable way (available to everyone).
+**NOTES:**
+- A new plugin on OctoPrint implementing the above protocol should be the preferable way (available to everyone)
+- With the exception of TFT70, the maximum number of displayable layer count is 999 (there's no space to display layer number and count if the layer count is above 999)
 
 ### Adding Gcode Thumbnails
 

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -712,19 +712,19 @@ void setPrintAbort(void)
 
 void setPrintPause(HOST_STATUS hostStatus, PAUSE_TYPE pauseType)
 {
-  // in case print was completed or printAbort() is aborting the print,
-  // nothing to do (infoHost.status must be set to "HOST_STATUS_IDLE"
-  // in case it is "HOST_STATUS_STOPPING" just to finalize the print abort)
-  if (infoHost.status <= HOST_STATUS_STOPPING)
-  {
-    infoHost.status = HOST_STATUS_IDLE;  // wakeup printAbort() if waiting for print completion
-    return;
-  }
-
   if (infoPrinting.printing)
   {
     infoPrinting.pause = true;
     infoPrinting.pauseType = pauseType;
+  }
+
+  // in case host is not printing, print was completed or printAbort() is aborting the print,
+  // nothing to do (infoHost.status must be set to "HOST_STATUS_IDLE" in case it is
+  // "HOST_STATUS_STOPPING" just to finalize the print abort)
+  if (infoHost.status <= HOST_STATUS_STOPPING)
+  {
+    infoHost.status = HOST_STATUS_IDLE;  // wakeup printAbort() if waiting for print completion
+    return;
   }
 
   // in case of printing from Marlin Mode (infoPrinting.printing set to "false") or printing from remote host
@@ -738,13 +738,13 @@ void setPrintPause(HOST_STATUS hostStatus, PAUSE_TYPE pauseType)
 
 void setPrintResume(HOST_STATUS hostStatus)
 {
-  // in case print was completed or printAbort() is aborting the print,
+  // no need to check it is printing when setting the value to "false"
+  infoPrinting.pause = false;
+
+  // in case host is not printing, print was completed or printAbort() is aborting the print,
   // nothing to do (infoHost.status must never be changed)
   if (infoHost.status <= HOST_STATUS_STOPPING)
     return;
-
-  // no need to check it is printing when setting the value to "false"
-  infoPrinting.pause = false;
 
   // in case of printing from Marlin Mode (infoPrinting.printing set to "false") or printing from remote host
   // (e.g. OctoPrint) or infoSettings.m27_active set to "false", infoHost.status is always forced to

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -49,10 +49,12 @@ bool isNotEmptyCmdQueue(void)
 bool isEnqueued(const CMD cmd)
 {
   bool found = false;
+
   for (int i = 0; i < infoCmd.count && !found; ++i)
   {
     found = strcmp(cmd, infoCmd.queue[(infoCmd.index_r + i) % CMD_QUEUE_SIZE].gcode) == 0;
   }
+
   return found;
 }
 
@@ -127,6 +129,7 @@ void mustStoreScript(const char * format, ...)
   char * p = script;
   uint16_t i = 0;
   CMD cmd;
+
   for (;;)
   {
     char c = *p++;
@@ -190,6 +193,7 @@ bool moveCacheToCmd(void)
   storeCmd("%s", infoCacheCmd.queue[infoCacheCmd.index_r].gcode);
   infoCacheCmd.count--;
   infoCacheCmd.index_r = (infoCacheCmd.index_r + 1) % CMD_QUEUE_SIZE;
+
   return true;
 }
 
@@ -232,8 +236,10 @@ bool sendCmd(bool purge, bool avoidTerminal)
     // dump serial data sent to debug port
     Serial_Puts(SERIAL_DEBUG_PORT, serialPort[cmd_port_index].id);  // serial port ID (e.g. "2" for SERIAL_PORT_2)
     Serial_Puts(SERIAL_DEBUG_PORT, ">>");
+
     if (purge)
       Serial_Puts(SERIAL_DEBUG_PORT, purgeStr);
+
     Serial_Puts(SERIAL_DEBUG_PORT, cmd_ptr);
   #endif
 
@@ -243,6 +249,7 @@ bool sendCmd(bool purge, bool avoidTerminal)
       Serial_Puts(SERIAL_PORT, cmd_ptr);
     else
       rrfSendCmd(cmd_ptr);
+
     setCurrentAckSrc(cmd_port_index);
   }
 
@@ -250,6 +257,7 @@ bool sendCmd(bool purge, bool avoidTerminal)
   {
     if (purge)
       terminalCache(purgeStr, strlen(purgeStr), cmd_port_index, SRC_TERMINAL_GCODE);
+
     terminalCache(cmd_ptr, cmd_len, cmd_port_index, SRC_TERMINAL_GCODE);
   }
 
@@ -288,6 +296,7 @@ static bool cmd_seen(char code)
       return true;
     }
   }
+
   return false;
 }
 
@@ -295,6 +304,17 @@ static bool cmd_seen(char code)
 static int32_t cmd_value(void)
 {
   return (strtol(&cmd_ptr[cmd_index], NULL, 10));
+}
+
+// Get the int after "/", if any.
+static int32_t cmd_second_value(void)
+{
+  char * secondValue = strchr(&cmd_ptr[cmd_index], '/');
+
+  if (secondValue != NULL)
+    return (strtol(secondValue + 1, NULL, 10));
+  else
+    return -0.5;
 }
 
 // Get the float after "code". Call after cmd_seen(code).
@@ -893,9 +913,21 @@ void sendQueueCmd(void)
           break;
 
         case 117:  // M117
-          if (cmd_seen_from(cmd_base_index, "Time Left"))
+          if (cmd_seen_from(cmd_base_index, "Time Left"))  // parsing printing time left
           {
+            // format: Time Left <XX>h<YY>m<ZZ>s (e.g. Time Left 02h04m06s)
             parsePrintRemainingTime(&cmd_ptr[cmd_index]);  // cmd_index was set by cmd_seen_from function
+          }
+          else if (cmd_seen_from(cmd_base_index, "Layer Left"))  // parsing printing layer left
+          {
+            // format: Layer Left <XXXX>/<YYYY> (e.g. Layer Left 51/940)
+            setPrintLayerNumber(cmd_value());
+            setPrintLayerCount(cmd_second_value());
+          }
+          else if (cmd_seen_from(cmd_base_index, "Data Left"))  // parsing printing data left
+          {
+            // format: Data Left <XXXX>/<YYYY> (e.g. Data Left 123/12345)
+            setPrintProgress(cmd_value(), cmd_second_value());
           }
           else
           {

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -265,18 +265,15 @@ bool processKnownEcho(void)
     if (knownEcho[i].notifyType == ECHO_NOTIFY_NONE)
       return isKnown;
 
-    //if (forceIgnore[i] == 0)
-    //{
-      if (knownEcho[i].notifyType == ECHO_NOTIFY_TOAST)
-      {
-        addToast(DIALOG_TYPE_INFO, dmaL2Cache);
-      }
-      else if (knownEcho[i].notifyType == ECHO_NOTIFY_DIALOG)
-      {
-        BUZZER_PLAY(SOUND_NOTIFY);
-        addNotification(DIALOG_TYPE_INFO, (char *)magic_echo, (char *)dmaL2Cache + ack_index, true);
-      }
-    //}
+    if (knownEcho[i].notifyType == ECHO_NOTIFY_TOAST)
+    {
+      addToast(DIALOG_TYPE_INFO, dmaL2Cache);
+    }
+    else if (knownEcho[i].notifyType == ECHO_NOTIFY_DIALOG)
+    {
+      BUZZER_PLAY(SOUND_NOTIFY);
+      addNotification(DIALOG_TYPE_INFO, (char *)magic_echo, (char *)dmaL2Cache + ack_index, true);
+    }
   }
 
   return isKnown;

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -110,13 +110,16 @@ bool syncL2CacheFromL1(uint8_t port)
 static bool ack_cmp(const char * str)
 {
   uint16_t i;
+
   for (i = 0; i < dmaL2Cache_len && str[i] != 0; i++)
   {
     if (str[i] != dmaL2Cache[i])
       return false;
   }
+
   if (str[i] != 0)  // if end of str is not reached, there was no match
     return false;
+
   return true;
 }
 
@@ -134,12 +137,14 @@ static bool ack_seen(const char * str)
   {
     for (i = 0; i < str_len && str[i] == dmaL2Cache[ack_index + i]; i++)
     {}
+
     if (i == str_len)  // if end of str is reached, a match was found
     {
       ack_index += i;
       return true;
     }
   }
+
   return false;
 }
 
@@ -158,12 +163,14 @@ static bool ack_continue_seen(const char * str)
   {
     for (i = 0; i < str_len && str[i] == dmaL2Cache[ack_index + i]; i++)
     {}
+
     if (i == str_len)  // if end of str is reached, a match was found
     {
       ack_index += i;
       return true;
     }
   }
+
   ack_index = ack_index_orig;
   return false;
 }
@@ -173,28 +180,32 @@ static float ack_value()
   return (strtod(&dmaL2Cache[ack_index], NULL));
 }
 
-// read the value after "/", if exists
+// read the value after "/", if any
 static float ack_second_value()
 {
   char * secondValue = strchr(&dmaL2Cache[ack_index], '/');
+
   if (secondValue != NULL)
-  {
     return (strtod(secondValue + 1, NULL));
-  }
   else
-  {
     return -0.5;
-  }
 }
 
 void ack_values_sum(float * data)
 {
   while (((dmaL2Cache[ack_index] < '0') || (dmaL2Cache[ack_index] > '9')) && dmaL2Cache[ack_index] != '\n')
+  {
     ack_index++;
+  }
+
   *data += ack_value();
+
   while ((((dmaL2Cache[ack_index] >= '0') && (dmaL2Cache[ack_index] <= '9')) ||
           (dmaL2Cache[ack_index] == '.')) && (dmaL2Cache[ack_index] != '\n'))
+  {
     ack_index++;
+  }
+
   if (dmaL2Cache[ack_index] != '\n')
     ack_values_sum(data);
 }
@@ -202,6 +213,7 @@ void ack_values_sum(float * data)
 void ackPopupInfo(const char * info)
 {
   bool show_dialog = true;
+
   if (MENU_IS(menuTerminal) ||
       (MENU_IS(menuStatus) && info == magic_echo))
     show_dialog = false;
@@ -221,13 +233,9 @@ void ackPopupInfo(const char * info)
 
     // show notification based on notificaiton settings
     if (infoSettings.ack_notification == 1)
-    {
       addNotification(DIALOG_TYPE_INFO, (char *)info, (char *)dmaL2Cache + ack_index, show_dialog);
-    }
     else if (infoSettings.ack_notification == 2)
-    {
       addToast(DIALOG_TYPE_INFO, dmaL2Cache);  // show toast notificaion if turned on
-    }
   }
   else
   {
@@ -256,6 +264,7 @@ bool processKnownEcho(void)
   {
     if (knownEcho[i].notifyType == ECHO_NOTIFY_NONE)
       return isKnown;
+
     //if (forceIgnore[i] == 0)
     //{
       if (knownEcho[i].notifyType == ECHO_NOTIFY_TOAST)
@@ -269,6 +278,7 @@ bool processKnownEcho(void)
       }
     //}
   }
+
   return isKnown;
 }
 
@@ -278,13 +288,21 @@ void hostActionCommands(void)
   {
     uint16_t index = ack_index;  // save the current index for further usage
 
-    if (ack_seen("Data Left"))  // parsing printing data left
-    { // format: Data Left <XXXX>/<YYYY> (e.g. Data Left 123/12345)
-      setPrintProgress(ack_value(), ack_second_value());
-    }
-    else if (ack_seen("Time Left"))  // parsing printing time left
-    { // format: Time Left <XX>h<YY>m<ZZ>s (e.g. Time Left 02h04m06s)
+    if (ack_seen("Time Left"))  // parsing printing time left
+    {
+      // format: Time Left <XX>h<YY>m<ZZ>s (e.g. Time Left 02h04m06s)
       parsePrintRemainingTime((char *)dmaL2Cache + ack_index);
+    }
+    else if (ack_seen("Layer Left"))  // parsing printing layer left
+    {
+      // format: Layer Left <XXXX>/<YYYY> (e.g. Layer Left 51/940)
+      setPrintLayerNumber(ack_value());
+      setPrintLayerCount(ack_second_value());
+    }
+    else if (ack_seen("Data Left"))  // parsing printing data left
+    {
+      // format: Data Left <XXXX>/<YYYY> (e.g. Data Left 123/12345)
+      setPrintProgress(ack_value(), ack_second_value());
     }
     else
     {
@@ -321,9 +339,7 @@ void hostActionCommands(void)
     setPrintPause(HOST_STATUS_PAUSING, PAUSE_EXTERNAL);
 
     if (ack_seen("filament_runout"))
-    {
       setRunoutAlarmTrue();
-    }
   }
   else if (ack_seen(":resume") || ack_seen(":resumed"))
   {
@@ -449,9 +465,9 @@ void parseACK(void)
         requestCommandInfo.inResponse = true;
         requestCommandInfo.inWaitResponse = false;
       }
-      else if ((requestCommandInfo.error_num > 0 && ack_seen(requestCommandInfo.errorMagic[0]))
-            || (requestCommandInfo.error_num > 1 && ack_seen(requestCommandInfo.errorMagic[1]))
-            || (requestCommandInfo.error_num > 2 && ack_seen(requestCommandInfo.errorMagic[2])))
+      else if ((requestCommandInfo.error_num > 0 && ack_seen(requestCommandInfo.errorMagic[0])) ||
+               (requestCommandInfo.error_num > 1 && ack_seen(requestCommandInfo.errorMagic[1])) ||
+               (requestCommandInfo.error_num > 2 && ack_seen(requestCommandInfo.errorMagic[2])))
       { // parse onboard media error
         requestCommandInfo.done = true;
         requestCommandInfo.inResponse = false;
@@ -655,8 +671,11 @@ void parseACK(void)
         // NOTE: this block is not reached in case of printing from onboard media because printStart() will call
         //       request_M23_M36() that will be managed in parseAck() by the block "onboard media gcode command response"
 
+        // parse file name.
+        // Format: "File opened: <file name> Size: <YYYY>" (e.g. "File opened: 1A29A~1.GCO Size: 6974")
+        //
         char file_name[MAX_PATH_LEN];
-        char * end_string = " Size:";  // File opened: 1A29A~1.GCO Size: 6974
+        char * end_string = " Size:";
 
         uint16_t start_index = ack_index;
         uint16_t end_index = ack_continue_seen(end_string) ? (ack_index - strlen(end_string)) : start_index;
@@ -680,10 +699,10 @@ void parseACK(void)
       {
         setPrintResume(HOST_STATUS_PRINTING);
 
-        // parsing printing data
-        // format: SD printing byte <XXXX>/<YYYY> (e.g. SD printing byte 123/12345)
+        // parse file data progress.
+        // Format: "SD printing byte <XXXX>/<YYYY>" (e.g. "SD printing byte 123/12345")
+        //
         setPrintProgress(ack_value(), ack_second_value());
-        //powerFailedCache(position);
       }
       // parse and store M24, printing from (remote) onboard media completed
       else if (infoMachineSettings.onboardSD == ENABLED &&


### PR DESCRIPTION
**IMPROVEMENTS:**
* Added Layer Left to **Printing from Host API** reported in README.MD: It can be used by a remote host (e.g. ESP3D, OctoPrint ect...) to display current print layer number and count. It implements #2486.
* Minor cleanup.

**BUGFIXES:**
* Fixed bug with filament runout on mainboard reported in #2483: After a filament change, the nozzle was moved on top of print and it was needed to press on resume button to resume the print.

resolves #2486
fixes #2483

**PR STATE:** Ready for merge.
