### PR TITLE
Add CRC16 check to detect change in settings 

### DIFF
--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -187,7 +187,7 @@ void initSettings(void)
                                                 sizeof(infoSettings) - sizeof(infoSettings.CRC_checksum));
 }
 
-// save settings data to FLASH, if changed, and release backed up Settings data
+// Save settings to Flash only if CRC does not match
 void saveSettings(void)
 {
   // Calculate checksum excluding the CRC variable in infoSettings

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -181,6 +181,24 @@ void initSettings(void)
   }
 
   resetConfig();
+
+  // Calculate checksum excluding the CRC variable in infoSettings
+  infoSettings.CRC_checksum = calculateCRC16((uint8_t*)&infoSettings + sizeof(infoSettings.CRC_checksum),
+                                                sizeof(infoSettings) - sizeof(infoSettings.CRC_checksum));
+}
+
+// save settings data to FLASH, if changed, and release backed up Settings data
+void saveSettings(void)
+{
+  // Calculate checksum excluding the CRC variable in infoSettings
+  uint32_t curCRC = calculateCRC16((uint8_t*)&infoSettings + sizeof(infoSettings.CRC_checksum),
+                                      sizeof(infoSettings) - sizeof(infoSettings.CRC_checksum));
+
+  if (curCRC != infoSettings.CRC_checksum) // save to Flash only if CRC does not match
+  {
+    infoSettings.CRC_checksum = curCRC;
+    storePara();
+  }
 }
 
 void initMachineSettings(void)

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -370,7 +370,7 @@ extern const uint8_t default_custom_enabled[];
 // Init settings data with default values
 void initSettings(void);
 
