### PR TITLE
Leveling points bugfix

### DIFF
--- a/TFT/src/User/API/LevelingControl.c
+++ b/TFT/src/User/API/LevelingControl.c
@@ -10,12 +10,18 @@ typedef struct XY_coord
 LEVELING_POINT probedPoint = LEVEL_NO_POINT;  // last probed point or LEVEL_NO_POINT in case of no new updates
 float probedZ = 0.0f;                         // last Z offset measured by probe
 
+int16_t setCoordValue(AXIS axis, ALIGN_POSITION align)
+{
+  return ((align == LEFT || align == BOTTOM) ? infoSettings.machine_size_min[axis] + infoSettings.level_edge
+                                             : infoSettings.machine_size_max[axis] - infoSettings.level_edge) - infoParameters.HomeOffset[axis];
+}
+
 void levelingGetPointCoords(LEVELING_POINT_COORDS coords)
 {
-  int16_t x_left = ((infoSettings.machine_size_min[X_AXIS] < 0) ? 0 : infoSettings.machine_size_min[X_AXIS]) + infoSettings.level_edge;
-  int16_t x_right = infoSettings.machine_size_max[X_AXIS] - infoSettings.level_edge;
-  int16_t y_bottom = ((infoSettings.machine_size_min[Y_AXIS] < 0) ? 0 : infoSettings.machine_size_min[Y_AXIS]) + infoSettings.level_edge;
-  int16_t y_top = infoSettings.machine_size_max[Y_AXIS] - infoSettings.level_edge;
+  int16_t x_left = setCoordValue(X_AXIS, LEFT);
+  int16_t x_right = setCoordValue(X_AXIS, RIGHT);
+  int16_t y_bottom = setCoordValue(Y_AXIS, LEFT);
+  int16_t y_top = setCoordValue(Y_AXIS, RIGHT);
 
   if (GET_BIT(infoSettings.inverted_axis, X_AXIS))
   { // swap left and right

--- a/TFT/src/User/API/LevelingControl.h
+++ b/TFT/src/User/API/LevelingControl.h
@@ -7,9 +7,6 @@ extern "C" {
 
 #include <stdint.h>
 
-#define LOCK_STEPPER_CMD   "M18 S0\n"  // set stepper inactivity timeout to infinite just to avoid the steppers are disarmed
-#define UNLOCK_STEPPER_CMD "M18\n"     // disarm all steppers
-
 typedef enum
 {
   LEVEL_NO_POINT = -1,

--- a/TFT/src/User/Menu/Leveling.c
+++ b/TFT/src/User/Menu/Leveling.c
@@ -94,6 +94,7 @@ void menuManualLeveling(void)
         break;
 
       case KEY_ICON_7:
+        probeHeightMove(infoSettings.level_z_raise);
         CLOSE_MENU();
         break;
 


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

#### Bugs fixed:
 - if home offset in non-zero, the leveling points for the  "Leveling corner" and "Leveling" menus are determined wrong, they are asymmetrical and not respecting the leveling edge parameter (off by the values of the home offset)
 - if home offset is non-zero than the minimal edge level value is calculated wrong resulting skipped leveling points measurements
 -  just by entering the "L corner" menu the steppers would never auto-disable after the predefined inactivity timeout

#### Enhancements:
 - exiting from the "Leveling" menu the nozzle is raised to a predefined value (Config.ini: "level_z_raise") rather than leaving it very close to the bed

### Benefits

- usability of the aforementioned menus for those who have non-zero home offset
- safer nozzle height when exiting from "Leveling" menu
- smaller compiled flash size

### Related Issues

- none reported
