### PR TITLE
Bug fixes on Printing menu + cleanup

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -259,8 +259,8 @@ fan_speed_percentage:1
 #   Options: [disable: 0, enable: 1]
 persistent_info:0
 
-#### Temperature ACK In Terminal
-# Show temperature ACK in Terminal menu.
+#### Temperature And Wait ACK In Terminal
+# Show "temperature" and "wait" ACK in Terminal menu.
 #   Options: [disable: 0, enable: 1]
 terminal_ack:0
 

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -232,8 +232,8 @@ fan_speed_percentage:1
 #   Options: [disable: 0, enable: 1]
 persistent_info:0
 
-#### Temperature ACK In Terminal
-# Show temperature ACK in Terminal menu.
+#### Temperature And Wait ACK In Terminal
+# Show "temperature" and "wait" ACK in Terminal menu.
 #   Options: [disable: 0, enable: 1]
 terminal_ack:0
 

--- a/TFT/src/User/API/Printing.h
+++ b/TFT/src/User/API/Printing.h
@@ -52,7 +52,7 @@ void resumeAndContinue(void);
 void setPrintExpectedTime(uint32_t expectedTime);
 uint32_t getPrintExpectedTime(void);
 
-void adjustPrintTime(uint32_t osTime);
+void updatePrintTime(uint32_t osTime);
 uint32_t getPrintTime(void);
 
 void setPrintRemainingTime(int32_t remainingTime);  // used for M73 Rxx and M117 Time Left xx
@@ -70,13 +70,11 @@ uint32_t getPrintCur(void);
 
 void setPrintProgress(float cur, float size);
 void setPrintProgressPercentage(uint8_t percentage);  // used by M73 Pxx
-void updatePrintProgress(void);
+uint8_t updatePrintProgress(void);
 uint8_t getPrintProgress(void);
 
 void setPrintRunout(bool runout);
 bool getPrintRunout(void);
-
-bool getPrintAborted(void);
 
 //
 // commented because NOT externally invoked
@@ -111,6 +109,7 @@ bool printPause(bool isPause, PAUSE_TYPE pauseType);
 
 bool isPrinting(void);
 bool isPaused(void);
+bool isAborted(void);
 bool isTFTPrinting(void);
 bool isHostPrinting(void);
 bool isRemoteHostPrinting(void);

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -1228,9 +1228,6 @@ void loopCheckBackPress(void)
 
           infoMenu.menu[1] = infoMenu.menu[infoMenu.cur];  // prepare menu tree for jump to 0
           infoMenu.cur = 1;
-
-          if (infoMenu.menu[1] == menuPrinting)
-            clearInfoFile();
         }
       }
     }

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1208,7 +1208,7 @@ void parseACK(void)
     }
 
   parse_end:
-    if (avoid_terminal != true && MENU_IS(menuTerminal))
+    if (!avoid_terminal && MENU_IS(menuTerminal))
     {
       terminalCache(dmaL2Cache, dmaL2Cache_len, ack_port_index, SRC_TERMINAL_ACK);
     }

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -214,8 +214,8 @@
 #define PERSISTENT_INFO 0  // Default: 0
 
 /**
- * Temperature ACK In Terminal
- * Show temperature ACK in Terminal menu.
+ * Temperature And Wait ACK In Terminal
+ * Show "temperature" and "wait" ACK in Terminal menu.
  *   Options: [disable: 0, enable: 1]
  */
 #define TERMINAL_ACK 0  // Default: 0
@@ -1081,7 +1081,7 @@
 #define SPEED_ID {"Sp.", "Fr."}  // (speed, flow rate)
 
 // Axes names displayed in Parameter Settings menu
-#define AXIS_DISPLAY_ID    {"X", "Y", "Z", "E0", "E1"}                    // (X, Y, Z, E0, E1)
+#define AXIS_DISPLAY_ID    {"X", "Y", "Z", "E0", "E1"}                                // (X, Y, Z, E0, E1)
 #define STEPPER_DISPLAY_ID {"X", "X2", "Y", "Y2", "Z", "Z2", "Z3", "Z4", "E0", "E1"}  // (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
 
 // Manual Leveling

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -10,11 +10,11 @@ const GUI_RECT printinfo_val_rect[6] = {
   {PS_ICON_VAL_X, PS_ICON_VAL_Y, PS_ICON_VAL_SM_EX, PS_ICON_VAL_Y + BYTE_HEIGHT}
 };
 
