### PR TITLE
TMC driver settings bugs, bump sensitivity and current for Dual X/Y s…

### DIFF
--- a/TFT/src/User/API/MachineParameters.c
+++ b/TFT/src/User/API/MachineParameters.c
@@ -26,9 +26,9 @@ const uint8_t parameterElementCount[PARAMETERS_COUNT] = {
   3,                          // Delta Endstop Adjustments
   (AXIS_INDEX_COUNT - 2),     // Probe offset (X, Y, Z)
   2,                          // Linear Advance (E0, E1)
-  STEPPER_INDEX_COUNT,        // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  STEPPER_INDEX_COUNT,        // Stepper Motor Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
   STEPPER_INDEX_COUNT,        // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  (STEPPER_INDEX_COUNT - 2),  // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
+  (STEPPER_INDEX_COUNT - 2),  // TMC Bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
   1                           // MBL offset
 };
 
@@ -55,9 +55,9 @@ const char * const parameterCode[PARAMETERS_COUNT] = {
   "M666",  // Delta Endstop Adjustments
   "M851",  // Probe offset
   "M900",  // Linear Advance
-  "M906",  // Current
+  "M906",  // Stepper Motor Current
   "M913",  // TMC Hybrid Threshold Speed
-  "M914",  // bump Sensitivity
+  "M914",  // TMC Bump Sensitivity
   "G29",   // MBL offset
 };
 
