### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -17,85 +17,127 @@ jobs:
     if: github.repository == 'bigtreetech/BIGTREETECH-TouchScreenFirmware'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
       - name: Setup Python
         uses: actions/setup-python@master
         with:
           python-version: '3.x'
-      - name: Install Platform IO
+
+      - name: Install PlatformIO
         run: |
           python -m pip install --upgrade pip
           pip install -U platformio
+
       - name: Build TFT24 V1.1
         run: platformio run --environment BIGTREE_TFT24_V1_1
+
       - name: Build TFT28 V1.0
         run: platformio run --environment BIGTREE_TFT28_V1_0
+
       - name: Build TFT28 V3.0
         run: platformio run --environment BIGTREE_TFT28_V3_0
+
       - name: Build TFT35 V1.0
         run: platformio run --environment BIGTREE_TFT35_V1_0
+
       - name: Build TFT35 V1.1
         run: platformio run --environment BIGTREE_TFT35_V1_1
+
       - name: Build TFT35 V1.2
         run: platformio run --environment BIGTREE_TFT35_V1_2
+
       - name: Build TFT35 V2.0
         run: platformio run --environment BIGTREE_TFT35_V2_0
+
       - name: Build TFT35 V3.0
         run: platformio run --environment BIGTREE_TFT35_V3_0
+
       - name: Build TFT35 E3 V3.0
         run: platformio run --environment BIGTREE_TFT35_E3_V3_0
+
       - name: Build TFT35 B1 V3.0
         run: platformio run --environment BIGTREE_TFT35_B1_V3_0
+
       - name: Build TFT43 V3.0
         run: platformio run --environment BIGTREE_TFT43_V3_0
+
       - name: Build TFT50 V3.0
         run: platformio run --environment BIGTREE_TFT50_V3_0
+
       - name: Build TFT70 V3.0
         run: platformio run --environment BIGTREE_TFT70_V3_0
+
       - name: Build GD_TFT24 V1.1
         run: platformio run --environment BIGTREE_GD_TFT24_V1_1
+
       - name: Build GD_TFT35 V2.0
         run: platformio run --environment BIGTREE_GD_TFT35_V2_0
+
       - name: Build GD TFT35 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_V3_0
+
       - name: Build GD TFT35 E3 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_E3_V3_0
+
       - name: Build GD TFT35 B1 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_B1_V3_0
+
       - name: Build GD TFT43 V3.0
         run: platformio run --environment BIGTREE_GD_TFT43_V3_0
+
       - name: Build GD TFT50 V3.0
         run: platformio run --environment BIGTREE_GD_TFT50_V3_0
+
       - name: Build GD TFT70 V3.0
         run: platformio run --environment BIGTREE_GD_TFT70_V3_0
+
       - name: Build MKS TFT28 V3.0
         run: platformio run --environment MKS_TFT28_V3_0
+
       - name: Build MKS TFT28 V4.0
         run: platformio run --environment MKS_TFT28_V4_0
+
       - name: Build MKS TFT28 New Genius
         run: platformio run --environment MKS_TFT28_NEW_GENIUS
+
       - name: Build MKS TFT32 V1.3
         run: platformio run --environment MKS_TFT32_V1_3
+
       - name: Build MKS TFT32 V1.4
         run: platformio run --environment MKS_TFT32_V1_4
+
       - name: Build MKS TFT32 V1.4 No Bootloader
         run: platformio run --environment MKS_TFT32_V1_4_NOBL
+
       - name: Build MKS TFT35 V1.0
         run: platformio run --environment MKS_TFT35_V1_0
+
       - name: Remove Old Binaries
         run: find "Copy to SD Card root directory to update/" -name '*.bin' -print -delete
+
       - name: Remove Old Config
         run: find "Copy to SD Card root directory to update/" -name 'config.ini' -print -delete
+
       - name: Copy New Binaries
         run: find .pio/build/ -name '*.bin' -exec cp -vf '{}' "./Copy to SD Card root directory to update/" ";"
+
       - name: Copy New Config
         run: find TFT/src/User/ -name 'config.ini' -exec cp -vf '{}' "./Copy to SD Card root directory to update/" ";"
+
       - name: Stage New Binaries
-        run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && git config user.name "${GITHUB_ACTOR}" && find "Copy to SD Card root directory to update/" -name '*.bin' -exec git add {} \;
+        run: |
+          find "Copy to SD Card root directory to update/" -name '*.bin' -exec git add {} \;
+
       - name: Stage New Config
-        run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com" && git config user.name "${GITHUB_ACTOR}" && find "Copy to SD Card root directory to update/" -name 'config.ini' -exec git add {} \;
+        run: |
+          find "Copy to SD Card root directory to update/" -name 'config.ini' -exec git add {} \;
+
       - name: Push
