### PR TITLE
Fix comment parsing speed regression

### DIFF
--- a/TFT/src/User/API/comment.c
+++ b/TFT/src/User/API/comment.c
@@ -5,7 +5,7 @@
 #define KEYWORD_INTIALS "lLrRtT"  // the initials of the searched keywords, add new initials for new keywords
 
 char gCodeCommentLine[COMMENT_MAX_CHAR] = {0};
-bool slicerTimePresence = false;
+static bool slicerTimePresence = false;
 
 void setTimeFromSlicer(bool present)
 {
@@ -17,90 +17,74 @@ void parseComment(void)
   if (gCodeCommentLine[0] == '\0')
     return;
 
-  // check for words starting with "l", "L", "r", "R", "t" or "T".
+  // - check for words starting with "l", "L", "r", "R", "t" or "T"
   // It is done so for speed purposes, it is a waste of MCU cycles to extract
   // tokens, convert them to lower case and check if they are among the known
-  // keywords if they do not start with the above mentioned letters
-  //
+  // keywords if they do not start with the above mentioned letters.
   if (strchr(KEYWORD_INTIALS, gCodeCommentLine[0]) != NULL)
   {
     char * token;
     uint32_t token_value;
 
-    token = strlwr(strtok(gCodeCommentLine, TOKEN_DELIMITERS));
+    token = strToLwr(strtok(gCodeCommentLine, TOKEN_DELIMITERS));
 
     // check for "layer" keyword in comment (layer number or layer count)
     if (strcmp(token, "layer") == 0)
     {
-      if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)
+      token = strToLwr(strtok(NULL, TOKEN_DELIMITERS));
+
+      if (strcmp(token, "count") == 0)  // check if next word is "count"
       {
-        strlwr(token);
+        token = strtok(NULL, TOKEN_DELIMITERS);
+        token_value = strtoul(token, NULL, 0);
 
-        if (strcmp(token, "count") == 0)  // check if next word is "count"
-        {
-          if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)  // get the layer number
-          {
-            token_value = strtoul(token, NULL, 0);
-
-            if (token_value != 0)
-              setPrintLayerCount(token_value);
-          }
-        }
-        else if (NUMERIC(token[0]))  // check if a number is found
-        {
-          token_value = strtoul(token, NULL, 0);
-
-          // "token_value == 0" for object by object printing, when print goes to the next object
-          // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
-          setPrintLayerNumber(((token_value == 0) || (getPrintLayerNumber() == token_value)) ? token_value + 1 : token_value);
-        }
+        if (token_value != 0)
+          setPrintLayerCount(token_value);
+      }
+      else if (NUMERIC(token[0]))  // check if a number is found
+      {
+        token_value = strtoul(token, NULL, 0);
+        // "token_value == 0" for object by object printing, when print goes to the next object
+        // if there is "layer 0" add an offset of 1 (avoiding using an offset variable)
+        setPrintLayerNumber(((token_value == 0) || (getPrintLayerNumber() == token_value)) ? token_value + 1: token_value);
       }
     }
 
     // check for "time" keyword in comment to retrieve total or elapsed time, Cura specific
     else if (strcmp(token, "time") == 0 && slicerTimePresence == false)  // check if first word is "time"
     {
-      if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)
+      token = strToLwr(strtok(NULL, TOKEN_DELIMITERS));
+
+      if (strcmp(token, "elapsed") == 0 && getPrintExpectedTime() > 0)  // check if next word is "elapsed"
       {
-        strlwr(token);
+        token = strtok(NULL, TOKEN_DELIMITERS);
+        token_value = strtoul(token, NULL, 0);  // get the elapsed time in seconds
+        setPrintRemainingTime(getPrintExpectedTime() - token_value);
+      }
+      else if (NUMERIC(token[0]))  // check if a number is found
+      {
+        token_value = strtoul(token, NULL, 0);  // get the time in seconds
+        setPrintExpectedTime(token_value);
+        setPrintRemainingTime(token_value);
 
-        if (strcmp(token, "elapsed") == 0 && getPrintExpectedTime() > 0)  // check if next word is "elapsed"
-        {
-          if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)  // get the elapsed time in seconds
-          {
-            setPrintRemainingTime(getPrintExpectedTime() - strtoul(token, NULL, 0));
-          }
-        }
-        else if (NUMERIC(token[0]))  // check if a number is found
-        {
-          token_value = strtoul(token, NULL, 0);  // get the time in seconds
-
-          setPrintExpectedTime(token_value);
-          setPrintRemainingTime(token_value);
-
-          if (getPrintProgressSource() < PROG_TIME && infoSettings.prog_source == 1)
-            setPrintProgressSource(PROG_TIME);
-        }
+        if (getPrintProgressSource() < PROG_TIME && infoSettings.prog_source == 1)
+          setPrintProgressSource(PROG_TIME);
       }
     }
 
     // check for "remaining" keyword in comment to retrieve remaining time, IdeaMaker specific
     else if (strcmp(token, "remaining") == 0 && slicerTimePresence == false)  // check if first word is "remaining"
     {
-      if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)
+      token = strToLwr(strtok(NULL, TOKEN_DELIMITERS));
+
+      if (strcmp(token, "time") == 0)  // check if next word is "time"
       {
-        strlwr(token);
+        token = strtok(NULL, TOKEN_DELIMITERS);
+        token_value = strtoul(token, NULL, 0);  // get the remaining time in seconds
+        setPrintRemainingTime(token_value);
 
-        if (strcmp(token, "time") == 0)  // check if next word is "time"
-        {
-          if ((token = strtok(NULL, TOKEN_DELIMITERS)) != NULL)  // get the remaining time in seconds
-          {
-            setPrintRemainingTime(strtoul(token, NULL, 0));
-
-            if (getPrintProgressSource() < PROG_TIME && infoSettings.prog_source == 1)
-              setPrintProgressSource(PROG_TIME);
-          }
-        }
+        if (getPrintProgressSource() < PROG_TIME && infoSettings.prog_source == 1)
+          setPrintProgressSource(PROG_TIME);
       }
     }
   }

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1117,7 +1117,7 @@
  * Monitoring Debug
  * Uncomment/Enable to monitor/show system resources usage in Monitoring menu.
  */