-#define PROGRESS_BAR_RAW_X0   (START_X)                             // X0 aligned to first icon
+#define PROGRESS_BAR_RAW_X0   (START_X)                                 // X0 aligned to first icon
 #ifdef PORTRAIT_MODE
-  #define PROGRESS_BAR_RAW_X1 (START_X + 3*ICON_WIDTH + 2*SPACE_X)  // X1 aligned to last icon
+  #define PROGRESS_BAR_RAW_X1 (START_X + 3 * ICON_WIDTH + 2 * SPACE_X)  // X1 aligned to last icon
 #else
-  #define PROGRESS_BAR_RAW_X1 (START_X + 4*ICON_WIDTH + 3*SPACE_X)  // X1 aligned to last icon
+  #define PROGRESS_BAR_RAW_X1 (START_X + 4 * ICON_WIDTH + 3 * SPACE_X)  // X1 aligned to last icon
 #endif
 
 #ifdef MARKED_PROGRESS_BAR
@@ -50,10 +50,10 @@ const uint8_t printingIcon[] = {ICON_PRINTING_NOZZLE, ICON_PRINTING_BED,    ICON
 
 const uint8_t printingIcon2nd[] = {ICON_PRINTING_CHAMBER, ICON_PRINTING_FLOW};
 
-const char *const speedId[2] = {"Speed", "Flow "};
+const char * const speedId[2] = {"Speed", "Flow "};
 
-#define TOGGLE_TIME     2000  // 1 seconds is 1000
-#define LAYER_DELTA     0.1  // minimal layer height change to update the layer display (avoid congestion in vase mode)
+#define TOGGLE_TIME     2000     // 1 seconds is 1000
+#define LAYER_DELTA     0.1      // minimal layer height change to update the layer display (avoid congestion in vase mode)
 #define LAYER_TITLE     "Layer"
 #define MAX_TITLE_LEN   70
 #define TIME_FORMAT_STR "%02u:%02u:%02u"
@@ -97,14 +97,11 @@ static void setLayerHeightText(char * layer_height_txt)
 {
   float layer_height;
   layer_height = coordinateGetAxis(Z_AXIS);
+
   if (layer_height > 0)
-  {
     sprintf(layer_height_txt, "%6.2fmm", layer_height);
-  }
   else
-  {
     strcpy(layer_height_txt, " --- mm ");  // leading and trailing space char so the text is centered on both rows
-  }
 }
 
 static void setLayerNumberTxt(char * layer_number_txt)
@@ -134,7 +131,7 @@ static void setLayerNumberTxt(char * layer_number_txt)
 }
 
 // initialize printing info before opening Printing menu
-void initMenuPrinting(void)
+static void initMenuPrinting(void)
 {
   getPrintTitle(title, MAX_TITLE_LEN);  // get print title according to print originator (remote or local to TFT)
   clearInfoFile();                      // as last, clear and free memory for file list
@@ -172,6 +169,7 @@ void startPrint(void)
     // in case the calling function is menuPrintFromSource,
     // remove the filename from path to allow the files scanning from its folder avoiding a scanning error message
     exitFolder();
+
     return;
   }
 
@@ -188,10 +186,10 @@ void startPrint(void)
   OPEN_MENU(menuPrinting);
 }
 
