### PR TITLE
Fix icon and language flash sign

### DIFF
--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -18,8 +18,8 @@ extern "C" {
 
 #define FONT_FLASH_SIGN       20210522  // (YYYYMMDD) change if fonts require updating
 #define CONFIG_FLASH_SIGN     20220518  // (YYYYMMDD) change if any keyword(s) in config.ini is added or removed
-#define LANGUAGE_FLASH_SIGN   20220601  // (YYYYMMDD) change if any keyword(s) in language pack is added or removed
-#define ICON_FLASH_SIGN       20220601  // (YYYYMMDD) change if any icon(s) is added or removed
+#define LANGUAGE_FLASH_SIGN   20220712  // (YYYYMMDD) change if any keyword(s) in language pack is added or removed
+#define ICON_FLASH_SIGN       20220712  // (YYYYMMDD) change if any icon(s) is added or removed
 
 #define FONT_CHECK_SIGN       (FONT_FLASH_SIGN + WORD_UNICODE_ADDR + FLASH_SIGN_ADDR)
 #define CONFIG_CHECK_SIGN     (CONFIG_FLASH_SIGN + STRINGS_STORE_ADDR + \


### PR DESCRIPTION
Merges from 12.VII.2022 brought new icons and new keywords but the "Settings.h" wasn't updated to reflect these changes so a FW update doesn't warn about the need to update language file and icons.
This PR fixes this issue.