-#define DEBUG_MONITORING  // Default: commented (disabled)
+//#define DEBUG_MONITORING  // Default: commented (disabled)
 
 /**
  * Generic Debug
@@ -1431,7 +1431,7 @@
  * Uncomment to enable a progress bar with 10% markers.
  * Comment to enable a standard progress bar.
  */
-#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
+//#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
 
 /**
  * Live Text Common Color Layout (Status Screen menu)

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -5,6 +5,7 @@
 #include <stddef.h>
 
 #define CRC_POLY 0xA001
+#define HIGH_TO_LOW_CASE 32  // 'a' - 'A'
 
 uint8_t inRange(int cur, int tag , int range)
 {
@@ -173,6 +174,35 @@ double strtod_ligth(char *str, char **endptr)
 
   return val * sign;
 }
+
+// converts a string to lower case, returns the pointer of said string
+char * strToLwr(char * string)
+{
+  char * tmp_str = string;
+  while (*tmp_str != '\0')
+  {
+    if (UPPER_CASE(*tmp_str))
+      *tmp_str |= HIGH_TO_LOW_CASE;
+    tmp_str++;
+  }
+
+  return string;
+}
+
+// converts a string to upper case, returns the pointer of said string
+char * strToUpr(char * string)
+{
+  char * tmp_str = string;
+  while (*tmp_str != '\0')
+  {
+    if (LOWER_CASE(*tmp_str))
+      *tmp_str &= ~HIGH_TO_LOW_CASE;
+    tmp_str++;
+  }
+
+  return string;
+}
+
 
 // light weight and safe strncpy() function with padding:
 // - copy "src" to "dest" for a maximum of "n-1" characters

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -29,6 +29,8 @@ extern "C" {
 
 #define WITHIN(N, L, H) ((N) >= (L) && (N) <= (H))
 #define NUMERIC(a)      WITHIN(a, '0', '9')
+#define LOWER_CASE(c)   WITHIN(c, 'a', 'z')
+#define UPPER_CASE(c)   WITHIN(c, 'A', 'Z')
 
 // Bitwise macros
 
@@ -90,6 +92,9 @@ void time_2_string(char *buf, char *str_format, uint32_t time);           // con
 double strtod_ligth(char *str, char **endptr);               // light weight strtod() function without exponential support
 void strncpy_pad(char *dest, const char *src, size_t n);     // light weight and safe strncpy() function with padding
 void strncpy_no_pad(char *dest, const char *src, size_t n);  // light weight and safe strncpy() function without padding
+
+char * strToLwr(char * string);  // converts a string to lower case, returns the pointer of said string
+char * strToUpr(char * string);  // converts a string to upper case, returns the pointer of said string
 
 const char *stripHead(const char *str);  // strip out any leading " ", "/" or ":" character that might be in the string
 void stripChecksum(char *str);           // strip out any trailing checksum that might be in the string


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

##
PR #2671 promised to "Optimize comment parsing in comment.c", instead it crowded the MCU with unnecessary instructions, all these during printing, where speed is crucial. The opposite of optimize was done, there is no benefit from it, only loss. The resulting code is not even smaller with one single byte.
Because of PR #2671 the first word in every comment from the G-code file is preprocessed even if it is not even a candidate for a known keyword. This takes time and it is unnecessary, not to mention again that this is during printing.

This PR brings back the systematic approach that was done before this "optimization" and also does what PR #2671 assumably wanted to do, reduces the footprint of "comment.c" on the FW's size.

##
An alternative for `strlwr()' and 'strupr()' is introduced. The introduced functions are lighter and are returning the pointer to the processed string. 
##

### Benefits

- faster overall processing of G-code comments

### Related Issues

 - luckily none reported yet
