### PR TITLE
Fix temperature parse when multi extruder

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -552,19 +552,24 @@ void parseACK(void)
     // parse and store temperatures
     else if ((ack_seen("@") && ack_seen("T:")) || ack_seen("T0:"))
     {
-      heatSetCurrentTemp(NOZZLE0, ack_value() + 0.5f);
-      heatSetTargetTemp(NOZZLE0, ack_second_value() + 0.5f, FROM_HOST);
+      uint8_t heaterIndex = NOZZLE0;
 
-      for (uint8_t i = 1; i < MAX_HEATER_COUNT; i++)
+      if (infoSettings.hotend_count == 1)
       {
-        if (!heaterDisplayIsValid(i))
-          continue;
+        heatSetCurrentTemp(heaterIndex, ack_value() + 0.5f);
+        heatSetTargetTemp(heaterIndex, ack_second_value() + 0.5f, FROM_HOST);
+        heaterIndex = BED;
+      }
 
-        if (ack_seen(heaterID[i]))
+      while (heaterIndex < MAX_HEATER_COUNT)
+      {
+        if (heaterDisplayIsValid(heaterIndex) && ack_seen(heaterID[heaterIndex]))
         {
-          heatSetCurrentTemp(i, ack_value() + 0.5f);
-          heatSetTargetTemp(i, ack_second_value() + 0.5f, FROM_HOST);
+          heatSetCurrentTemp(heaterIndex, ack_value() + 0.5f);
+          heatSetTargetTemp(heaterIndex, ack_second_value() + 0.5f, FROM_HOST);
         }
+
+        heaterIndex++;
       }
 
       avoid_terminal = !infoSettings.terminal_ack;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

On multi extruder printers parsing of extruder temperature is broken.
This PR fixes it.

### Related Issues

Fixes #2644
Possibly fixes #2637 too.
