### PR TITLE
Update language_fr.h

### DIFF
--- a/Copy to SD Card root directory to update/Language Packs/language_fr.ini
+++ b/Copy to SD Card root directory to update/Language Packs/language_fr.ini
@@ -111,7 +111,7 @@ label_zero:Zéro
 label_half:Moitié
 label_full:Max
 label_custom:Custom
-label_clear:Effacer
+label_clear:Suppr.
 label_default:Défaut
 label_start:Démarrer
 label_stop:Stopper
@@ -121,7 +121,7 @@ label_init:Init
 label_disconnect:Libérer
 label_shut_down:Eteindre
 label_force_shut_down:Forcer l'extinction
-label_emergencystop:Arrêt
+label_emergencystop:Urgence
 label_preheat:Préparer
 label_preheat_both:Global
 label_cooldown:Refroidir
@@ -148,8 +148,8 @@ label_process_completed:Processus terminé !
 label_process_aborted:Processus annulé !
 label_tft_sd:SD TFT
 label_tft_sd_read_error:Erreur de lecture de la carte SD !
-label_tft_sd_inserted:Carte insérée !
-label_tft_sd_removed:Carte retirée !
+label_tft_sd_inserted:Carte SD insérée !
+label_tft_sd_removed:Carte SD retirée !
 label_tft_sd_not_detected:Aucune carte SD détectée.
 label_tft_usb:USB TFT
 label_tft_usb_read_error:Erreur de lecture de la clé USB !

--- a/TFT/src/User/API/Language/language_fr.h
+++ b/TFT/src/User/API/Language/language_fr.h
@@ -120,7 +120,7 @@
     #define STRING_HALF                   "Moitié"
     #define STRING_FULL                   "Max"
     #define STRING_CUSTOM                 "Custom"
-    #define STRING_CLEAR                  "Effacer"
+    #define STRING_CLEAR                  "Suppr."
     #define STRING_DEFAULT                "Défaut"
 
     // Action Buttons
@@ -132,7 +132,7 @@
     #define STRING_DISCONNECT             "Libérer"
     #define STRING_SHUT_DOWN              "Eteindre"
     #define STRING_FORCE_SHUT_DOWN        "Forcer l'extinction"
-    #define STRING_EMERGENCYSTOP          "Arrêt"
+    #define STRING_EMERGENCYSTOP          "Urgence"
     #define STRING_PREHEAT                "Préparer"
     #define STRING_PREHEAT_BOTH           "Global"
     #define STRING_COOLDOWN               "Refroidir"
@@ -167,8 +167,8 @@
     // TFT Media, Onboard Media, Filament Runout Process Commands / Status / Info
     #define STRING_TFT_SD                 "SD TFT"
     #define STRING_TFT_SD_READ_ERROR      "Erreur de lecture de la carte SD !"
-    #define STRING_TFT_SD_INSERTED        "Carte insérée !"
-    #define STRING_TFT_SD_REMOVED         "Carte retirée !"
+    #define STRING_TFT_SD_INSERTED        "Carte SD insérée !"
+    #define STRING_TFT_SD_REMOVED         "Carte SD retirée !"
     #define STRING_TFT_SD_NOT_DETECTED    "Aucune carte SD détectée."
     #define STRING_TFT_USB                "USB TFT"
     #define STRING_TFT_USB_READ_ERROR     "Erreur de lecture de la clé USB !"


### PR DESCRIPTION
French customization to fit with max size of 10 char (label_clear), adapt the wording correctly ( label_tft_sd_inserted & label_tft_sd_removed) and adapt to comprehensive button (label_emergencystop) ( "Arrêt" in french is similar to Stop, but not not urgency. The correct spelling will be "Arrêt d'urgence" or "Stop d'urgence" but the size is limited to 10 char. So "Urgence" is more comprehensive with the bmp button with the stop)

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