-static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
+static void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
 {
   LIVE_INFO lvIcon;
-  GUI_RECT const *curRect = &printinfo_val_rect[icon_pos];
+  GUI_RECT const * curRect = &printinfo_val_rect[icon_pos];
   char tempstrTop[14];
   char tempstrBottom[14];
 
@@ -213,20 +211,20 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
     lvIcon.lines[0].font = FONT_SIZE_NORMAL;
     lvIcon.lines[0].fn_color = infoSettings.font_color;
     lvIcon.lines[0].text_mode = GUI_TEXTMODE_TRANS;
-    lvIcon.lines[0].text = (uint8_t*)tempstrTop;
+    lvIcon.lines[0].text = (uint8_t *)tempstrTop;
 
     switch (icon_pos)
     {
       case ICON_POS_EXT:
-        lvIcon.lines[0].text = (uint8_t*)heatDisplayID[currentTool];
+        lvIcon.lines[0].text = (uint8_t *)heatDisplayID[currentTool];
         break;
 
       case ICON_POS_BED:
-        lvIcon.lines[0].text = (uint8_t*)heatDisplayID[BED + currentBCIndex];
+        lvIcon.lines[0].text = (uint8_t *)heatDisplayID[BED + currentBCIndex];
         break;
 
       case ICON_POS_FAN:
-        lvIcon.lines[0].text = (uint8_t*)fanID[currentFan];
+        lvIcon.lines[0].text = (uint8_t *)fanID[currentFan];
         break;
 
       case ICON_POS_TIM:
@@ -240,9 +238,9 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
         if (layerDisplayType == SHOW_LAYER_BOTH)
           setLayerHeightText(tempstrTop);
         else if (layerDisplayType == CLEAN_LAYER_NUMBER || layerDisplayType == CLEAN_LAYER_BOTH)
-          lvIcon.lines[0].text = (uint8_t*)("        ");
+          lvIcon.lines[0].text = (uint8_t *)("        ");
         else
-          lvIcon.lines[0].text = (uint8_t*)LAYER_TITLE;
+          lvIcon.lines[0].text = (uint8_t *)LAYER_TITLE;
         break;
 
       case ICON_POS_SPD:
@@ -267,7 +265,7 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
     lvIcon.lines[1].font = FONT_SIZE_NORMAL;
     lvIcon.lines[1].fn_color = infoSettings.font_color;
     lvIcon.lines[1].text_mode = GUI_TEXTMODE_TRANS;
-    lvIcon.lines[1].text = (uint8_t*)tempstrBottom;
+    lvIcon.lines[1].text = (uint8_t *)tempstrBottom;
 
     tempstrBottom[0] = 0;  // always initialize to empty string as default value
 
@@ -301,7 +299,7 @@ static inline void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
         else if (layerDisplayType == SHOW_LAYER_NUMBER || layerDisplayType == SHOW_LAYER_BOTH)  // layer number or height & number (both)
           setLayerNumberTxt(tempstrBottom);
         else
-          lvIcon.lines[1].text=  (uint8_t*)("        ");
+          lvIcon.lines[1].text = (uint8_t *)("        ");
         break;
 
       case ICON_POS_SPD:
@@ -364,7 +362,7 @@ static inline void toggleInfo(void)
   }
 }
 
-static inline void reDrawProgressBar(uint8_t prevProgress, uint8_t nextProgress, uint16_t barColor, uint16_t sliceColor)
+static void reDrawProgressBar(uint8_t prevProgress, uint8_t nextProgress, uint16_t barColor, uint16_t sliceColor)
 {
   uint16_t start = (PROGRESS_BAR_FULL_WIDTH * prevProgress) / 100;
   uint16_t end = (PROGRESS_BAR_FULL_WIDTH * nextProgress) / 100;
@@ -389,9 +387,14 @@ static inline void reDrawProgressBar(uint8_t prevProgress, uint8_t nextProgress,
   #endif
 }
 
-static inline void reDrawProgress(uint8_t prevProgress)
+static void reDrawProgress(uint8_t oldProgress)
 {
-  reDrawProgressBar(prevProgress, getPrintProgress(), PB_FILL, PB_STRIPE_ELAPSED);
+  uint8_t newProgress = getPrintProgress();
+
+  if (newProgress > oldProgress)
+    reDrawProgressBar(oldProgress, newProgress, PB_FILL, PB_STRIPE_ELAPSED);
+  else  // if it's a regression, swap indexes and colors
+    reDrawProgressBar(newProgress, oldProgress, PB_BCKG, PB_STRIPE_REMAINING);
 
   if (progDisplayType != ELAPSED_REMAINING)
     reDrawPrintingValue(ICON_POS_TIM, LIVE_INFO_TOP_ROW);
@@ -412,7 +415,7 @@ static inline void drawLiveInfo(void)
   GUI_RestoreColorDefault();
 }
 
-void drawPrintInfo(void)
+static inline void drawPrintInfo(void)
 {
   GUI_SetTextMode(GUI_TEXTMODE_TRANS);
 
@@ -425,7 +428,7 @@ void drawPrintInfo(void)
                           rect_of_keySS[KEY_INFOBOX].y0 + STATUS_MSG_ICON_YOFFSET,
                           rect_of_keySS[KEY_INFOBOX].x1 - STATUS_MSG_TITLE_XOFFSET,
                           rect_of_keySS[KEY_INFOBOX].y1 - STATUS_MSG_ICON_YOFFSET,
-                          (uint8_t *)textSelect((getPrintAborted() == true) ? LABEL_PROCESS_ABORTED : LABEL_PRINT_FINISHED));
+                          (uint8_t *)textSelect((isAborted() == true) ? LABEL_PROCESS_ABORTED : LABEL_PRINT_FINISHED));
 
   GUI_SetColor(INFOMSG_FONT_COLOR);
   GUI_SetBkColor(INFOMSG_BG_COLOR);
