### PR TITLE
RRF setupMachine Fix

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -244,17 +244,16 @@ void setupMachine(FW_TYPE fwType)
 
   if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)  // Smoothieware does not report detailed M115 capabilities
   {
-    infoMachineSettings.leveling        = BL_ABL;
+    infoMachineSettings.leveling = BL_ABL;
     infoMachineSettings.emergencyParser = ENABLED;
   }
   else if (infoMachineSettings.firmwareType == FW_REPRAPFW)
   {
     infoMachineSettings.softwareEndstops = ENABLED;
     #if BED_LEVELING_TYPE == 1
-    infoMachineSettings.leveling         = BL_ABL;
+      infoMachineSettings.leveling = BL_ABL;
     #endif
     mustStoreCmd("M552\n");  // query network state, populate IP if the screen boots up after RRF
-    return;
   }
 
   mustStoreCmd("M503 S0\n");


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

After PR #2171 the setupMachine() procedure was prematurely interrupted for RRF resulting in unknown absolute/relative mode of XYZE coordinates, no report of "config.g" settings and the LED not being initialized.

This PR fixes these.

### Benefits

RRF

### Related Issues

Fixes #2557