### PR TITLE
Enabling Leveling in RRF

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -250,7 +250,7 @@ void setupMachine(FW_TYPE fwType)
   else if (infoMachineSettings.firmwareType == FW_REPRAPFW)
   {
     infoMachineSettings.softwareEndstops = ENABLED;
-
+    infoMachineSettings.leveling         = BL_ABL;
     mustStoreCmd("M552\n");  // query network state, populate IP if the screen boots up after RRF
     return;
   }


### PR DESCRIPTION
Enabling Leveling in RRF

After merging #2179, users with RRF no longer see the leveling icon.
This fix sets fixed ABL leveling for RRF.

resolves #2537 
