### PR TITLE
Change "Auto Load Bed Leveling Data" Default to Disabled

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -498,7 +498,7 @@ ext_speed:S60 N600 F1200
 #          If the mesh is invalid / incomplete leveling will not be enabled.
 #
 #   Options: [disable: 0, enable: 1]
-auto_load_leveling:1
+auto_load_leveling:0
 
 #### Onboard / Printer Media Support
 # Enable/disable presence of onboard media.

--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -470,7 +470,7 @@ ext_speed:S60 N600 F1200
 #          If the mesh is invalid / incomplete leveling will not be enabled.
 #
 #   Options: [disable: 0, enable: 1]
-auto_load_leveling:1
+auto_load_leveling:0
 
 #### Onboard / Printer Media Support
 # Enable/disable presence of onboard media.

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -511,7 +511,7 @@
  *
  *   Options: [disable: 0, enable: 1]
  */
-#define AUTO_LOAD_LEVELING 1  // Default: 1
+#define AUTO_LOAD_LEVELING 0  // Default: 0
 
 /**
  * Onboard / Printer Media

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -498,7 +498,7 @@ ext_speed:S60 N600 F1200
 #          If the mesh is invalid / incomplete leveling will not be enabled.
 #
 #   Options: [disable: 0, enable: 1]
-auto_load_leveling:1
+auto_load_leveling:0
 
 #### Onboard / Printer Media Support
 # Enable/disable presence of onboard media.

--- a/TFT/src/User/config_rrf.ini
+++ b/TFT/src/User/config_rrf.ini
@@ -470,7 +470,7 @@ ext_speed:S60 N600 F1200
 #          If the mesh is invalid / incomplete leveling will not be enabled.
 #
 #   Options: [disable: 0, enable: 1]
-auto_load_leveling:1
+auto_load_leveling:0
 
 #### Onboard / Printer Media Support
 # Enable/disable presence of onboard media.


### PR DESCRIPTION
### Description

Disables the autoloading of bed leveling data due to shear number of "Failed to enable bed leveling" reports from users thinking it's a Marlin firmware bug. This question also shows up repeatedly in various Facebook groups.

Probes might be a common upgrade, but they aren't standard on 3D printers yet. Also, leveling types like UBL are not as common as Bilinear, which won't have a mesh to load when the TFT boots up, so this is a more sane default.

### Benefits

Stop false bug reports or confused users blaming Marlin.