### PR TITLE
fix deprecation warning src_filter vs. build_src_filter (#2635)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -170,7 +170,7 @@ upload_protocol = cmsis-dap
 [env:BIGTREE_TFT24_V1_1]
 extends       = common_stm32
 board         = STM32F105RC_0x6000
-src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
+build_src_filter = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f105xC_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
@@ -216,7 +216,7 @@ build_flags   = ${stm32f2xx.build_flags} ${base64_png.build_flags}
 [env:BIGTREE_TFT35_V1_0]
 extends       = common_stm32
 board         = STM32F103VC_0x6000
-src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_hd>
+build_src_filter = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_hd>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f103xC_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
@@ -280,7 +280,7 @@ monitor_speed = 250000
 [env:BIGTREE_TFT35_V3_0]
 extends       = common_stm32
 board         = STM32F207VC_0x8000
-src_filter    = ${stm32f2xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f2xx>
+build_src_filter = ${stm32f2xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f2xx>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f2xxxC_0x8000_iap.py
 build_flags   = ${stm32f2xx.build_flags} ${base64_png.build_flags}
@@ -354,7 +354,7 @@ build_flags   = ${stm32f2xx.build_flags} ${base64_png.build_flags}
 [env:BIGTREE_TFT70_V3_0]
 extends       = common_stm32
 board         = STM32F407VG_0x8000
-src_filter    = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
+build_src_filter = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f4xxxG_0x8000_iap.py
 build_flags   = ${stm32f4xx.build_flags} ${base64_png.build_flags}
@@ -375,7 +375,7 @@ build_flags   = ${stm32f4xx.build_flags} ${base64_png.build_flags}
 [env:BIGTREE_GD_TFT24_V1_1]
 extends       = common_stm32
 board         = STM32F105RC_0x6000
-src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
+build_src_filter = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f105xC_0x6000_iap.py
 build_flags   = ${stm32f10x.build_flags}
@@ -411,7 +411,7 @@ monitor_speed = 250000
 [env:BIGTREE_GD_TFT35_V3_0]
 extends       = common_gd32
 board         = GD32F205VC_0x3000
-src_filter    = ${gd32f20x.default_src_filter} ${base64_png.default_src_filter}
+build_src_filter = ${gd32f20x.default_src_filter} ${base64_png.default_src_filter}
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/gd32f20xxC_0x3000_iap.py
 build_flags   = ${gd32f20x.build_flags} ${base64_png.build_flags}
@@ -485,7 +485,7 @@ build_flags   = ${gd32f20x.build_flags} ${base64_png.build_flags}
 [env:BIGTREE_GD_TFT70_V3_0]
 extends       = common_stm32
 board         = STM32F407VG_0x8000
-src_filter    = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
+build_src_filter = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f4xxxG_0x8000_iap.py
 build_flags   = ${stm32f4xx.build_flags} ${base64_png.build_flags}
@@ -560,7 +560,7 @@ extends       = common_stm32
 board         = STM32F107VC_0x7000
 upload_protocol = stlink
 debug_tool = stlink
-src_filter    = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
+build_src_filter = ${stm32f10x.default_src_filter} +<src/Libraries/Startup/stm32f10x_cl>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f107xC_0x7000_iap.py
 build_flags   = ${stm32f10x.build_flags}
@@ -621,7 +621,7 @@ extends       = env:MKS_TFT32_V1_3
 board         = STM32F407VE_0xC000
 upload_protocol = stlink
 debug_port    = stlink
-src_filter    = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
+build_src_filter = ${stm32f4xx.default_src_filter} ${base64_png.default_src_filter} +<src/Libraries/Startup/stm32f40_41x>
 extra_scripts = ${common.extra_scripts}
                 buildroot/scripts/stm32f4xxxE_0xC000_iap.py
                 post:buildroot/scripts/mks_encrypt.py


### PR DESCRIPTION
### Description

Fixes deprecation warning with PlatformIO 6.x; i.e.:

```bash
pio run --environment BIGTREE_TFT70_V3_0
Warning! `src_filter` configuration option in section [env:BIGTREE_TFT24_V1_1] is deprecated and will be removed in the next release! Please use `build_src_filter` instead
...
```

<!-- What does this fix or improve? -->

### Related Issues

#2635