### PR TITLE
M106 bugfix

### DIFF
--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -866,20 +866,12 @@ void sendQueueCmd(void)
           break;
 
         case 106:  // M106
-        {
-          uint8_t i = cmd_seen('P') ? cmd_value() : 0;
-
-          if (cmd_seen('S')) fanSetCurSpeed(i, cmd_value());
+          fanSetCurSpeed(cmd_seen('P') ? cmd_value() : 0, cmd_seen('S') ? cmd_value() : 100);
           break;
-        }
 
         case 107:  // M107
-        {
-          uint8_t i = cmd_seen('P') ? cmd_value() : 0;
-
-          fanSetCurSpeed(i, 0);
+          fanSetCurSpeed(cmd_seen('P') ? cmd_value() : 0, 0);
           break;
-        }
 
         case 109:  // M109
           if (fromTFT)

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -619,12 +619,9 @@ void parseACK(void)
       speedQuerySetWait(false);
     }
     // parse and store M106, fan speed
-    else if (ack_starts_with("M106 P"))
+    else if (ack_starts_with("M106"))
     {
-      uint8_t i = ack_value();
-
-      if (ack_continue_seen("S"))
-        fanSetCurSpeed(i, ack_value());
+      fanSetCurSpeed(ack_continue_seen("P") ? ack_value() : 0, ack_continue_seen("S") ? ack_value() : 100);
     }
     // parse and store M710, controller fan
     else if (ack_starts_with("M710"))


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

Sending `M106 Px` or just `M106` will make the part cooling fan spin at max speed but the status of the fan on the TFT is not updated to 100%.
This PR fixes it.

### Benefits

 - show max speed of part cooling fan when "S" parameter is omitted from "M106" command.

### Related Issues

 - none reported, own finding


### Notes

- bug is present only if "REPORT_FAN_CHANGE" is not enabled in Marlin