@@ -433,24 +436,19 @@ void drawPrintInfo(void)
   GUI_RestoreColorDefault();
 }
 
-void stopConfirm(void)
-{
-  printAbort();
-}
-
 void printSummaryPopup(void)
 {
   char showInfo[150];
   char tempstr[30];
 
-  timeToString(showInfo, (char*)textSelect(LABEL_PRINT_TIME), infoPrintSummary.time);
+  timeToString(showInfo, (char *)textSelect(LABEL_PRINT_TIME), infoPrintSummary.time);
 
-  if (getPrintAborted() == true)
+  if (isAborted() == true)
   {
     sprintf(tempstr, "\n\n%s", (char *)textSelect(LABEL_PROCESS_ABORTED));
     strcat(showInfo, tempstr);
   }
-  else if (infoPrintSummary.length + infoPrintSummary.weight + infoPrintSummary.cost == 0)  // all  equals 0
+  else if (infoPrintSummary.length + infoPrintSummary.weight + infoPrintSummary.cost == 0)  // all equals 0
   {
     strcat(showInfo, (char *)textSelect(LABEL_NO_FILAMENT_STATS));
   }
@@ -461,23 +459,25 @@ void printSummaryPopup(void)
       sprintf(tempstr, (char *)textSelect(LABEL_FILAMENT_LENGTH), infoPrintSummary.length);
       strcat(showInfo, tempstr);
     }
+
     if (infoPrintSummary.weight > 0)
     {
       sprintf(tempstr, (char *)textSelect(LABEL_FILAMENT_WEIGHT), infoPrintSummary.weight);
       strcat(showInfo, tempstr);
     }
+
     if (infoPrintSummary.cost > 0)
     {
       sprintf(tempstr, (char *)textSelect(LABEL_FILAMENT_COST), infoPrintSummary.cost);
       strcat(showInfo, tempstr);
     }
   }