-        uses: actions-x/commit@v2
+        uses: actions-x/commit@v6
         with:
+          email: 38851044+bigtreetech@users.noreply.github.com
+          name: bigtreetech
           message: Update prebuilt binaries and config
           token: ${{ secrets.MY_SECRET_TOKEN }}

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -8,81 +8,105 @@ on:
     - readme/**
     - '**/*.md'
 
-  push:
-    paths-ignore:
-    - Bootloader/**
-    - Copy to SD Card root directory to update/**
-    - images/**
-    - readme/**
-    - '**/*.md'
-
 jobs:
   main:
     name: Build Test
+    if: github.repository == 'bigtreetech/BIGTREETECH-TouchScreenFirmware'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
       - name: Setup Python
         uses: actions/setup-python@master
         with:
           python-version: '3.x'
-      - name: Install Platform IO
+
+      - name: Install PlatformIO
         run: |
           python -m pip install --upgrade pip
           pip install -U platformio
+
       - name: Build TFT24 V1.1
         run: platformio run --environment BIGTREE_TFT24_V1_1
+
       - name: Build TFT28 V1.0
         run: platformio run --environment BIGTREE_TFT28_V1_0
+
       - name: Build TFT28 V3.0
         run: platformio run --environment BIGTREE_TFT28_V3_0
+
       - name: Build TFT35 V1.0
         run: platformio run --environment BIGTREE_TFT35_V1_0
+
       - name: Build TFT35 V1.1
         run: platformio run --environment BIGTREE_TFT35_V1_1
+
       - name: Build TFT35 V1.2
         run: platformio run --environment BIGTREE_TFT35_V1_2
+
       - name: Build TFT35 V2.0
         run: platformio run --environment BIGTREE_TFT35_V2_0
+
       - name: Build TFT35 V3.0
         run: platformio run --environment BIGTREE_TFT35_V3_0
+
       - name: Build TFT35 E3 V3.0
         run: platformio run --environment BIGTREE_TFT35_E3_V3_0
+
       - name: Build TFT35 B1 V3.0
         run: platformio run --environment BIGTREE_TFT35_B1_V3_0
+
       - name: Build TFT43 V3.0
         run: platformio run --environment BIGTREE_TFT43_V3_0
+
       - name: Build TFT50 V3.0
         run: platformio run --environment BIGTREE_TFT50_V3_0
+
       - name: Build TFT70 V3.0
         run: platformio run --environment BIGTREE_TFT70_V3_0
+
       - name: Build GD_TFT24 V1.1
         run: platformio run --environment BIGTREE_GD_TFT24_V1_1
+
       - name: Build GD_TFT35 V2.0
         run: platformio run --environment BIGTREE_GD_TFT35_V2_0
+
       - name: Build GD TFT35 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_V3_0
+
       - name: Build GD TFT35 E3 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_E3_V3_0
+
       - name: Build GD TFT35 B1 V3.0
         run: platformio run --environment BIGTREE_GD_TFT35_B1_V3_0
+
       - name: Build GD TFT43 V3.0
         run: platformio run --environment BIGTREE_GD_TFT43_V3_0
+
       - name: Build GD TFT50 V3.0
         run: platformio run --environment BIGTREE_GD_TFT50_V3_0
+
       - name: Build GD TFT70 V3.0
         run: platformio run --environment BIGTREE_GD_TFT70_V3_0
+
       - name: Build MKS TFT28 V3.0
         run: platformio run --environment MKS_TFT28_V3_0
+
       - name: Build MKS TFT28 V4.0
         run: platformio run --environment MKS_TFT28_V4_0
+
       - name: Build MKS TFT28 New Genius
         run: platformio run --environment MKS_TFT28_NEW_GENIUS
+
       - name: Build MKS TFT32 V1.3
         run: platformio run --environment MKS_TFT32_V1_3
+
       - name: Build MKS TFT32 V1.4
         run: platformio run --environment MKS_TFT32_V1_4
+
       - name: Build MKS TFT32 V1.4 No Bootloader
         run: platformio run --environment MKS_TFT32_V1_4_NOBL
+
       - name: Build MKS TFT35 V1.0
         run: platformio run --environment MKS_TFT35_V1_0


### PR DESCRIPTION
### Description

Various Actions cleanup and fixes in response to [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) that broke the auto-building & committing of updated biniares & config.

*Note: The Build Binaries action will run after the next PR merge/commit since the `.github` folder is excluded.*

### Benefits

Binaries & config will update.

### Related Issues

None. Discovered broken actions while checking out recent updates.