@@ -84,9 +84,9 @@ const char * const parameterCmd[PARAMETERS_COUNT][MAX_ELEMENT_COUNT] = {
   {"X%.4f\n",            "Y%.4f\n",       "Z%.4f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Delta Endstop Adjustments (Ex, Ey, Ez)
   {"X%.2f\n",            "Y%.2f\n",       "Z%.2f\n",       NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Probe offset (X, Y, Z)
   {"T0 K%.2f\n",         "T1 K%.2f\n",    NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // Linear Advance (E0, E1)
-  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {"I0 X%.0f\n",         "I1 X%.0f\n",    "I0 Y%.0f\n",    "I1 Y%.0f\n",   "I0 Z%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // Stepper Motor Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
   {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n"    "T0 E%.0f\n",   "T1 E%.0f\n"},   // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
-  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n",   NULL,           NULL},           // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
+  {"I1 X%.0f\n",         "I2 X%.0f\n",    "I1 Y%.0f\n",    "I2 Y%.0f\n",   "I1 Z%.0f\n",   "I2 Z%.0f\n",   "I3 Z%.0f\n",   "I4 Z%.0f\n",   NULL,           NULL},           // TMC Bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
   {"S4 Z%.2f\nG29 S0\n", NULL,            NULL,            NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL},           // MBL offset
 };
 
@@ -114,11 +114,11 @@ const VAL_TYPE parameterValType[PARAMETERS_COUNT][MAX_ELEMENT_COUNT] = {
   {VAL_TYPE_NEG_FLOAT,  VAL_TYPE_NEG_FLOAT, VAL_TYPE_NEG_FLOAT},                                     // Delta Endstop Adjustments (Ex, Ey, Ez)
   {VAL_TYPE_NEG_FLOAT,  VAL_TYPE_NEG_FLOAT, VAL_TYPE_NEG_FLOAT},                                     // Probe offset (X, Y, Z)
   {VAL_TYPE_FLOAT,      VAL_TYPE_FLOAT},                                                             // Linear Advance (E0, E1)
-  {VAL_TYPE_INT,        VAL_TYPE_INT,       VAL_TYPE_INT,        VAL_TYPE_INT,     VAL_TYPE_INT,     // Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
+  {VAL_TYPE_INT,        VAL_TYPE_INT,       VAL_TYPE_INT,        VAL_TYPE_INT,     VAL_TYPE_INT,     // Stepper Motor Current (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
    VAL_TYPE_INT,        VAL_TYPE_INT,       VAL_TYPE_INT,        VAL_TYPE_INT,     VAL_TYPE_INT,},
   {VAL_TYPE_INT,        VAL_TYPE_INT,       VAL_TYPE_INT,        VAL_TYPE_INT,     VAL_TYPE_INT,     // TMC Hybrid Threshold Speed (X, X2, Y, Y2, Z, Z2, Z3, Z4, E0, E1)
    VAL_TYPE_INT,        VAL_TYPE_INT,       VAL_TYPE_INT,        VAL_TYPE_INT,     VAL_TYPE_INT,},
-  {VAL_TYPE_NEG_INT,    VAL_TYPE_NEG_INT,   VAL_TYPE_NEG_INT,    VAL_TYPE_NEG_INT, VAL_TYPE_NEG_INT, // bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
+  {VAL_TYPE_NEG_INT,    VAL_TYPE_NEG_INT,   VAL_TYPE_NEG_INT,    VAL_TYPE_NEG_INT, VAL_TYPE_NEG_INT, // TMC Bump Sensitivity (X, X2, Y, Y2, Z, Z2, Z3, Z4)
    VAL_TYPE_NEG_INT,    VAL_TYPE_NEG_INT,   VAL_TYPE_NEG_INT,},
   {VAL_TYPE_NEG_FLOAT},                                                                              // MBL offset
 };

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1139,13 +1139,23 @@ void sendQueueCmd(void)
         case 569:  // M569 TMC stepping mode
         {
           uint8_t k = (cmd_seen('S')) ? cmd_value() : 0;
-          uint8_t i = (cmd_seen('I')) ? cmd_value() : 0;
+          int8_t i = (cmd_seen('I')) ? cmd_value() : 0;
+
+          // if index is missing or set to -1 (meaning all indexes) then it must be converted to 0
+          // to make sure array index is never negative
+          if (i < 0)
+            i = 0;
 
           if (cmd_seen('X')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_X + i, k);
           if (cmd_seen('Y')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_Y + i, k);
           if (cmd_seen('Z')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_Z + i, k);
 
           i = (cmd_seen('T')) ? cmd_value() : 0;
+
+          // if index is missing or set to -1 (meaning all indexes) then it must be converted to 0
+          // to make sure array index is never negative
+          if (i < 0)
+            i = 0;
 
           if (cmd_seen('E')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_E0 + i, k);
           break;
@@ -1215,9 +1225,19 @@ void sendQueueCmd(void)
           if (cmd_value() == 913) param = P_HYBRID_THRESHOLD;  // P_HYBRID_THRESHOLD
           if (cmd_value() == 914) param = P_BUMPSENSITIVITY;   // P_BUMPSENSITIVITY
 
-          uint8_t i = (cmd_seen('I')) ? cmd_value() : 0;
+          int8_t i = (cmd_seen('I')) ? cmd_value() : 0;
 
-          if (i > 0)  // "X1"->0, "X2"->1, "Y1"->0, "Y2"->1, "Z1"->0, "Z2"->1, "Z3"->2, "Z4"->3
+          // if index is missing or set to -1 (meaning all indexes) then it must be converted to 0
+          // to make sure array index is never negative
+          if (i < 0)
+            i = 0;
+
+          // for M913 and M914, provided index is:
+          //   1->"X1", 2->"X2", 1->"Y1", 2->"Y2", 1->"Z1", 2->"Z2", 3->"Z3", 4->"Z4"
+          // and it must be converted to:
+          //   0->"X1", 1->"X2", 0->"Y1", 1->"Y2", 0->"Z1", 1->"Z2", 2->"Z3", 3->"Z4"
+          // to make sure array index is properly accessed
+          if (param > P_CURRENT && i > 0)
             i--;
 
           if (cmd_seen('X')) setParameter(param, STEPPER_INDEX_X + i, cmd_value());
@@ -1227,6 +1247,11 @@ void sendQueueCmd(void)
           if (param < P_BUMPSENSITIVITY)  // T and E options not supported by M914
           {
             i = (cmd_seen('T')) ? cmd_value() : 0;
+
+            // if index is missing or set to -1 (meaning all indexes) then it must be converted to 0
+            // to make sure array index is never negative
+            if (i < 0)
+              i = 0;
 
             if (cmd_seen('E')) setParameter(param, STEPPER_INDEX_E0 + i, cmd_value());
           }

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1088,18 +1088,15 @@ void sendQueueCmd(void)
         #endif
 
         case 301:  // Hotend PID
-        {
-          if (cmd_seen('P')) setParameter(P_HOTEND_PID, 0, cmd_float());
-          if (cmd_seen('I')) setParameter(P_HOTEND_PID, 1, cmd_float());
-          if (cmd_seen('D')) setParameter(P_HOTEND_PID, 2, cmd_float());
-          break;
-        }
-
         case 304:  // Bed PID
         {
-          if (cmd_seen('P')) setParameter(P_BED_PID, 0, cmd_float());
-          if (cmd_seen('I')) setParameter(P_BED_PID, 1, cmd_float());
-          if (cmd_seen('D')) setParameter(P_BED_PID, 2, cmd_float());
+          uint8_t param = P_HOTEND_PID;
+
+          if (cmd_value() == 304) param = P_BED_PID;  // P_BED_PID
+
+          if (cmd_seen('P')) setParameter(param, 0, cmd_float());
+          if (cmd_seen('I')) setParameter(param, 1, cmd_float());
+          if (cmd_seen('D')) setParameter(param, 2, cmd_float());
           break;
         }
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -985,7 +985,7 @@ void sendQueueCmd(void)
         case 201:  // M201 max acceleration (units/s2)
         case 203:  // M203 max feedrate (units/s)
         {
-          uint8_t param = P_STEPS_PER_MM;
+          PARAMETER_NAME param = P_STEPS_PER_MM;
 
           if (cmd_value() == 201) param = P_MAX_ACCELERATION;  // P_MAX_ACCELERATION
           if (cmd_value() == 203) param = P_MAX_FEED_RATE;     // P_MAX_FEED_RATE
@@ -1018,7 +1018,7 @@ void sendQueueCmd(void)
         case 218:  // M218 hotend offset
         case 851:  // M851 probe offset
         {
-          uint8_t param = P_HOME_OFFSET;
+          PARAMETER_NAME param = P_HOME_OFFSET;
 
           if (cmd_value() == 218) param = P_HOTEND_OFFSET;  // P_HOTEND_OFFSET
           if (cmd_value() == 851) param = P_PROBE_OFFSET;   // P_PROBE_OFFSET
@@ -1032,7 +1032,7 @@ void sendQueueCmd(void)
         case 207:  // M207 FW retraction
         case 208:  // M208 FW recover
         {
-          uint8_t param = P_FWRETRACT;
+          PARAMETER_NAME param = P_FWRETRACT;
 
           if (cmd_value() == 208) param = P_FWRECOVER;  // P_FWRECOVER
 
@@ -1090,7 +1090,7 @@ void sendQueueCmd(void)
         case 301:  // Hotend PID
         case 304:  // Bed PID
         {
-          uint8_t param = P_HOTEND_PID;
+          PARAMETER_NAME param = P_HOTEND_PID;
 
           if (cmd_value() == 304) param = P_BED_PID;  // P_BED_PID
 
@@ -1178,7 +1178,7 @@ void sendQueueCmd(void)
         case 665:  // Delta configuration / Delta tower angle
         case 666:  // Delta endstop adjustments
         {
-          uint8_t param = P_DELTA_TOWER_ANGLE;
+          PARAMETER_NAME param = P_DELTA_TOWER_ANGLE;
 
           if (cmd_value() == 666) param = P_DELTA_ENDSTOP;  // P_DELTA_ENDSTOP
 
@@ -1217,7 +1217,7 @@ void sendQueueCmd(void)
         case 913:  // M913 TMC hybrid threshold speed
         case 914:  // M914 TMC bump sensitivity
         {
-          uint8_t param = P_CURRENT;
+          PARAMETER_NAME param = P_CURRENT;
 
           if (cmd_value() == 913) param = P_HYBRID_THRESHOLD;  // P_HYBRID_THRESHOLD
           if (cmd_value() == 914) param = P_BUMPSENSITIVITY;   // P_BUMPSENSITIVITY

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -911,7 +911,7 @@ void parseACK(void)
       // parse and store axis steps-per-unit (steps/mm) (M92), max acceleration (units/s2) (M201) and max feedrate (units/s) (M203)
       else if (ack_seen("M92") || ack_seen("M201") || ack_seen("M203"))
       {
-        uint8_t param = P_STEPS_PER_MM;
+        PARAMETER_NAME param = P_STEPS_PER_MM;
 
         if (ack_seen("M201")) param = P_MAX_ACCELERATION;  // P_MAX_ACCELERATION
         if (ack_seen("M203")) param = P_MAX_FEED_RATE;     // P_MAX_FEED_RATE
@@ -943,7 +943,7 @@ void parseACK(void)
       // parse and store home offset (M206) and hotend offset (M218)
       else if (ack_seen("M206 X") || ack_seen("M218 T1 X"))
       {
-        uint8_t param = P_HOME_OFFSET;
+        PARAMETER_NAME param = P_HOME_OFFSET;
 
         if (ack_seen("M218")) param = P_HOTEND_OFFSET;  // P_HOTEND_OFFSET
 
@@ -954,7 +954,7 @@ void parseACK(void)
       // parse and store FW retraction (M207) and FW recover (M208)
       else if (ack_seen("M207 S") || ack_seen("M208 S"))
       {
-        uint8_t param = P_FWRETRACT;
+        PARAMETER_NAME param = P_FWRETRACT;
 
         if (ack_seen("M208")) param = P_FWRECOVER;  // P_FWRECOVER
 
@@ -979,7 +979,7 @@ void parseACK(void)
       // parse and store hotend PID (M301) and bed PID (M304)
       else if (ack_seen("M301") || ack_seen("M304"))
       {
-        uint8_t param = P_HOTEND_PID;
+        PARAMETER_NAME param = P_HOTEND_PID;
 
         if (ack_seen("M304")) param = P_BED_PID;  // P_BED_PID
 
@@ -1008,7 +1008,7 @@ void parseACK(void)
       //
       else if (ack_seen("M665") || ack_seen("M666"))
       {
-        uint8_t param = P_DELTA_TOWER_ANGLE;
+        PARAMETER_NAME param = P_DELTA_TOWER_ANGLE;
 
         if (ack_seen("M666")) param = P_DELTA_ENDSTOP;  // P_DELTA_ENDSTOP
 
@@ -1070,7 +1070,7 @@ void parseACK(void)
       // parse and store stepper motor current (M906), TMC hybrid threshold speed (M913) and TMC bump sensitivity (M914)
       else if (ack_seen("M906") || ack_seen("M913") || ack_seen("M914"))
       {
-        uint8_t param = P_CURRENT;
+        PARAMETER_NAME param = P_CURRENT;
 
         if (ack_seen("M913")) param = P_HYBRID_THRESHOLD;  // P_HYBRID_THRESHOLD
         if (ack_seen("M914")) param = P_BUMPSENSITIVITY;   // P_BUMPSENSITIVITY

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -976,21 +976,10 @@ void parseACK(void)
       {
         setParameter(P_AUTO_RETRACT, 0, ack_value());
       }
-      // parse and store hotend PID (M301)
-      else if (ack_seen("M301"))
+      // parse and store hotend PID (M301) and bed PID (M304)
+      else if (ack_seen("M301") || ack_seen("M304"))
       {
         uint8_t param = P_HOTEND_PID;
-
-        if (ack_seen("M301")) param = P_HOTEND_PID;  // P_HOTEND_PID
-
-        if (ack_seen("P")) setParameter(param, 0, ack_value());
-        if (ack_seen("I")) setParameter(param, 1, ack_value());
-        if (ack_seen("D")) setParameter(param, 2, ack_value());
-      }
-      // parse and store bed PID (M304)
-      else if (ack_seen("M304"))
-      {
-        uint8_t param = P_BED_PID;
 
         if (ack_seen("M304")) param = P_BED_PID;  // P_BED_PID
 

--- a/TFT/src/User/Menu/MPC.c
+++ b/TFT/src/User/Menu/MPC.c
@@ -11,7 +11,6 @@ typedef struct
   float fil_heat_capcity;
 } MPC_PARAM;
 
-
 typedef struct
 {
   MPC_STATUS status;
@@ -68,10 +67,11 @@ void menuSetMpcParam(void)
         do
         {
           tmpVal = numPadInt((uint8_t *)"1 ~ 255", mpcParameter[curTool_index].heater_power, DEF_HEATER_POWER, false);
-          if(tmpVal < 1 || tmpVal > 255)
+
+          if (tmpVal < 1 || tmpVal > 255)
             BUZZER_PLAY(SOUND_ERROR);
           else
-           break;
+            break;
         } while (true);
 
         mpcParameter[curTool_index].heater_power = tmpVal;
@@ -87,6 +87,7 @@ void menuSetMpcParam(void)
         do
         {
           tmpVal = numPadFloat((uint8_t *)"0.001 ~ 0.1", mpcParameter[curTool_index].fil_heat_capcity, DEF_FIL_HEAT_CAPACITY, false);
+
           if (tmpVal < 0.001 || tmpVal > 0.1)
             BUZZER_PLAY(SOUND_ERROR);
           else
@@ -103,7 +104,6 @@ void menuSetMpcParam(void)
         mustStoreCmd("M306 E%d P%d H%.5f\n", curTool_index, mpcParameter[curTool_index].heater_power, mpcParameter[curTool_index].fil_heat_capcity);
         CLOSE_MENU();
         break;
-
     }
 
     loopProcess();
@@ -112,7 +112,7 @@ void menuSetMpcParam(void)
 
 void mpcStart(void)
 {
-  if(storeCmd("%s\n", tool_change[curTool_index]))
+  if (storeCmd("%s\n", tool_change[curTool_index]))
   {
     if (storeCmd("M306 T\n"))
     {
@@ -188,6 +188,7 @@ void menuMPC(void)
           {
             curTool_index = (curTool_index + 1) % MAX_HOTEND_COUNT;
           } while (!heaterDisplayIsValid(curTool_index));
+
           displayValues();
           break;
 
@@ -205,6 +206,7 @@ void menuMPC(void)
           // set (neopixel) LED light to current color or to OFF according to infoSettings.led_always_on and
           // restore infoSettings.knob_led_idle and knob LED color to their default values
           LED_SetPostEventColor();
+
           CLOSE_MENU();
           break;
 
@@ -214,21 +216,23 @@ void menuMPC(void)
     }
     else if (mpcTuning.status == STARTED)
     {
+      mpcTuning.status = ONGOING;
+
       LED_SetEventColor(&ledRed, false);  // set (neopixel) LED light to RED
       LCD_SET_KNOB_LED_IDLE(false);       // set infoSettings.knob_led_idle temporary to OFF
-      mpcTuning.status = ONGOING;
     }
     else if (mpcTuning.status == ONGOING)
     {
       if (getMenuType() != MENU_TYPE_SPLASH)
       {
-       setDialogText(LABEL_SCREEN_INFO, LABEL_BUSY, LABEL_NULL, LABEL_NULL);
-       showDialog(DIALOG_TYPE_INFO, NULL, NULL, NULL);
+        setDialogText(LABEL_SCREEN_INFO, LABEL_BUSY, LABEL_NULL, LABEL_NULL);
+        showDialog(DIALOG_TYPE_INFO, NULL, NULL, NULL);
       }
 
       if (mpcTuning.result != NO_RESULT)
       {
         mpcTuning.status = DONE;
+
         LED_SetEventColor(&ledGreen, false);  // set (neopixel) LED light to GREEN
 
         switch (mpcTuning.result)

--- a/TFT/src/User/Menu/MPC.h
+++ b/TFT/src/User/Menu/MPC.h
@@ -23,13 +23,14 @@ typedef enum
   FINISHED,
 } MPC_RESULT;
 
-void menuMPC(void);
 void setMpcTuningStatus(MPC_STATUS status);
 MPC_STATUS getMpcTuningStatus(void);
 void setMpcTuningResult(MPC_RESULT result);
 void setMpcHeaterPower(uint8_t index, uint8_t power);
 void setMpcFilHeatCapacity(uint8_t index, float capacity);
 bool hasMPC(void);
+
+void menuMPC(void);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -9,7 +9,7 @@ const char *const pidCmdRRF[] = PID_CMD_RRF;
 static int16_t pidHeaterTarget[MAX_HEATER_PID_COUNT] = {0};
 static uint8_t curTool_index = NOZZLE0;
 static uint8_t degreeSteps_index = 1;
-uint32_t pidTimeout = 0;
+static uint32_t pidTimeout = 0;
 static PID_STATUS pidStatus = PID_IDLE;
 
 // called by parseAck() to notify PID process status
@@ -50,8 +50,10 @@ void pidRun(void)
 static inline void pidStart(void)
 {
   pidTimeout = OS_GetTimeMs() + PID_PROCESS_TIMEOUT;  // set timeout for overall PID process
+
   LED_SetEventColor(&ledRed, false);  // set (neopixel) LED light to RED
   LCD_SET_KNOB_LED_IDLE(false);       // set infoSettings.knob_led_idle temporary to OFF
+
   pidRun();
 }
 
@@ -112,6 +114,7 @@ void pidResultAction(void)
   if (checkFirstValidPID() == MAX_HEATER_PID_COUNT)  // no more tools left, PID autotune finished
   {
     pidStatus = PID_IDLE;
+
     LED_SetEventColor(&ledGreen, false);  // set (neopixel) LED light to GREEN
   }
 }
@@ -158,8 +161,7 @@ void menuPid(void)
         case KEY_DECREASE:
           if (pidHeaterTarget[curTool_index] > 0)
             pidHeaterTarget[curTool_index] =
-                NOBEYOND(0, pidHeaterTarget[curTool_index] - degreeSteps[degreeSteps_index],
-                        infoSettings.max_temp[curTool_index]);
+              NOBEYOND(0, pidHeaterTarget[curTool_index] - degreeSteps[degreeSteps_index], infoSettings.max_temp[curTool_index]);
 
           temperatureReDraw(curTool_index, &pidHeaterTarget[curTool_index], true);
           break;
@@ -179,8 +181,7 @@ void menuPid(void)
         case KEY_INCREASE:
           if (pidHeaterTarget[curTool_index] < infoSettings.max_temp[curTool_index])
             pidHeaterTarget[curTool_index] =
-                NOBEYOND(0, pidHeaterTarget[curTool_index] + degreeSteps[degreeSteps_index],
-                        infoSettings.max_temp[curTool_index]);
+              NOBEYOND(0, pidHeaterTarget[curTool_index] + degreeSteps[degreeSteps_index], infoSettings.max_temp[curTool_index]);
 
           temperatureReDraw(curTool_index, &pidHeaterTarget[curTool_index], true);
           break;
@@ -197,14 +198,14 @@ void menuPid(void)
 
             menuDrawItem(&pidItems.items[key_num], key_num);
             temperatureReDraw(curTool_index, &pidHeaterTarget[curTool_index], false);
-            break;
-
-          case KEY_ICON_5:
-            degreeSteps_index = (degreeSteps_index + 1) % ITEM_DEGREE_NUM;
-            pidItems.items[key_num] = itemDegreeSteps[degreeSteps_index];
-
-            menuDrawItem(&pidItems.items[key_num], key_num);
           }
+          break;
+
+        case KEY_ICON_5:
+          degreeSteps_index = (degreeSteps_index + 1) % ITEM_DEGREE_NUM;
+          pidItems.items[key_num] = itemDegreeSteps[degreeSteps_index];
+
+          menuDrawItem(&pidItems.items[key_num], key_num);
           break;
 
         case KEY_ICON_6:

--- a/TFT/src/User/Menu/Tuning.c
+++ b/TFT/src/User/Menu/Tuning.c
@@ -12,9 +12,9 @@ void menuTuning(void)
       {ICON_MPC_PID,                 LABEL_PID},
       {ICON_TUNE_EXTRUDER,           LABEL_TUNE_EXTRUDER},
       #if DELTA_PROBE_TYPE == 0  // if not Delta printer
-        {ICON_PROBE_OFFSET,          LABEL_H_OFFSET},
+        {ICON_PROBE_OFFSET,            LABEL_H_OFFSET},
       #else
-        {ICON_NULL,                  LABEL_NULL},
+        {ICON_NULL,                    LABEL_NULL},
       #endif
       {ICON_NULL,                    LABEL_NULL},
       {ICON_NULL,                    LABEL_NULL},


### PR DESCRIPTION
**BUGFIXES:**
* As reported in #2493 by @rondlh, since Marlin 2.0.9.3 the status of the TMC commands in relation to the usage of the I-command is the following:
  - **M913** (Set TMC Hybrid Threshold Speed) and
**M914** (Set TMC stallguard sensitivity)
The meaning of the I-parameter is as follows:
No I-parameter or I0 means all drivers (X, X2)
I1 means driver 1 (X, Y, Z)
I2 means driver 2(X2, Y2, Z2)
  - **M906** (set driver current) and
**M569** (Set spreadcycle or stealthchop)
The meaning of the I-parameter is as follows:
No I-parameter or I-1 means all drivers (X, X2)
I0 means driver 1 (X, Y, Z)
I1 means driver 2 (X, Y, Z)

  This PR is fixing indexing for M906 (the only command that was no more compliant with current Marlin implementation (checked Marlin 2.1.1 code).
  Furthermore, as already reported by @rondlh, Marlin documentation for both M913 and M914 is incorrect. I reported the bug here https://github.com/MarlinFirmware/Marlin/issues/24678.

* Minor code reduction for M301/M304 handling in interfaceCmd.c and parseAck.c.
* Minor cleanup.

**PR STATE:** Ready for merge.