+
   popupReminder(DIALOG_TYPE_INFO, (uint8_t *)infoPrintSummary.name, (uint8_t *)showInfo);
 }
 
 void menuPrinting(void)
 {
-  // 1 title, ITEM_PER_PAGE items (icon + label)
   MENUITEMS printingItems = {
     // title
     LABEL_NULL,
@@ -504,7 +504,6 @@ void menuPrinting(void)
   float prevLayerHeight = 0;
   uint16_t curLayerNumber = 0;
   uint16_t prevLayerNumber = 0;
-
   bool layerDrawEnabled = false;
   bool lastPause = isPaused();
   bool lastPrinting = isPrinting();
@@ -522,7 +521,6 @@ void menuPrinting(void)
     printingItems.items[KEY_ICON_5] = itemIsPrinting[0];  // Background
     printingItems.items[KEY_ICON_6] = itemIsPrinting[0];  // Background
     printingItems.items[KEY_ICON_7] = itemIsPrinting[2];  // Back
-    updatePrintProgress();
   }
 
   printingItems.title.address = title;
@@ -537,7 +535,7 @@ void menuPrinting(void)
 
   while (MENU_IS(menuPrinting))
   {
-    //Scroll_DispString(&titleScroll, LEFT);  // Scroll display file name will take too many CPU cycles
+    //Scroll_DispString(&titleScroll, LEFT);  // scroll display file name will take too many CPU cycles
 
     // check nozzle temp change
     if (nowHeat.T[currentTool].current != heatGetCurrentTemp(currentTool) ||
@@ -556,53 +554,50 @@ void menuPrinting(void)
       reDrawPrintingValue(ICON_POS_BED, LIVE_INFO_BOTTOM_ROW);
     }
 
-    // check Fan speed change
+    // check fan speed change
     if (nowFan[currentFan] != fanGetCurSpeed(currentFan))
     {
       nowFan[currentFan] = fanGetCurSpeed(currentFan);
       reDrawPrintingValue(ICON_POS_FAN, LIVE_INFO_BOTTOM_ROW);
     }
 
-    if (lastPrinting == true)
+    // check print time change
+    if (time != getPrintTime())
     {
-      // check print time change
-      if (time != getPrintTime())
-      {
-        time = getPrintTime();
-        if (progDisplayType == ELAPSED_REMAINING)
-          reDrawPrintingValue(ICON_POS_TIM, LIVE_INFO_TOP_ROW | LIVE_INFO_BOTTOM_ROW);
-        else
-          reDrawPrintingValue(ICON_POS_TIM, LIVE_INFO_BOTTOM_ROW);
-      }
+      time = getPrintTime();
 
-      // check print progress percentage change
-      updatePrintProgress();
-      if (oldProgress < getPrintProgress())
-      {
-        reDrawProgress(oldProgress);
-        oldProgress = getPrintProgress();
-      }
+      if (progDisplayType == ELAPSED_REMAINING)
+        reDrawPrintingValue(ICON_POS_TIM, LIVE_INFO_TOP_ROW | LIVE_INFO_BOTTOM_ROW);
+      else
+        reDrawPrintingValue(ICON_POS_TIM, LIVE_INFO_BOTTOM_ROW);
+    }
+
+    // check print progress percentage change
+    if (oldProgress != updatePrintProgress())
+    {
+      reDrawProgress(oldProgress);
+      oldProgress = getPrintProgress();
     }
 
     // Z_AXIS coordinate
     if (layerDisplayType == SHOW_LAYER_BOTH || layerDisplayType == SHOW_LAYER_HEIGHT)
     {
       curLayerHeight = coordinateGetAxis(Z_AXIS);
+
       if (prevLayerHeight != curLayerHeight)
       {
         if (ABS(curLayerHeight - usedLayerHeight) >= LAYER_DELTA)
-        {
           layerDrawEnabled = true;
-        }
+
         if (layerDrawEnabled == true)
         {
           usedLayerHeight = curLayerHeight;
           reDrawPrintingValue(ICON_POS_Z, (layerDisplayType == SHOW_LAYER_BOTH) ? LIVE_INFO_TOP_ROW : LIVE_INFO_BOTTOM_ROW);
         }
+
         if (ABS(curLayerHeight - prevLayerHeight) < LAYER_DELTA)
-        {
           layerDrawEnabled = false;
-        }
+
         prevLayerHeight = curLayerHeight;
       }
     }
@@ -610,6 +605,7 @@ void menuPrinting(void)
     if (layerDisplayType == SHOW_LAYER_BOTH || layerDisplayType == SHOW_LAYER_NUMBER)
     {
       curLayerNumber = getPrintLayerNumber();
+
       if (curLayerNumber != prevLayerNumber)
       {
         prevLayerNumber = curLayerNumber;
@@ -642,7 +638,7 @@ void menuPrinting(void)
           printSummaryPopup();
       #endif
 
-      return;  // It will restart this interface if directly return this function without modify the value of infoMenu
+      return;  // it will restart this interface if directly return this function without modify the value of infoMenu
     }
 
     toggleInfo();
@@ -671,17 +667,17 @@ void menuPrinting(void)
 
       case PS_KEY_4:
         layerDisplayType++;  // trigger cleaning previous values
+
         if (layerDisplayType != CLEAN_LAYER_HEIGHT)
-        {
           reDrawPrintingValue(ICON_POS_Z, LIVE_INFO_TOP_ROW);
-        }
+
         reDrawPrintingValue(ICON_POS_Z, LIVE_INFO_BOTTOM_ROW);
 
         layerDisplayType = (layerDisplayType + 1) % 6;  // iterate layerDisplayType
+
         if (layerDisplayType != SHOW_LAYER_NUMBER)  // upper row content changes
-        {
           reDrawPrintingValue(ICON_POS_Z, LIVE_INFO_TOP_ROW);
-        }
+
         reDrawPrintingValue(ICON_POS_Z, LIVE_INFO_BOTTOM_ROW);
         break;
 
@@ -701,7 +697,6 @@ void menuPrinting(void)
         }
         else
         { // Main button
-          clearInfoFile();
           infoMenu.cur = 0;
         }
         break;
@@ -724,11 +719,15 @@ void menuPrinting(void)
           else
           {
             setDialogText(LABEL_WARNING, LABEL_STOP_PRINT, LABEL_CONFIRM, LABEL_CANCEL);
-            showDialog(DIALOG_TYPE_ALERT, stopConfirm, NULL, NULL);
+            showDialog(DIALOG_TYPE_ALERT, printAbort, NULL, NULL);
           }
         }
         else
         { // Back button
+          // in case the print was started from menuPrintFromSource menu,
+          // remove the filename from path to allow the files scanning from its folder avoiding a scanning error message
+          exitFolder();
+
           CLOSE_MENU();
         }
         break;

--- a/TFT/src/User/Menu/PrintingMenu.h
+++ b/TFT/src/User/Menu/PrintingMenu.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include <stdbool.h>
 
+extern bool hasFilamentData;
+
 // start print originated or handled by remote host
 // (e.g. print started from remote onboard media or hosted by remote host) and open Printing menu
 void startRemotePrint(const char * filename);
@@ -15,10 +17,8 @@ void startRemotePrint(const char * filename);
 // (e.g. print started from TFT's GUI or hosted by TFT) and open Printing menu
 void startPrint(void);
 
-void menuPrinting(void);
 void printSummaryPopup(void);
-
-extern bool hasFilamentData;
+void menuPrinting(void);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -259,8 +259,8 @@ fan_speed_percentage:1
 #   Options: [disable: 0, enable: 1]
 persistent_info:0
 
-#### Temperature and "wait" ACK In Terminal
-# Show temperature and "wait" ACK in Terminal menu.
+#### Temperature And Wait ACK In Terminal
+# Show "temperature" and "wait" ACK in Terminal menu.
 #   Options: [disable: 0, enable: 1]
 terminal_ack:0
 

--- a/TFT/src/User/os_timer.c
+++ b/TFT/src/User/os_timer.c
@@ -41,7 +41,7 @@ void TIMER6_IRQHandler(void)
 
     os_counter++;
 
-    adjustPrintTime(os_counter);
+    updatePrintTime(os_counter);
 
     loopTouchScreen();
 
@@ -60,7 +60,7 @@ void TIM7_IRQHandler(void)
 
     os_counter++;
 
-    adjustPrintTime(os_counter);
+    updatePrintTime(os_counter);
 
     loopTouchScreen();
 


### PR DESCRIPTION
**BUG FIXES:**
* Elapsed print time stopped during a print pause/filament runtout etc.: The elapsed print time must not be stopped (e.g. as during the heating phase). It measures the total time to reach the print completion not the active time spent to print. Fix done in function updatePrintTime().
* Progress bar on Printing menu not fully supporting a switch from file based progress to Slicer based progress: As also supported by Marlin, the progress bar is now (as it was before one of the last merged PR) properly supporting the switch from file based to slicer based progress (it means the possibility the progress can be reduced). The fix is done in function reDrawProgress() (a function that is expected to be called only 100 times in a whole print). In general, the Printing menu must make no assumption about the Printing API and the Remote Printing API listed in **Printing from Remote Host** section in README.MD. Any value set by the API must be simply displayed by the Printing menu.
* Fixed wrong progress display in case a print is aborted and the progress was controlled by slicer: The progress was set to 0% instead of 100%. Fix done in function printComplete().
* Fixed not 100% progress display when a print is completed: It can happen (in particular with files not big or printing from onboard) that the progress is moved to 100 just when the print is also completed (print status changed to **not printing**). In that case, the latest merged PR will not update the progress to 100% on screen (progress bar and value not updated. E.g. it will remain to 99%). Fix done in function menuPrinting().
* File based progress formula restored to linear function **file_pos(t) / file_size** as also used by any known mainboard firmware (e.g. Marlin). It didn't make any sense to provide a function not linear and variable during the print removing the comments contribution only when they are read from file (all the comments contribution should be removed offline before starting the print (file_size should be constant during the entire print)). The result of that formula was wrong even in case the print is based on a repeated pattern (e.g. 100 bytes of gcode + 100 of comments on a print duration of 100 minutes will provide a 33% (instead of 50%) of progress after 50 minutes while the linear function will always provide the correct value (50% at 50% of the print, 75% at 75% of print etc...).

**MINOR IMPROVEMENTS:**
* Some cleanup:
  * clearInfoFile() not needed when exiting from Printing menu (it was already called in initMenuPrinting() just before starting the print).
  * exitFolder() not needed in Printing API (it is needed by menuPrintFromSource() (if any was used to start the print) so it is called when exiting from Printing menu. It is compliant (it works) with any kind of print (TFT, onboard, remote)).
  * Usual code style review.
* Minor code reduction.

**PR STATE:** Ready for merge.
