### PR TITLE
G90/91 Fix

### DIFF
--- a/TFT/src/User/API/coordinate.c
+++ b/TFT/src/User/API/coordinate.c
@@ -58,15 +58,13 @@ float coordinateGetAxisTarget(AXIS axis)
 
 void coordinateSetAxisTarget(AXIS axis, float position)
 {
-  bool r = (axis == E_AXIS) ? (relative_e || relative_mode) : relative_mode;
-
-  if (r == false)
+  if ((axis == E_AXIS) ? relative_e : relative_mode)
   {
-    targetPosition.axis[axis] = position;
+    targetPosition.axis[axis] += position;
   }
   else
   {
-    targetPosition.axis[axis] += position;
+    targetPosition.axis[axis] = position;
   }
 }
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1289,14 +1289,16 @@ void sendQueueCmd(void)
           break;
         #endif
 
-        case 90:  // G90, set absolute position mode, this includes the extruder position unless overridden by M83.
+        case 90:  // G90, set absolute position mode, in Marlin this includes the extruder position unless overridden by M83.
           coorSetRelative(false);
-          eSetRelative(false);
+          if (infoMachineSettings.firmwareType == FW_MARLIN)
+            eSetRelative(false);
           break;
 
-        case 91:  // G91, set relative position mode, this includes the extruder position unless overridden by M82.
+        case 91:  // G91, set relative position mode, in Marlin this includes the extruder position unless overridden by M82.
           coorSetRelative(true);
-          eSetRelative(true);
+          if (infoMachineSettings.firmwareType == FW_MARLIN)
+            eSetRelative(true);
           break;
 
         case 92:  // G92

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1289,12 +1289,14 @@ void sendQueueCmd(void)
           break;
         #endif
 
-        case 90:  // G90
+        case 90:  // G90, set absolute position mode, this includes the extruder position unless overridden by M83.
           coorSetRelative(false);
+          eSetRelative(false);
           break;
 
-        case 91:  // G91
+        case 91:  // G91, set relative position mode, this includes the extruder position unless overridden by M82.
           coorSetRelative(true);
+          eSetRelative(true);
           break;
 
         case 92:  // G92


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

In Marlin G90 and G91 gcode sets the extruder also to relative or absolute mode. This change is not reflected in the TFT's FW so in case of these gcode commands the flag for extruder's absolute or relative mode is not updated accordingly which can lead to anomalies. 
E axis coordinate was set wrong if X, Y, Z coordinates were set to relative and E was set to absolute.

This PR fixes these bugs.

### Benefits

~~Possible fix for #2557~~

### Related Issues

~~#2557~~
