### PR TITLE
Added X and Y coordinates in MBL and Mesh Editor menus

### DIFF
--- a/TFT/src/User/API/coordinate.c
+++ b/TFT/src/User/API/coordinate.c
@@ -105,6 +105,11 @@ void coordinateSetAxisActual(AXIS axis, float position)
   curPosition.axis[axis] = position;
 }
 
+void coordinateGetAllActual(COORDINATE *tmp)
+{
+  memcpy(tmp, &curPosition, sizeof(curPosition));
+}
+
 void coordinateQuerySetWait(bool wait)
 {
   coordinateQueryWait = wait;

--- a/TFT/src/User/API/coordinate.h
+++ b/TFT/src/User/API/coordinate.h
@@ -49,6 +49,7 @@ float coordinateGetExtruderActual(void);
 void coordinateSetExtruderActualSteps(float steps);
 float coordinateGetAxisActual(AXIS axis);
 void coordinateSetAxisActual(AXIS axis, float position);
+void coordinateGetAllActual(COORDINATE *tmp);
 void coordinateQuerySetWait(bool wait);
 void coordinateQuery(uint8_t delay);
 void coordinateQueryTurnOff(void);

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -29,15 +29,17 @@ void zOffsetDraw(bool status, float val)
   {
     sprintf(tempstr, "%-15s", textSelect(itemToggle[status].index));
     sprintf(tempstr3, "%-15s", "");
-    GUI_SetColor(infoSettings.reminder_color);
     sprintf(tempstr2, "  %.2f  ", val);
+
+    GUI_SetColor(infoSettings.reminder_color);
   }
   else
   {
     sprintf(tempstr, "ZO:%.2f  ", val);
     sprintf(tempstr3, "Shim:%.3f", infoSettings.level_z_pos);
-    GUI_SetColor(infoSettings.status_color);
     sprintf(tempstr2, "  %.2f  ", val + infoSettings.level_z_pos);
+
+    GUI_SetColor(infoSettings.status_color);
   }
 
   GUI_DispString(exhibitRect.x0, exhibitRect.y0, (uint8_t *) tempstr);


### PR DESCRIPTION
**IMPROVEMENTS:**
* Added X and Y coordinates in MBL and Mesh Editor menus: It implements #2385.

resolves #2385

**PR STATE:** Ready for merge.

![IMG_20220412_160842](https://user-images.githubusercontent.com/64427768/162990615-8029f70d-b36a-4db4-811b-de07511de5e3.jpg)

![IMG_20220412_161454](https://user-images.githubusercontent.com/64427768/162990660-ba034339-2b9b-4a03-a025-cf1a2556715e.jpg)
