### PR TITLE
Save settings after Delta Calibration

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -867,6 +867,22 @@ void parseACK(void)
         if (ack_seen("Y: ")) y = ack_value();
         if (ack_seen("Z: ")) levelingSetProbedPoint(x, y, ack_value());  // save probed Z value
       }
+      // parse and store Delta Calibration settings
+      #if DELTA_PROBE_TYPE != 0
+      else if (ack_seen("Calibration OK"))
+      {
+        BUZZER_PLAY(SOUND_SUCCESS);
+        if (infoMachineSettings.EEPROM == 1)
+          {
+            setDialogText(LABEL_DELTA_CONFIGURATION, LABEL_EEPROM_SAVE_INFO, LABEL_CONFIRM, LABEL_CANCEL);
+            showDialog(DIALOG_TYPE_SUCCESS, saveEepromSettings, NULL, NULL);
+          }
+        else
+          {
+            popupReminder(DIALOG_TYPE_SUCCESS, LABEL_DELTA_CONFIGURATION, LABEL_PROCESS_COMPLETED);
+          } 
+      } 
+      #endif
 
       //----------------------------------------
       // Parameter / M503 / M115 parsed responses


### PR DESCRIPTION
This PR parse when Delta Calibration is ended and allow to save settings in EEPROM when enabled or inform process is ended if EEPROM is disabled.