### PR TITLE
Add auto copy firmware to SD card script and cleanup pre/post build scripts

### DIFF
--- a/buildroot/scripts/auto_copy_firmware.py
+++ b/buildroot/scripts/auto_copy_firmware.py
@@ -1,16 +1,21 @@
 Import("env")
+import os
 import shutil
 
 def copy_firmware(source, target, env):
     print("Releasing firmware...")
+    repo_path = os.path.realpath("")
     build_dir = env.subst('$BUILD_DIR')
-    filename = "/" + env['PROGNAME'] + ".bin"
+    filename = env['PROGNAME'] + ".bin"
+    src_file_path = os.path.join(repo_path, build_dir, filename)
     build_flags = env.ParseFlags(env['BUILD_FLAGS'])
     flags = {k: v for (k, v) in build_flags.get("CPPDEFINES")}
     target_dir = flags.get("BINARY_DIRECTORY")
     if target_dir == None:
         target_dir = "Copy to SD Card root directory to update"
-    shutil.copyfile(build_dir + filename, target_dir + filename)
+    target_file_path = os.path.join(repo_path, target_dir, filename)
+    shutil.copyfile(src_file_path, target_file_path)
+
     print("Done.")
 
 env.AddPostAction("buildprog", copy_firmware)

--- a/buildroot/scripts/auto_copy_to_sd.py
+++ b/buildroot/scripts/auto_copy_to_sd.py
@@ -1,0 +1,34 @@
+Import("env")
+import os
+import shutil
+import psutil
+
+def copy_to_sd(source, target, env):
+    repo_path = os.path.realpath("")
+    build_dir = env.subst('$BUILD_DIR')
+    filename = env['PROGNAME'] + ".bin"
+    src_file_path = os.path.join(repo_path, build_dir, filename)
+    copied = False
+    unsupported_format = False
+    # Iterate through all connected devices
+    for partition in psutil.disk_partitions():
+        # Check if the device is removable
+        if partition.fstype != "" and 'removable' in partition.opts:
+            if (partition.fstype == "vfat" or partition.fstype == "FAT32" or partition.fstype == "exFAT"):
+                # Define destination file path
+                target_file_path = os.path.join(partition.device, filename)
+                # Copy the file
+                shutil.copyfile(src_file_path, target_file_path)
+                print(filename + " copied to " + partition.device + " succesfully.")
+                copied = True
+                unsupported_format = False
+                break
+            else:
+                unsupported_format = True
+    # print error if unsuccessful
+    if copied == False:
+        if unsupported_format:
+            print("No removable storage found with file format FAT32 or exFAT!")
+        else:
+            print("No removable storage found!")
+env.AddPostAction("buildprog", copy_to_sd)

--- a/buildroot/scripts/auto_gen_language_pack.py
+++ b/buildroot/scripts/auto_gen_language_pack.py
@@ -21,10 +21,10 @@ string_header = """#### Language Code:_code_
 ## Maximum byte per keyword is 250 Bytes.
 ## Escape characters are not supported except newline '\\n'\n\n"""
 
-input_path = "/TFT/src/User/API/Language"
-output_path = "/Copy to SD Card root directory to update/Language Packs"
+input_path =  os.path.join("TFT", "src", "User", "API", "Language")
+output_path = os.path.join("Copy to SD Card root directory to update", "Language Packs")
 # output_path2 = "/Copy to SD Card root directory to update - Unified Menu Material theme/Language Packs"
-setting_path = "/TFT/src/User/API/Settings.h"
+setting_path = os.path.join("TFT", "src", "User", "API", "Settings.h")
 
 file_count = 0
 key_count = 0
@@ -41,7 +41,7 @@ def get_filename(line):
 
 def dest_filepath(line):
     filename = get_filename(line).replace(".h", ".ini")
-    d_path = repo_path + output_path + "/" + filename
+    d_path = os.path.join(repo_path, output_path, filename)
     return d_path
 
 def make_label(line):
@@ -63,56 +63,46 @@ def get_string(line):
 
 def get_lang_sign():
     global lang_sign
-    set_file = open(repo_path + setting_path, 'r', encoding = "utf8")
-    lines_list = set_file.readlines()
+    with open(os.path.join( repo_path, setting_path), 'r', encoding = "utf8") as set_file:
+        lines_list = set_file.readlines()
     for text_line in lines_list:
         text_line = text_line.strip()
         if text_line.startswith(lang_sign_prefix):
             l = text_line.split()
             lang_sign = l[2]
     #print("lang sign :" + lang_sign)
-    set_file.close()
 
-    #####
 try:
     print("Generate language_xx.ini files:")
     repo_path = os.path.realpath("")
     #print(repo_path)
     get_lang_sign()
-
-    for src_file in glob.glob(repo_path + input_path + "/" + source_file):
+    # open and scan every .h file found
+    for src_file in glob.glob(os.path.join(repo_path, input_path, source_file)):
         key_count = 0
         file_count += 1
         print("Processing: " + get_filename(src_file), end = ": ")
-        source_file = open(src_file, 'r', encoding = "utf8")
-        dest_file = open(dest_filepath(src_file), 'w', encoding = "utf8")
-        header = string_header.replace("_code_", get_langcode(get_filename(src_file)))
-        header = header.replace("_sign_", lang_sign)
-        dest_file.writelines(header)
-        lines_list = source_file.readlines()
+        # create .ini file to start writing keywords
+        with open(src_file, 'r', encoding = "utf8") as source_file, open(dest_filepath(src_file), 'w', encoding = "utf8") as dest_file:
+            header = string_header.replace("_code_", get_langcode(get_filename(src_file)))
+            header = header.replace("_sign_", lang_sign)
+            dest_file.write(header)
+            # extract keywords from source file
+            for line in source_file:
+                line = line.strip()
+                if line.startswith(line_start):
+                    label = make_label(line)
+                    val_string = get_string(line)
+                    #print(val_string)
+                    # write keywords to ini file if within size limits
+                    if len(val_string.encode()) <= bytesize:
+                        dest_file.write(val_string + '\n')
+                        key_count += 1
+            # add final new line at the end of the file
+            #dest_file.writelines("\n")
+            print("Total keys: " + str(key_count))
 
