### PR TITLE
MODULE BTT UPS and wrong resume printing while Power Off  - #2592

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -401,6 +401,8 @@ bool printRemoteStart(const char * filename)
 
 bool printStart(void)
 {
+  bool printRestore = false;
+
   // always clean infoPrinting first and then set the needed attributes
   clearInfoPrint();
 
@@ -433,7 +435,10 @@ bool printStart(void)
         powerFailedInitData();
 
         if (powerFailedCreate(infoFile.path))    // if PLR feature is enabled, open a new PLR file
+        {
+          printRestore = true;
           powerFailedlSeek(&infoPrinting.file);  // seek on PLR file
+        }
       }
 
       break;
@@ -453,7 +458,7 @@ bool printStart(void)
   // we assume infoPrinting is clean, so we need to set only the needed attributes
   infoPrinting.printing = true;
 
-  if (GET_BIT(infoSettings.send_gcodes, SEND_GCODES_START_PRINT))
+  if (!printRestore && GET_BIT(infoSettings.send_gcodes, SEND_GCODES_START_PRINT)) // PLR continue printing, CAN NOT use start gcode
     sendPrintCodes(0);
 
   if (infoFile.source == FS_ONBOARD_MEDIA)


### PR DESCRIPTION
### Description

<!--

In release 27 it worked, now with the power outage recovery, the printer restarts at the wrong height + 10mm, ingnoring parameter pl_recovery_z_raise.
when trigger power outage, the bed lowered of 10mm as predicted by the marlin firmware.
After the resumption of printing, the bed is lowered further by 10mm.
After heating the bed and the nozzle, the bed rises only 10mm and consequently 10mm are uncovered.

-->

### Benefits

Restored UPS module function

resolves https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/2592