-// save settings data to FLASH, if changed, and release backed up Settings data
+// Save settings to Flash only if CRC does not match
 void saveSettings(void);
 
 // Init Machine settings data with default values

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -166,6 +166,7 @@ typedef enum
 
 typedef struct
 {
+  uint16_t CRC_checksum;
   // General Settings
   uint8_t  serial_port[MAX_SERIAL_PORT_COUNT];
   uint8_t  general_settings;  // emulated M600 / emulated M109-M190 / file comment parsing toggles (Bit Values)
@@ -366,9 +367,18 @@ extern const uint16_t default_preheat_ext[];
 extern const uint16_t default_preheat_bed[];
 extern const uint8_t default_custom_enabled[];
 
+// Init settings data with default values
 void initSettings(void);
+
+// save settings data to FLASH, if changed, and release backed up Settings data
+void saveSettings(void);
+
+// Init Machine settings data with default values
 void initMachineSettings(void);
+
+// setup machine setting
 void setupMachine(FW_TYPE fwType);
+
 float flashUsedPercentage(void);
 void checkflashSign(void);
 bool getFlashSignStatus(int index);

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -51,8 +51,6 @@ void menuBaudrate(void)
   uint8_t curItem = 0;
   uint16_t curPage;
 
-  backupCurrentSettings();  // backup current Settings data if not already backed up
-
   // fill baudrate items
   for (uint8_t i = 0; i < size; i++)
   {
@@ -93,7 +91,7 @@ void menuBaudrate(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 void menuSerialPorts(void)

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -91,7 +91,7 @@ void menuBaudrate(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 void menuSerialPorts(void)

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -256,5 +256,5 @@ void menuFeatureSettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -241,8 +241,6 @@ void menuFeatureSettings(void)
 
   uint16_t index = KEY_IDLE;
 
-  backupCurrentSettings();  // backup current Settings data if not already backed up
-
   listViewCreate(title, settingPage, SKEY_COUNT, &fe_cur_page, true, NULL, loadFeatureSettings);
 
   while (MENU_IS(menuFeatureSettings))
@@ -258,5 +256,5 @@ void menuFeatureSettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -546,7 +546,7 @@ void menuLEDColor(void)
 
   if (forceExit)
   {
-    saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+    saveSettings();  // Save settings
 
     if (forceLedOff)  // if LED is switched off, set (neopixel) LED light current color to OFF
       LED_SetColor(&ledOff, false);

--- a/TFT/src/User/Menu/LEDColor.c
+++ b/TFT/src/User/Menu/LEDColor.c
@@ -479,8 +479,6 @@ void menuLEDColor(void)
   KEY_VALUES key_num = KEY_IDLE;
   bool forceLedOff, forceExit;
 
-  backupCurrentSettings();  // backup current Settings data if not already backed up
-
   LED_SetColor(&infoSettings.led_color, false);  // set (neopixel) LED light current color to configured color
   LED_SendColor(&ledColor);                      // set (neopixel) LED light to current color
   forceLedOff = false;
@@ -548,7 +546,7 @@ void menuLEDColor(void)
 
   if (forceExit)
   {
-    storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+    saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 
     if (forceLedOff)  // if LED is switched off, set (neopixel) LED light current color to OFF
       LED_SetColor(&ledOff, false);

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -30,8 +30,6 @@ void menuManualLeveling(void)
 
   KEY_VALUES key_num = KEY_IDLE;
 
-  backupCurrentSettings();  // backup current Settings data if not already backed up
-
   manualLevelingItems.items[KEY_ICON_3] = itemSubmenu[curSubmenu_index];
 
   menuDrawPage(&manualLevelingItems);
@@ -106,5 +104,5 @@ void menuManualLeveling(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -104,5 +104,5 @@ void menuManualLeveling(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -90,7 +90,7 @@ void menuEmulatorFontColor(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 void menuEmulatorBGColor(void)
@@ -140,7 +140,7 @@ void menuEmulatorBGColor(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 void menuMarlinModeSettings(void)
@@ -212,7 +212,7 @@ void menuMarlinModeSettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 #endif  // ST7920_EMULATOR
@@ -387,7 +387,7 @@ void menuUISettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 #ifdef BUZZER_PIN
@@ -426,7 +426,7 @@ void menuSoundSettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }  // menuSoundSettings
 
 #endif  // BUZZER_PIN
@@ -500,7 +500,7 @@ void menuBrightnessSettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }
 
 #endif  // LCD_LED_PWM_CHANNEL
@@ -602,5 +602,5 @@ void menuScreenSettings(void)
     loopProcess();
   }
 
-  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // Save settings
 }

--- a/TFT/src/User/Menu/ScreenSettings.c
+++ b/TFT/src/User/Menu/ScreenSettings.c
@@ -50,8 +50,6 @@ void menuEmulatorFontColor(void)
   uint16_t curIndex = KEY_IDLE;
   uint8_t curItem = 0;
 
-  backupCurrentSettings();  // backup current Settings data if not already backed up
-
   // fill items
   for (uint8_t i = 0; i < COUNT(totalItems); i++)
   {
@@ -92,7 +90,7 @@ void menuEmulatorFontColor(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 void menuEmulatorBGColor(void)
@@ -101,8 +99,6 @@ void menuEmulatorBGColor(void)
   LISTITEM totalItems[LCD_COLOR_COUNT];
   uint16_t curIndex = KEY_IDLE;
   uint8_t curItem = 0;
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   // fill items
   for (uint8_t i = 0; i < COUNT(totalItems); i++)
@@ -144,7 +140,7 @@ void menuEmulatorBGColor(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 void menuMarlinModeSettings(void)
@@ -174,8 +170,6 @@ void menuMarlinModeSettings(void)
   setDynamicTextValue(4, (char *)labelMarlinType[infoSettings.marlin_type]);
 
   uint16_t curIndex = KEY_IDLE;
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   listViewCreate(title, marlinModeitems, COUNT(marlinModeitems), NULL, true, NULL, NULL);
 
@@ -218,7 +212,7 @@ void menuMarlinModeSettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 #endif  // ST7920_EMULATOR
@@ -303,8 +297,6 @@ void menuUISettings(void)
   };
 
   uint16_t curIndex = KEY_IDLE;
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   setDynamicTextValue(0, (char *)itemNotificationType[infoSettings.ack_notification]);
   setDynamicTextValue(1, (char *)itemSortBy[infoSettings.files_sort_by]);
@@ -395,7 +387,7 @@ void menuUISettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 #ifdef BUZZER_PIN
@@ -412,8 +404,6 @@ void menuSoundSettings(void)
   };
 
   uint16_t curIndex = KEY_IDLE;
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   for (uint8_t i = 0; i < SOUND_TYPE_COUNT; i++)
   {
@@ -436,7 +426,7 @@ void menuSoundSettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }  // menuSoundSettings
 
 #endif  // BUZZER_PIN
@@ -456,8 +446,6 @@ void menuBrightnessSettings(void)
 
   uint16_t curIndex = KEY_IDLE;
   char tempstr[8];
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   sprintf(tempstr, (char *)textSelect(LABEL_PERCENT_VALUE), lcd_brightness[infoSettings.lcd_brightness]);
   setDynamicTextValue(0, tempstr);
@@ -512,7 +500,7 @@ void menuBrightnessSettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }
 
 #endif  // LCD_LED_PWM_CHANNEL
@@ -553,8 +541,6 @@ void menuScreenSettings(void)
   #endif
 
   uint16_t curIndex = KEY_IDLE;
-
-  backupCurrentSettings();  // backup current Settings data if not already backed up
 
   menuDrawPage(&screenSettingsItems);
 
@@ -616,5 +602,5 @@ void menuScreenSettings(void)
     loopProcess();
   }
 
-  storeCurrentSettings();  // store new Settings data to FLASH, if changed, and release backed up Settings data
+  saveSettings();  // save settings data to FLASH, if changed, and release backed up Settings data
 }

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -304,32 +304,6 @@ float editFloatValue(float minValue, float maxValue, float resetValue, float val
   return NOBEYOND(minValue, val, maxValue);
 }
 
-// Backup of current Settings data
-static SETTINGS * nowInfoSettings = NULL;
-
-// Backup current Settings data if not already backed up
-void backupCurrentSettings(void)
-{
-  if (nowInfoSettings == NULL)
-  {
-    nowInfoSettings = (SETTINGS *) malloc(sizeof(SETTINGS));
-    *nowInfoSettings = infoSettings;
-  }
-}
-
-// Store new Settings data to FLASH, if changed, and release backed up Settings data
-void storeCurrentSettings(void)
-{
-  if (nowInfoSettings != NULL)
-  {
-    if (memcmp(nowInfoSettings, &infoSettings, sizeof(SETTINGS)))  // if settings have been modified, save to FLASH
-      storePara();
-
-    free(nowInfoSettings);
-    nowInfoSettings = NULL;
-  }
-}
-
 // set the hotend to the minimum extrusion temperature if user selected "OK"
 void heatToMinTemp(void)
 {

--- a/TFT/src/User/Menu/common.h
+++ b/TFT/src/User/Menu/common.h
@@ -93,12 +93,6 @@ int32_t editIntValue(int32_t minValue, int32_t maxValue, int32_t resetValue, int
 // Edit a float value in a standard menu
 float editFloatValue(float minValue, float maxValue, float resetValue, float value);
 
-// Backup current Settings data if not already backed up
-void backupCurrentSettings(void);
-
-// Store new Settings data to FLASH, if changed, and release backed up Settings data
-void storeCurrentSettings(void);
-
 NOZZLE_STATUS warmupNozzle(void);
 
 #ifdef SAFETY_ALERT

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <string.h>
 
+#define CRC_POLY 0xA001
+
 uint8_t inRange(int cur, int tag , int range)
 {
   if ((cur <= tag + range) && (cur >= tag - range))
@@ -16,6 +18,29 @@ uint8_t inRange(int cur, int tag , int range)
 long map(long x, long in_min, long in_max, long out_min, long out_max)
 {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}
+
+// Calculate CRC16 checksum
+uint32_t calculateCRC16(const uint8_t *data, uint32_t length)
+{
+  uint16_t crc = 0xFFFF;
+  uint32_t i;
+  for (i = 0; i < length; i++)
+  {
+    crc = (crc ^ data[i]) & 0xFFFF;
+    for (uint8_t j = 0; j < 8; j++)
+    {
+      if (crc & 1)
+      {
+        crc = (crc >> 1) ^ CRC_POLY;
+      }
+      else
+      {
+        crc = crc >> 1;
+      }
+    }
+  }
+  return crc;
 }
 
 // string convert to uint8, MSB

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -64,6 +64,8 @@ extern "C" {
 uint8_t inRange(int cur, int tag , int range);
 long map(long x, long in_min, long in_max, long out_min, long out_max);
 
+uint32_t calculateCRC16(const uint8_t *data, uint32_t length);  // Calculate CRC16 checksum
+
 uint8_t string_2_uint8_t(const uint8_t *string);
 uint8_t *uint8_2_string(uint8_t num, uint8_t *string);
 uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);


### PR DESCRIPTION
- Add CRC16 check to detect changes in settings to remove dependency on unsafe **malloc**.
- Move the Save settings function to Settings.c