### PR TITLE
Fixed #2493, #2509, a possible freeze on Status Screen menu

### DIFF
--- a/TFT/src/User/API/MachineParameters.c
+++ b/TFT/src/User/API/MachineParameters.c
@@ -58,30 +58,30 @@ const char * const parameterCode[PARAMETERS_COUNT] = {
 };
 
 const char * const parameterCmd[PARAMETERS_COUNT][MAX_ELEMENT_COUNT] = {
-  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       "T0 E%.2f\n",   "T1 E%.2f\n", NULL,           NULL,           NULL,           NULL,           NULL},           // Steps/mm (X, Y, Z, E0, E1)
-  {"S%.0f\n",            "S1 T0 D%.2f\n", "S1 T1 D%.2f\n", NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Filament Diameter (Enable, E0, E1)
-  {"X%.0f\n",            "Y%.0f\n",       "Z%.0f\n",       "T0 E%.0f\n",   "T1 E%.0f\n", NULL,           NULL,           NULL,           NULL,           NULL},           // MaxAcceleration (X, Y, Z, E0, E1)
-  {"X%.0f\n",            "Y%.0f\n",       "Z%.0f\n",       "T0 E%.0f\n",   "T1 E%.0f\n", NULL,           NULL,           NULL,           NULL,           NULL},           // MaxFeedrate (X, Y, Z, E0, E1)
-  {"P%.0f\n",            "R%.0f\n",       "T%.0f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Acceleration (Print, Retract, Travel)
-  {"X%.0f\n",            "Y%.0f\n",       "Z%.2f\n",       "E%.2f\n",      NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Jerk (X, Y, Z, E)
-  {"J%.3f\n",            NULL,            NULL,            NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Junction Deviation
-  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Home offset (X, Y, Z)
-  {"S%.2f\n",            "W%.2f\n",       "F%.2f\n",       "Z%.2f\n",      NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // FW retract (Length, Swap Length, Feedrate, Z lift height)
-  {"S%.2f\n",            "W%.2f\n",       "F%.2f\n",       "R%.2f\n",      NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // FW retract recover (Additional length, Additional Swap Length, Feedrate, Swap feedrate)
-  {"S%.0f\n",            NULL,            NULL,            NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Set auto FW retract
-  {"T1 X%.2f\n",         "T1 Y%.2f\n",    "T1 Z%.2f\n",    NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Hotend Offset (X, Y, Z)
-  {"S%.0f\n",            "Z%.2f\n",       NULL,            NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // ABL State & Z Fade
-  {"S%.0f X\n",          "S%.0f I1 X\n",  "S%.0f Y\n",     "S%.0f I1 Y\n", "S%.0f Z\n",  "S%.0f I1 Z\n", "S%.0f I2 Z\n", "S%.0f I3 Z\n", "S%.0f T0 E\n", "S%.0f T1 E\n"}, // TMC StealthChop (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"H%.2f\n",            "S%.2f\n",       "R%.2f\n",       "L%.2f\n",      NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Configuration (Height, Segment per sec, Radius, Diagonal Rod)
-  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Tower Angle (Tx, Ty, Tz)
-  {"A%.2f\n",            "B%.2f\n",       "C%.2f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Diagonal Rod Trim (Dx, Dy, Dz)
-  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Endstop Adjustments (Ex, Ey, Ez)
-  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Probe offset (X, Y, Z)
-  {"T0 K%.2f\n",         "T1 K%.2f\n",    NULL,            NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // Linear Advance (E0, E1)
-  {"X%.0f\n",            "I1 X%.0f\n",    "Y%.0f\n",       "I1 Y%.0f\n",   "Z%.0f\n",    "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"X%.0f\n",            "I1 X%.0f\n",    "Y%.0f\n",       "I1 Y%.0f\n",   "Z%.0f\n",    "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"X%.0f\n",            "I1 X%.0f\n",    "Y%.0f\n",       "I1 Y%.0f\n",   "Z%.0f\n",    "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   NULL,           NULL},           // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
-  {"S4 Z%.2f\nG29 S0\n", NULL,            NULL,            NULL,           NULL,         NULL,           NULL,           NULL,           NULL,           NULL},           // MBL offset
+  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       "T0 E%.2f\n",   "T1 E%.2f\n",   NULL,           NULL,           NULL,           NULL,           NULL},           // Steps/mm (X, Y, Z, E0, E1)
+  {"S%.0f\n",            "S1 T0 D%.2f\n", "S1 T1 D%.2f\n", NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Filament Diameter (Enable, E0, E1)
+  {"X%.0f\n",            "Y%.0f\n",       "Z%.0f\n",       "T0 E%.0f\n",   "T1 E%.0f\n",   NULL,           NULL,           NULL,           NULL,           NULL},           // MaxAcceleration (X, Y, Z, E0, E1)
+  {"X%.0f\n",            "Y%.0f\n",       "Z%.0f\n",       "T0 E%.0f\n",   "T1 E%.0f\n",   NULL,           NULL,           NULL,           NULL,           NULL},           // MaxFeedrate (X, Y, Z, E0, E1)
+  {"P%.0f\n",            "R%.0f\n",       "T%.0f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Acceleration (Print, Retract, Travel)
+  {"X%.0f\n",            "Y%.0f\n",       "Z%.2f\n",       "E%.2f\n",      NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Jerk (X, Y, Z, E)
+  {"J%.3f\n",            NULL,            NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Junction Deviation
+  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Home offset (X, Y, Z)
+  {"S%.2f\n",            "W%.2f\n",       "F%.2f\n",       "Z%.2f\n",      NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // FW retract (Length, Swap Length, Feedrate, Z lift height)
+  {"S%.2f\n",            "W%.2f\n",       "F%.2f\n",       "R%.2f\n",      NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // FW retract recover (Additional length, Additional Swap Length, Feedrate, Swap feedrate)
+  {"S%.0f\n",            NULL,            NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Set auto FW retract
+  {"T1 X%.2f\n",         "T1 Y%.2f\n",    "T1 Z%.2f\n",    NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Hotend Offset (X, Y, Z)
+  {"S%.0f\n",            "Z%.2f\n",       NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // ABL State & Z Fade
+  {"S%.0f I0 X\n",       "S%.0f I1 X\n",  "S%.0f I0 Y\n",  "S%.0f I1 Y\n", "S%.0f I0 Z\n", "S%.0f I1 Z\n", "S%.0f I2 Z\n", "S%.0f I3 Z\n", "S%.0f T0 E\n", "S%.0f T1 E\n"}, // TMC StealthChop (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"H%.2f\n",            "S%.2f\n",       "R%.2f\n",       "L%.2f\n",      NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Configuration (Height, Segment per sec, Radius, Diagonal Rod)
+  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Tower Angle (Tx, Ty, Tz)
+  {"A%.2f\n",            "B%.2f\n",       "C%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Diagonal Rod Trim (Dx, Dy, Dz)
+  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Endstop Adjustments (Ex, Ey, Ez)
+  {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Probe offset (X, Y, Z)
+  {"T0 K%.2f\n",         "T1 K%.2f\n",    NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Linear Advance (E0, E1)
+  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   NULL,           NULL},           // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
+  {"S4 Z%.2f\nG29 S0\n", NULL,            NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // MBL offset
 };
 
 const VAL_TYPE parameterValType[PARAMETERS_COUNT][MAX_ELEMENT_COUNT] = {

--- a/TFT/src/User/API/MachineParameters.c
+++ b/TFT/src/User/API/MachineParameters.c
@@ -78,9 +78,9 @@ const char * const parameterCmd[PARAMETERS_COUNT][MAX_ELEMENT_COUNT] = {
   {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Endstop Adjustments (Ex, Ey, Ez)
   {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Probe offset (X, Y, Z)
   {"T0 K%.2f\n",         "T1 K%.2f\n",    NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Linear Advance (E0, E1)
-  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   NULL,           NULL},           // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
+  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n",   NULL,           NULL},           // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
   {"S4 Z%.2f\nG29 S0\n", NULL,            NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // MBL offset
 };
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1205,6 +1205,9 @@ void sendQueueCmd(void)
 
           uint8_t i = (cmd_seen('I')) ? cmd_value() : 0;
 
+          if (i > 0)  // "X1"->0, "X2"->1, "Y1"->0, "Y2"->1, "Z1"->0, "Z2"->1, "Z3"->2, "Z4"->3
+            i--;
+
           if (cmd_seen('X')) setParameter(param, STEPPER_INDEX_X + i, cmd_value());
           if (cmd_seen('Y')) setParameter(param, STEPPER_INDEX_Y + i, cmd_value());
           if (cmd_seen('Z')) setParameter(param, STEPPER_INDEX_Z + i, cmd_value());

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1031,6 +1031,9 @@ void parseACK(void)
 
         uint8_t i = (ack_seen("I")) ? ack_value() : 0;
 
+        if (i > 0)  // "X1"->0, "X2"->1, "Y1"->0, "Y2"->1, "Z1"->0, "Z2"->1, "Z3"->2, "Z4"->3
+          i--;
+
         if (ack_seen("X")) setParameter(param, STEPPER_INDEX_X + i, ack_value());
         if (ack_seen("Y")) setParameter(param, STEPPER_INDEX_Y + i, ack_value());
         if (ack_seen("Z")) setParameter(param, STEPPER_INDEX_Z + i, ack_value());

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -1,10 +1,20 @@
 #include "Move.h"
 #include "includes.h"
 
+#define LOAD_XYZ_LABEL_INDEX(p0, dir0, p1, dir1, axis) do { \
+                                                         moveItems.items[p0].label.index = LABEL_##axis##_##dir0; \
+                                                         moveItems.items[p1].label.index = LABEL_##axis##_##dir1; \
+                                                       } while(0)
 #define X_MOVE_GCODE "G1 X%.2f F%d\n"
 #define Y_MOVE_GCODE "G1 Y%.2f F%d\n"
 #define Z_MOVE_GCODE "G1 Z%.2f F%d\n"
 #define GANTRY_UPDATE_DELAY 500  // 1 seconds is 1000
+
+#ifdef PORTRAIT_MODE
+  #define OFFSET 0
+#else
+  #define OFFSET 1
+#endif
 
 const char *const xyzMoveCmd[] = {X_MOVE_GCODE, Y_MOVE_GCODE, Z_MOVE_GCODE};
 static uint8_t item_moveLen_index = 1;
@@ -19,31 +29,20 @@ void storeMoveCmd(AXIS xyz, int8_t direction)
   nowAxis = xyz;  // update now axis be selected
 }
 
-#define LOAD_XYZ_LABEL_INDEX(p0, dir0, p1, dir1, axis) do { \
-                                                         moveItems.items[p0].label.index = LABEL_##axis##_##dir0; \
-                                                         moveItems.items[p1].label.index = LABEL_##axis##_##dir1; \
-                                                       } while(0)
-
 void drawXYZ(void)
 {
   char tempstr[30];
 
   GUI_SetColor(infoSettings.status_color);
 
-  #ifdef PORTRAIT_MODE
-    sprintf(tempstr, "X:%.2f Y:%.2f Z:%.2f", coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS),
-            coordinateGetAxisActual(Z_AXIS));
-    GUI_DispString(START_X + 1 * SPACE_X + 1 * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
-  #else
-    sprintf(tempstr, "X:%.2f  ", coordinateGetAxisActual(X_AXIS));
-    GUI_DispString(START_X + 1 * SPACE_X + 1 * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
+  sprintf(tempstr, "X:%.2f  ", coordinateGetAxisActual(X_AXIS));
+  GUI_DispString(START_X + (OFFSET + 0) * SPACE_X + (OFFSET + 0) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
-    sprintf(tempstr, "Y:%.2f  ", coordinateGetAxisActual(Y_AXIS));
-    GUI_DispString(START_X + 2 * SPACE_X + 2 * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
+  sprintf(tempstr, "Y:%.2f  ", coordinateGetAxisActual(Y_AXIS));
+  GUI_DispString(START_X + (OFFSET + 1) * SPACE_X + (OFFSET + 1) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
-    sprintf(tempstr, "Z:%.2f  ", coordinateGetAxisActual(Z_AXIS));
-    GUI_DispString(START_X + 3 * SPACE_X + 3 * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
-  #endif
+  sprintf(tempstr, "Z:%.2f  ", coordinateGetAxisActual(Z_AXIS));
+  GUI_DispString(START_X + (OFFSET + 2) * SPACE_X + (OFFSET + 2) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
   GUI_SetColor(infoSettings.font_color);
 }

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -15,22 +15,23 @@ void storeMoveCmd(AXIS xyz, int8_t direction)
   // if invert is true, 'direction' multiplied by -1
   storeCmd(xyzMoveCmd[xyz], (GET_BIT(infoSettings.inverted_axis, xyz) ? -direction : direction) * moveLenSteps[item_moveLen_index],
            ((xyz != Z_AXIS) ? infoSettings.xy_speed[infoSettings.move_speed] : infoSettings.z_speed[infoSettings.move_speed]));
-  // update now axis be selected
-  nowAxis = xyz;
+
+  nowAxis = xyz;  // update now axis be selected
 }
 
-#define LOAD_XYZ_LABEL_INDEX(p0, dir0, p1, dir1, axis) do{ \
-                                                            moveItems.items[p0].label.index = LABEL_##axis##_##dir0; \
-                                                            moveItems.items[p1].label.index = LABEL_##axis##_##dir1; \
-                                                         }while(0)
+#define LOAD_XYZ_LABEL_INDEX(p0, dir0, p1, dir1, axis) do { \
+                                                         moveItems.items[p0].label.index = LABEL_##axis##_##dir0; \
+                                                         moveItems.items[p1].label.index = LABEL_##axis##_##dir1; \
+                                                       } while(0)
 
 void drawXYZ(void)
 {
   char tempstr[30];
+
   GUI_SetColor(infoSettings.status_color);
 
   #ifdef PORTRAIT_MODE
-    sprintf(tempstr, "X:%.2f  Y:%.2f  Z:%2.f", coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS),
+    sprintf(tempstr, "X:%.2f Y:%.2f Z:%.2f", coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS),
             coordinateGetAxisActual(Z_AXIS));
     GUI_DispString(START_X + 1 * SPACE_X + 1 * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
   #else
@@ -90,26 +91,27 @@ void menuMove(void)
   mustStoreCmd("G91\n");
   mustStoreCmd("M114\n");
 
-  // postion table of key
+  // keys position table
   uint8_t table[TOTAL_AXIS][2] =
-  #ifdef ALTERNATIVE_MOVE_MENU
-    /*-------*-------*-------*---------*
-     | Z-(0) | Y+(1) | Z+(2) | unit(3) |
-     *-------*-------*-------*---------*
-     | X-(4) | Y-(5) | X+(6) | back(7) |
-     *-------*-------*-------*---------*/
-    //X+ X-   Y+ Y-   Z+ Z-
-    {{6, 4}, {1, 5}, {2, 0}}
-  #else
-    /*-------*-------*-------*---------*
-     | X+(0) | Y+(1) | Z+(2) | unit(3) |
-     *-------*-------*-------*---------*
-     | X-(4) | Y-(5) | Z-(6) | back(7) |
-     *-------*-------*-------*---------*/
-    //X+ X-   Y+ Y-   Z+ Z-
-    {{0, 4}, {1, 5}, {2, 6}}
-  #endif
+    #ifdef ALTERNATIVE_MOVE_MENU
+      /*-------*-------*-------*---------*
+       | Z-(0) | Y+(1) | Z+(2) | unit(3) |
+       *-------*-------*-------*---------*
+       | X-(4) | Y-(5) | X+(6) | back(7) |
+       *-------*-------*-------*---------*
+       |X+ X-  |Y+ Y-  |Z+ Z-            */
+      {{6, 4}, {1, 5}, {2, 0}}
+    #else
+      /*-------*-------*-------*---------*
+       | X+(0) | Y+(1) | Z+(2) | unit(3) |
+       *-------*-------*-------*---------*
+       | X-(4) | Y-(5) | Z-(6) | back(7) |
+       *-------*-------*-------*---------*
+       |X+ X-  |Y+ Y-  |Z+ Z-            */
+      {{0, 4}, {1, 5}, {2, 6}}
+    #endif
     ;
+
   if (!GET_BIT(infoSettings.inverted_axis, X_AXIS))
     LOAD_XYZ_LABEL_INDEX(table[X_AXIS][0], INC, table[X_AXIS][1], DEC, X);  // table[0] <--> INC(+) table[1] <--> DEC(+) if not inverted
   else

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -26,7 +26,7 @@ void storeMoveCmd(AXIS xyz, int8_t direction)
 
 void drawXYZ(void)
 {
-  char tempstr[20];
+  char tempstr[30];
   GUI_SetColor(infoSettings.status_color);
 
   #ifdef PORTRAIT_MODE

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -15,7 +15,7 @@
 #define UPDATE_TOOL_TIME 2000  // 1 seconds is 1000
 
 #ifdef PORTRAIT_MODE
-  #define XYZ_STATUS " X:%.2f Y:%.2f Z:%.2f "
+  #define XYZ_STATUS "X:%.2f Y:%.2f Z:%.2f"
 #else
   #define XYZ_STATUS "   X: %.2f   Y: %.2f   Z: %.2f   "
 #endif
@@ -62,11 +62,11 @@ const GUI_POINT ss_val_point   = {SS_ICON_WIDTH / 2, SS_ICON_VAL_Y0};
 
 // info box msg area
 #ifdef PORTRAIT_MODE
-  const  GUI_RECT msgRect = {START_X + 0.5 * ICON_WIDTH + 0 * SPACE_X + 2, ICON_START_Y +  0 * ICON_HEIGHT + 0 * SPACE_Y + STATUS_MSG_BODY_YOFFSET,
-                             START_X + 2.5 * ICON_WIDTH + 1 * SPACE_X - 2, ICON_START_Y +  1 * ICON_HEIGHT + 0 * SPACE_Y - STATUS_MSG_BODY_BOTTOM};
+  const  GUI_RECT msgRect = {START_X + 0.5 * ICON_WIDTH + 0 * SPACE_X + 2, ICON_START_Y + 0 * ICON_HEIGHT + 0 * SPACE_Y + STATUS_MSG_BODY_YOFFSET,
+                             START_X + 2.5 * ICON_WIDTH + 1 * SPACE_X - 2, ICON_START_Y + 1 * ICON_HEIGHT + 0 * SPACE_Y - STATUS_MSG_BODY_BOTTOM};
 
-  const GUI_RECT RecGantry = {START_X-2,                                SS_ICON_HEIGHT + ICON_START_Y + STATUS_GANTRY_YOFFSET,
-                              START_X+2 + 3 * ICON_WIDTH + 2 * SPACE_X, ICON_HEIGHT + SPACE_Y + ICON_START_Y - STATUS_GANTRY_YOFFSET};
+  const GUI_RECT RecGantry = {START_X - 3,                                SS_ICON_HEIGHT + ICON_START_Y + STATUS_GANTRY_YOFFSET,
+                              START_X + 3 + 3 * ICON_WIDTH + 2 * SPACE_X, ICON_HEIGHT + SPACE_Y + ICON_START_Y - STATUS_GANTRY_YOFFSET};
 #else
   const  GUI_RECT msgRect = {START_X + 1 * ICON_WIDTH + 1 * SPACE_X + 2, ICON_START_Y + 1 * ICON_HEIGHT + 1 * SPACE_Y + STATUS_MSG_BODY_YOFFSET,
                              START_X + 3 * ICON_WIDTH + 2 * SPACE_X - 2, ICON_START_Y + 2 * ICON_HEIGHT + 1 * SPACE_Y - STATUS_MSG_BODY_BOTTOM};
@@ -182,11 +182,19 @@ void drawStatus(void)
     showLiveInfo(3, &lvIcon, true);
   #endif
 
+  sprintf(tempstr, XYZ_STATUS, coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS), coordinateGetAxisActual(Z_AXIS));
+
+  #ifdef PORTRAIT_MODE
+    int padding_width = ((RecGantry.x1 - RecGantry.x0) - (strlen(tempstr) * BYTE_WIDTH)) / 2;
+
+    GUI_SetColor(GANTRY_XYZ_BG_COLOR);
+    GUI_FillRect(RecGantry.x0, RecGantry.y0, RecGantry.x0 + padding_width, RecGantry.y1);
+    GUI_FillRect(RecGantry.x1 - padding_width, RecGantry.y0, RecGantry.x1, RecGantry.y1);
+  #endif
+
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
   GUI_SetColor(GANTRY_XYZ_FONT_COLOR);
   GUI_SetBkColor(GANTRY_XYZ_BG_COLOR);
-
-  sprintf(tempstr, XYZ_STATUS, coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS), coordinateGetAxisActual(Z_AXIS));
   GUI_DispStringInPrect(&RecGantry, (uint8_t *)tempstr);
 
   GUI_RestoreColorDefault();
@@ -285,7 +293,7 @@ void menuStatus(void)
 
   GUI_SetBkColor(infoSettings.bg_color);
   menuDrawPage(&StatusItems);
-  GUI_SetColor(infoSettings.status_xyz_bg_color);
+  GUI_SetColor(GANTRY_XYZ_BG_COLOR);
   GUI_FillPrect(&RecGantry);
   drawStatus();
   drawStatusScreenMsg();

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -78,7 +78,7 @@ const GUI_POINT ss_val_point   = {SS_ICON_WIDTH / 2, SS_ICON_VAL_Y0};
 void drawStatus(void)
 {
   // icons and their values are updated one by one to reduce flicker/clipping
-  char tempstr[10];
+  char tempstr[45];
 
   LIVE_INFO lvIcon;
   lvIcon.enabled[0] = true;
@@ -185,8 +185,8 @@ void drawStatus(void)
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
   GUI_SetColor(GANTRY_XYZ_FONT_COLOR);
   GUI_SetBkColor(GANTRY_XYZ_BG_COLOR);
-  sprintf(tempstr, XYZ_STATUS, coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS),
-          coordinateGetAxisActual(Z_AXIS));
+
+  sprintf(tempstr, XYZ_STATUS, coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS), coordinateGetAxisActual(Z_AXIS));
   GUI_DispStringInPrect(&RecGantry, (uint8_t *)tempstr);
 
   GUI_RestoreColorDefault();

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -188,8 +188,8 @@ void drawStatus(void)
     int paddingWidth = ((RecGantry.x1 - RecGantry.x0) - (strlen(tempstr) * BYTE_WIDTH)) / 2;
 
     GUI_SetColor(GANTRY_XYZ_BG_COLOR);
-    GUI_FillRect(RecGantry.x0, RecGantry.y0, RecGantry.x0 + paddingWidth, RecGantry.y1);
-    GUI_FillRect(RecGantry.x1 - paddingWidth, RecGantry.y0, RecGantry.x1, RecGantry.y1);
+    GUI_FillRect(RecGantry.x0, RecGantry.y0, RecGantry.x0 + paddingWidth, RecGantry.y1);  // left padding
+    GUI_FillRect(RecGantry.x1 - paddingWidth, RecGantry.y0, RecGantry.x1, RecGantry.y1);  // right padding
   #endif
 
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -15,7 +15,7 @@
 #define UPDATE_TOOL_TIME 2000  // 1 seconds is 1000
 
 #ifdef PORTRAIT_MODE
-  #define XYZ_STATUS " X: %.2f  Y: %.2f  Z: %.2f "
+  #define XYZ_STATUS " X:%.2f Y:%.2f Z:%.2f "
 #else
   #define XYZ_STATUS "   X: %.2f   Y: %.2f   Z: %.2f   "
 #endif

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -185,11 +185,11 @@ void drawStatus(void)
   sprintf(tempstr, XYZ_STATUS, coordinateGetAxisActual(X_AXIS), coordinateGetAxisActual(Y_AXIS), coordinateGetAxisActual(Z_AXIS));
 
   #ifdef PORTRAIT_MODE
-    int padding_width = ((RecGantry.x1 - RecGantry.x0) - (strlen(tempstr) * BYTE_WIDTH)) / 2;
+    int paddingWidth = ((RecGantry.x1 - RecGantry.x0) - (strlen(tempstr) * BYTE_WIDTH)) / 2;
 
     GUI_SetColor(GANTRY_XYZ_BG_COLOR);
-    GUI_FillRect(RecGantry.x0, RecGantry.y0, RecGantry.x0 + padding_width, RecGantry.y1);
-    GUI_FillRect(RecGantry.x1 - padding_width, RecGantry.y0, RecGantry.x1, RecGantry.y1);
+    GUI_FillRect(RecGantry.x0, RecGantry.y0, RecGantry.x0 + paddingWidth, RecGantry.y1);
+    GUI_FillRect(RecGantry.x1 - paddingWidth, RecGantry.y0, RecGantry.x1, RecGantry.y1);
   #endif
 
   GUI_SetTextMode(GUI_TEXTMODE_NORMAL);


### PR DESCRIPTION
**BUGFIXES:**
* Fixed #2493
* Fixed #2509
* Fixed out of range array size for XYZ status on Status Screen menu: That bug present since #2448 could cause a freeze on Status screen menu. The array size has been restored to 45 (instead of 10).
* Reviewed XYZ status layout for Portrait Mode in Status Screen and Move menus: Z coord was previously not fully displayed (e.g. on TFT35 V3). Now XYZ are properly displayed (see pictures below).

fixes #2493
fixes #2509

**PR STATE:** Ready for merge.

![Move_1](https://user-images.githubusercontent.com/64427768/166153822-1ecf524d-c30e-40ad-854f-796fe3b0cf46.jpg)

![Ready_5](https://user-images.githubusercontent.com/64427768/166153831-47c53861-a6e7-4543-bdae-890492ff6ba4.jpg)

