### PR TITLE
UBL Slave to slot menu Bugfix

### DIFF
--- a/TFT/src/User/Menu/ABL.c
+++ b/TFT/src/User/Menu/ABL.c
@@ -142,15 +142,10 @@ void menuUBLSaveLoad(void)
 
       case KEY_ICON_7:
         if (ublSlotSaved == true && infoMachineSettings.EEPROM == 1)
-        {
-          ublSlotSaved = false;
           popupDialog(DIALOG_TYPE_QUESTION, LABEL_ABL_SETTINGS_UBL, LABEL_ABL_SLOT_EEPROM, LABEL_CONFIRM, LABEL_CANCEL, saveEepromSettings, NULL, NULL);
-        }
-        else
-        {
-          ublSlotSaved = false;
-          CLOSE_MENU();
-        }
+
+        ublSlotSaved = false;
+        CLOSE_MENU();
         break;
 
       default:


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

Exiting from UBL's "Slave to slot" menu, if there was a saving to a slot, there's a popup asking about saving the mesh to EEprom. After making your choice and the popup is gone, your still in the same menu you were about to exit, the "Slave to slot" menu, so you  have to press "Back" again to really exit from that menu.
This PR fixes it, after the popup closes you're out from the "Save to slot" menu.

### Benefits

- as described above, "Save to slot" menu will exit after "Save mesh to EEprom" popup closes

### Related Issues

- none reported