-        for text_line in lines_list:
-            text_line = text_line.strip()
-            if text_line.startswith(line_start):
-                key_count += 1
-                label = make_label(text_line)
-                val_string = get_string(text_line)
-                #print(val_string)
-                if len(val_string.encode('utf-8')) > bytesize:
-                    raise Exception(">> Size of key '" + get_defined_name(text_line) + "' in " + get_filename(src_file) + " is larger than " + str(bytesize) + " Bytes!\n")
-                dest_file.writelines(val_string + "\n")
+except Exception as e:
+    print("Error Occured: " + str(e))
 
-        dest_file.writelines("\n") #add new line at the end of the file
-        source_file.close()
-        dest_file.close()
-        # shutil.copy(dest_filepath(src_file), repo_path + output_path2) #copy file to second folder
-        print("Total keywords found:" + str(key_count) + ", File generated:" + get_filename(dest_filepath(src_file)))
-
-    if file_count == 0:
-        print("No files found.")
-    else:
-        print("Total language files processed: " + str(file_count))
-
-except:
-    print("Unable to get correct path")
 # %%

--- a/buildroot/scripts/custom_filename.py
+++ b/buildroot/scripts/custom_filename.py
@@ -1,13 +1,13 @@
 Import("env")
 
-print("Generating firmware...")
 build_flags = env.ParseFlags(env['BUILD_FLAGS'])
 flags = {k: v for (k, v) in build_flags.get("CPPDEFINES")}
 filename = flags.get("BINARY_FILENAME")
+# set file name by hardware and firmware version
 if filename == None:
     filename = flags.get("HARDWARE") + "." + flags.get("SOFTWARE_VERSION")
+# rename firmware if portrait mode is selected
 if flags.get("PORTRAIT_MODE") != None:
     filename = filename + flags.get("PORTRAIT_MODE")
-print("Done.")
 
 env.Replace(PROGNAME = filename)

--- a/buildroot/scripts/pre_install_dependencies.py
+++ b/buildroot/scripts/pre_install_dependencies.py
@@ -1,0 +1,9 @@
+import pkg_resources
+
+Import("env")
+installed = {pkg.key for pkg in pkg_resources.working_set}
+
+if 'psutil' in installed:
+    pass
+else:
+    env.Execute("$PYTHONEXE -m pip install psutil")

--- a/buildroot/scripts/short_out_filename.py
+++ b/buildroot/scripts/short_out_filename.py
@@ -1,14 +1,18 @@
 Import("env")
+import os
 import shutil
 
 def make_short_file(source, target, env):
     print("Generating firmware with short file name...")
+    repo_path = os.path.realpath("")
     build_dir = env.subst('$BUILD_DIR')
-    filename = "/" + env['PROGNAME'] + ".bin"
+    filename = env['PROGNAME'] + ".bin"
+    src_file_path = os.path.join(repo_path, build_dir, filename)
     build_flags = env.ParseFlags(env['BUILD_FLAGS'])
     flags = {k: v for (k, v) in build_flags.get("CPPDEFINES")}
-    filename_short = "/" + flags.get("HARDWARE_SHORT") + flags.get("SOFTWARE_VERSION_SHORT") + ".new"
-    shutil.copyfile(build_dir + filename, build_dir + filename_short)
+    filename_short = flags.get("HARDWARE_SHORT") + flags.get("SOFTWARE_VERSION_SHORT") + ".new"
+    target_file_path = os.path.join(repo_path, build_dir, filename_short)
+    shutil.copyfile(src_file_path, target_file_path)
     print("Done.")
 
 env.AddPostAction("buildprog", make_short_file)

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,10 +54,12 @@ default_src_filter = +<src/*> -<src/Libraries>
                      -<src/User/Hal/STM32_USB_HOST_Library> -<src/User/Hal/STM32_USB_OTG_Driver/>
                      -<src/User/Hal/gd32f20x> -<src/User/Hal/GD32F20x_usbfs_library>
                      ${json.default_src_filter}
-extra_scripts      = pre:buildroot/scripts/custom_filename.py
-                     post:buildroot/scripts/short_out_filename.py
+extra_scripts      = pre:buildroot/scripts/pre_install_dependencies.py
+                     pre:buildroot/scripts/custom_filename.py
                      post:buildroot/scripts/auto_gen_language_pack.py
 ;                     post:buildroot/scripts/auto_copy_firmware.py  ; uncomment here when a new .bin firmware needs to be released
+;                     post:buildroot/scripts/auto_copy_to_sd.py  ; uncomment here to copy new .bin file to sd card
+;                     post:buildroot/scripts/short_out_filename.py  ; uncomment to generate .bin file with short file name.
 build_flags        = -fmax-errors=5
                      -g
                      -ggdb


### PR DESCRIPTION
- Add auto-copy firmware to removable storage/SD card script (Can be enabled by uncommenting `post:buildroot/scripts/auto_copy_to_sd.py` in platformio.ini).
- Make file path generation in scripts safer for cross-platform usage.
- Clean up pre/post-build scripts.
- Remove ambiguous verbose in custom_filename.py
- Disable short_out_filename.py by default.