### PR TITLE
Fix TuneExtruder to use current E-steps

### DIFF
--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -48,7 +48,16 @@ void showNewESteps(const float measured_length, const float old_esteps, float * 
 
 static inline void extrudeFilament(void)
 {
-  // Home extruder
+  // check and adopt current E-steps
+  mustStoreCmd("M92\n");
+  infoParameters.StepsPerMM[E_AXIS] = 0;  // reset E-steps value
+
+  while (infoParameters.StepsPerMM[E_AXIS] == 0)  // wait until E-steps is updated
+  {
+    loopProcess();
+  }
+
+  // Home extruder and set absolute positioning
   mustStoreScript("G28\nG90\n");
 
   if (tool_index != heatGetCurrentTool())
@@ -69,7 +78,6 @@ static inline void extrudeFilament(void)
 
   OPEN_MENU(menuNewExtruderESteps);
 }
-// end Esteps part
 
 void menuTuneExtruder(void)
 {
@@ -230,8 +238,6 @@ void menuNewExtruderESteps(void)
   float measured_length;
   float now = measured_length = 20.00f;
   float old_esteps, new_esteps;  // get the value of the E-steps
-
-  mustStoreCmd("M503 S0\n");
 
   old_esteps = getParameter(P_STEPS_PER_MM, E_AXIS);  // get the value of the E-steps
 


### PR DESCRIPTION
### Requirements

MKS or BTT TFT

### Description

This PR updates current E-steps to be used in the E-steps calibration procedure's formula in  the "TuneExtruder" menu.

### Benefits

It makes sure the right E-steps are used in the E-steps calibration formula.

### Related Issues

If E-steps was changed externally (not from the TFT) than the E-steps calibration procedure would not use the real E-steps in its formula resulting in erroneous results.