### PR TITLE
Feature/decode png to flash

### DIFF
--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -426,7 +426,16 @@ bool model_DirectDisplay_Base64PNG(GUI_POINT pos, FIL *gcodeFile)
 
 bool model_DecodeToFlash_Base64PNG(FIL *gcodeFile, uint32_t addr)
 {
+  uint16_t w = ICON_WIDTH;
+  uint16_t h = ICON_HEIGHT;
+
   W25Qxx_DECODE session = {0, addr, {}};
+
+  memcpy(session.buf, (uint8_t *)&w, sizeof(uint16_t));
+  session.bnum += sizeof(uint16_t);
+  memcpy(session.buf + session.bnum, (uint8_t *)&h, sizeof(uint16_t));
+  session.bnum += sizeof(uint16_t);
+
   return model_Process_Base64PNG(gcodeFile, &session, on_decode_png_pixel, on_decode_png_pixel_done);
 }
 

--- a/TFT/src/User/API/UI/ui_draw.c
+++ b/TFT/src/User/API/UI/ui_draw.c
@@ -323,6 +323,36 @@ void on_draw_png_pixel(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint3
   LCD_WR_16BITS_DATA(color_alpha_565(0, 0, 0, rgba[0], rgba[1], rgba[2], rgba[3]));
 }
 
+typedef struct
+{
+    uint16_t bnum;
+    uint32_t addr;
+    uint8_t buf[256];
+} W25Qxx_DECODE;
+
+void on_decode_png_pixel(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t rgba[4])
+{
+  W25Qxx_DECODE *session = (W25Qxx_DECODE *) pngle_get_user_data(pngle);
+
+  uint16_t color = color_alpha_565(0, 0, 0, rgba[0], rgba[1], rgba[2], rgba[3]);
+
+  session->buf[session->bnum++] = (uint8_t) (color >> 8);
+  session->buf[session->bnum++] = (uint8_t) (color & 0xFF);
+
+  if (session->bnum == 256)
+  {
+    W25Qxx_WritePage(session->buf, session->addr, 256);
+    session->addr += 256;
+    session->bnum = 0;
+  }
+}
+
+void on_decode_png_pixel_done(pngle_t *pngle)
+{
+  W25Qxx_DECODE *session = (W25Qxx_DECODE *) pngle_get_user_data(pngle);
+  W25Qxx_WritePage(session->buf, session->addr, session->bnum);
+}
+
 /**
  * Thumbnail is a Base64 encoded PNG file.
  * Gcode format:
@@ -330,7 +360,8 @@ void on_draw_png_pixel(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint3
  * <BASE64 encoded PNG>
  * ; thumbnail end
  */
-bool model_DirectDisplay_Base64PNG(GUI_POINT pos, FIL *gcodeFile)
+bool model_Process_Base64PNG(FIL *gcodeFile, void *user_data, pngle_draw_callback_t draw_callback,
+                             pngle_done_callback_t done_callback)
 {
   uint32_t base64_len;
   char buf[256];
@@ -354,8 +385,9 @@ bool model_DirectDisplay_Base64PNG(GUI_POINT pos, FIL *gcodeFile)
   if (!pngle)
     goto pngle_new_failed;
 
-  pngle_set_draw_callback(pngle, on_draw_png_pixel);
-  pngle_set_user_data(pngle, &pos);
+  pngle_set_draw_callback(pngle, draw_callback);
+  if (done_callback) pngle_set_done_callback(pngle, done_callback);
+  pngle_set_user_data(pngle, user_data);
 
   int remain = 0;
   int len;
@@ -385,6 +417,17 @@ pngle_failed:
 
 pngle_new_failed:
   return false;
+}
+
+bool model_DirectDisplay_Base64PNG(GUI_POINT pos, FIL *gcodeFile)
+{
+  return model_Process_Base64PNG(gcodeFile, &pos, on_draw_png_pixel, NULL);
+}
+
+bool model_DecodeToFlash_Base64PNG(FIL *gcodeFile, uint32_t addr)
+{
+  W25Qxx_DECODE session = {0, addr, {}};
+  return model_Process_Base64PNG(gcodeFile, &session, on_decode_png_pixel, on_decode_png_pixel_done);
 }
 
 #endif
@@ -473,49 +516,37 @@ bool model_DirectDisplay(GUI_POINT pos, char *gcode)
   return false;
 }
 
