### PR TITLE
Corner leveling bugfix

### DIFF
--- a/TFT/src/User/API/LevelingControl.c
+++ b/TFT/src/User/API/LevelingControl.c
@@ -1,6 +1,12 @@
 #include "LevelingControl.h"
 #include "includes.h"
 
+typedef struct XY_coord
+{
+  int16_t x_coord;
+  int16_t y_coord;
+} COORD, LEVELING_POINT_COORDS[LEVELING_POINT_COUNT];
+
 LEVELING_POINT probedPoint = LEVEL_NO_POINT;  // last probed point or LEVEL_NO_POINT in case of no new updates
 float probedZ = 0.0f;                         // last Z offset measured by probe
 
@@ -12,29 +18,24 @@ void levelingGetPointCoords(LEVELING_POINT_COORDS coords)
   int16_t y_top = infoSettings.machine_size_max[Y_AXIS] - infoSettings.level_edge;
 
   if (GET_BIT(infoSettings.inverted_axis, X_AXIS))
-  {
-    int16_t temp = x_left;  // swap left and right
+  { // swap left and right
+    int16_t temp = x_left;
     x_left = x_right;
     x_right = temp;
   }
 
-  if (GET_BIT(infoSettings.inverted_axis, E_AXIS))  // leveling Y axis
-  {
-    int16_t temp = y_bottom;  // swap lower and upper
+  if (GET_BIT(infoSettings.inverted_axis, Y_AXIS))  // leveling Y axis
+  { // swap bottom and top
+    int16_t temp = y_bottom;
     y_bottom = y_top;
     y_top = temp;
   }
 
-  coords[LEVEL_BOTTOM_LEFT][0] = x_left;
-  coords[LEVEL_BOTTOM_LEFT][1] = y_bottom;
-  coords[LEVEL_BOTTOM_RIGHT][0] = x_right;
-  coords[LEVEL_BOTTOM_RIGHT][1] = y_bottom;
-  coords[LEVEL_TOP_RIGHT][0] = x_right;
-  coords[LEVEL_TOP_RIGHT][1] = y_top;
-  coords[LEVEL_TOP_LEFT][0] = x_left;
-  coords[LEVEL_TOP_LEFT][1] = y_top;
-  coords[LEVEL_CENTER][0] = (x_left + x_right) / 2;
-  coords[LEVEL_CENTER][1] = (y_bottom + y_top) / 2;
+  coords[LEVEL_BOTTOM_LEFT] = (COORD){x_left, y_bottom};
+  coords[LEVEL_BOTTOM_RIGHT] = (COORD){x_right, y_bottom};
+  coords[LEVEL_TOP_RIGHT] = (COORD){x_right, y_top};
+  coords[LEVEL_TOP_LEFT] = (COORD){x_left, y_top};
+  coords[LEVEL_CENTER] = (COORD){(x_left + x_right) / 2, (y_bottom + y_top) / 2};
 }
 
 LEVELING_POINT levelingGetPoint(int16_t x, int16_t y)
@@ -46,7 +47,7 @@ LEVELING_POINT levelingGetPoint(int16_t x, int16_t y)
 
   for (i = 0; i < LEVELING_POINT_COUNT; i++)
   {
-    if (coords[i][0] == x && coords[i][1] == y)  // if point is found, exit from loop
+    if (coords[i].x_coord == x && coords[i].y_coord == y)  // if point is found, exit from loop
       break;
   }
 
@@ -66,7 +67,7 @@ void levelingMoveToPoint(LEVELING_POINT point)
     storeCmd("G28\n");
 
   storeCmd("G0 Z%.3f F%d\n", infoSettings.level_z_raise, infoSettings.level_feedrate[FEEDRATE_Z]);
-  storeCmd("G0 X%d Y%d F%d\n", coords[point][0], coords[point][1], infoSettings.level_feedrate[FEEDRATE_XY]);
+  storeCmd("G0 X%d Y%d F%d\n", coords[point].x_coord, coords[point].y_coord, infoSettings.level_feedrate[FEEDRATE_XY]);
   storeCmd("G0 Z%.3f F%d\n", infoSettings.level_z_pos, infoSettings.level_feedrate[FEEDRATE_Z]);
 }
 
@@ -82,12 +83,12 @@ void levelingProbePoint(LEVELING_POINT point)
   if (infoSettings.touchmi_sensor != 0)
   {
     mustStoreCmd("M401\n");
-    mustStoreCmd("G30 E0 X%d Y%d\n", coords[point][0], coords[point][1]);  // move to selected point
+    mustStoreCmd("G30 E0 X%d Y%d\n", coords[point].x_coord, coords[point].y_coord);  // move to selected point
     mustStoreCmd("G1 Z10\n");
   }
   else
   {
-    mustStoreCmd("G30 E1 X%d Y%d\n", coords[point][0], coords[point][1]);  // move to selected point
+    mustStoreCmd("G30 E1 X%d Y%d\n", coords[point].x_coord, coords[point].y_coord);  // move to selected point
   }
 
   probedPoint = LEVEL_NO_POINT;  // reset probedPoint before waiting for new probed Z

--- a/TFT/src/User/API/LevelingControl.h
+++ b/TFT/src/User/API/LevelingControl.h
@@ -21,10 +21,6 @@ typedef enum
   LEVELING_POINT_COUNT
 } LEVELING_POINT;
 
-typedef int16_t LEVELING_POINT_COORDS[LEVELING_POINT_COUNT][2];  // [][0] X coord, [][1] Y coord
-
-void levelingGetPointCoords(LEVELING_POINT_COORDS coords);   // get all point coords
-LEVELING_POINT levelingGetPoint(int16_t x, int16_t y);       // get point matching XY coords or LEVEL_CENTER in case of no match
 void levelingMoveToPoint(LEVELING_POINT point);              // move to point
 void levelingProbePoint(LEVELING_POINT point);               // probe point
 void levelingSetProbedPoint(int16_t x, int16_t y, float z);  // set probed point and Z offset for point matching XY coords


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

Corner Level menu doesn't take into account if Y axis is inverted or not (introduced by PR #2233). 
This PR fixes it.

### Benefits

- inverted Y axis is taken into account in "Corner Level" menu

### Related Issues

- none reported