-bool model_DecodeToFlash(char *gcode)
+bool model_DecodeToFlash_Classic(FIL *gcodeFile, uint32_t addr)
 {
-  uint32_t addr = ICON_ADDR(ICON_PREVIEW);
-  uint16_t bnum;
+  uint16_t bnum = 0;
   uint16_t w = ICON_WIDTH;
   uint16_t h = ICON_HEIGHT;
 
   uint8_t buf[256];
-  FIL gcodeFile;
-
-  if (f_open(&gcodeFile, gcode, FA_OPEN_EXISTING | FA_READ) != FR_OK)
-    return false;
 
   // Move the file cursor to the corresponding resolution area
-  f_lseek(&gcodeFile, MODEL_PREVIEW_OFFSET);
+  f_lseek(gcodeFile, MODEL_PREVIEW_OFFSET);
 
   // Check whether the icon size matches
-  if (modelFileReadHalfword(&gcodeFile) != w || modelFileReadHalfword(&gcodeFile) != h)
+  if (modelFileReadHalfword(gcodeFile) != w || modelFileReadHalfword(gcodeFile) != h)
     return false;
 
   // Move to next line
-  f_lseek(&gcodeFile, gcodeFile.fptr + 3);
+  f_lseek(gcodeFile, gcodeFile->fptr + 3);
 
-  for (bnum = 0; bnum < (w * h * 2 + W25QXX_SECTOR_SIZE - 1) / W25QXX_SECTOR_SIZE; bnum++)
-  {
-    W25Qxx_EraseSector(addr + bnum * W25QXX_SECTOR_SIZE);
-  }
-
-  bnum = 0;
-
-  memcpy(buf, (uint8_t *)&w, sizeof(uint16_t));
+  memcpy(buf, (uint8_t *) &w, sizeof(uint16_t));
   bnum += sizeof(uint16_t);
-  memcpy(buf + bnum, (uint8_t *)&h, sizeof(uint16_t));
+  memcpy(buf + bnum, (uint8_t *) &h, sizeof(uint16_t));
   bnum += sizeof(uint16_t);
 
   for (uint16_t y = 0; y < h; y++)
   {
     for (uint16_t x = 0; x < w; x++)
     {
-      uint16_t color = modelFileReadHalfword(&gcodeFile);
+      uint16_t color = modelFileReadHalfword(gcodeFile);
 
-      buf[bnum++] = (uint8_t)(color >> 8);
-      buf[bnum++] = (uint8_t)(color & 0xFF);
+      buf[bnum++] = (uint8_t) (color >> 8);
+      buf[bnum++] = (uint8_t) (color & 0xFF);
 
       if (bnum == 256)
       {
@@ -526,12 +557,38 @@ bool model_DecodeToFlash(char *gcode)
     }
 
     // Move to next line
-    f_lseek(&gcodeFile, gcodeFile.fptr + 3);
+    f_lseek(gcodeFile, gcodeFile->fptr + 3);
   }
 
   W25Qxx_WritePage(buf, addr, bnum);
 
   return true;
+}
+
+bool model_DecodeToFlash(char *gcode)
+{
+  FIL gcodeFile;
+
+  if (f_open(&gcodeFile, gcode, FA_OPEN_EXISTING | FA_READ) != FR_OK)
+    return false;
+
+  uint32_t addr = ICON_ADDR(ICON_PREVIEW);
+
+  for (uint16_t bnum = 0;
+       bnum < (ICON_WIDTH * ICON_HEIGHT * 2 + W25QXX_SECTOR_SIZE - 1) / W25QXX_SECTOR_SIZE; bnum++)
+  {
+    W25Qxx_EraseSector(addr + bnum * W25QXX_SECTOR_SIZE);
+  }
+
+  if (model_DecodeToFlash_Classic(&gcodeFile, addr))
+    return true;
+
+#if (THUMBNAIL_PARSER == PARSER_BASE64PNG)
+  if (model_DecodeToFlash_Base64PNG(&gcodeFile, addr))
+    return true;
+#endif
+
+  return false;
 }
 
 void SMALLICON_ReadDisplay(uint16_t sx, uint16_t sy, uint8_t icon)


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Adds the decode to flash function for png, which in turn enables the display of the thumbnail image instead of the babystepping icon just as it does for "classic" (RGB565) thumbnail parsing.

### Benefits

The thumbnail now also works if the embedded image is in png format (prusa slicer e.g. does not have any RGB565 thumbnail generation)

### Related Issues

None, I just noticed that there is such a feature but only for classic thumbnails, so I changed it to also for png which was already implemented for the file list but not for the print screen.
