### PR TITLE
Size reduction by function calls reduction

### DIFF
--- a/TFT/src/User/API/HomeOffsetControl.c
+++ b/TFT/src/User/API/HomeOffsetControl.c
@@ -48,7 +48,7 @@ float homeOffsetSetValue(float value)
 // Get current Z offset value
 float homeOffsetGetValue(void)
 {
-  z_offset_value = getParameter(P_HOME_OFFSET, AXIS_INDEX_Z);
+  z_offset_value = infoParameters.HomeOffset[AXIS_INDEX_Z];
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/ProbeHeightControl.c
+++ b/TFT/src/User/API/ProbeHeightControl.c
@@ -16,7 +16,7 @@ static float origAblState = DISABLED;
 void probeHeightEnable(void)
 {
   origEndstopsState = infoMachineSettings.softwareEndstops;
-  origAblState = getParameter(P_ABL_STATE, 0);
+  origAblState = infoParameters.ABLState[0];
 
   if (origEndstopsState == ENABLED)  // if software endstops is enabled, disable it temporary
   {

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -34,8 +34,8 @@ void probeOffsetEnable(float shim)
 
   probeHeightRelative();                                            // set relative position mode
   mustStoreCmd("G1 X%.2f Y%.2f\n",
-               getParameter(P_PROBE_OFFSET, AXIS_INDEX_X),
-               getParameter(P_PROBE_OFFSET, AXIS_INDEX_Y));         // move nozzle to XY probing point
+               infoParameters.ProbeOffset[AXIS_INDEX_X],
+               infoParameters.ProbeOffset[AXIS_INDEX_Y]);           // move nozzle to XY probing point
   probeHeightStart(probedZ - probeOffsetGetValue() + shim, false);  // lower nozzle to probing Z0 point + shim
   probeOffsetSetValue(probedZ);                                     // set Z offset to match probing Z0 point
   probeHeightRelative();                                            // set relative position mode
@@ -72,7 +72,7 @@ float probeOffsetSetValue(float value)
 // Get current Z offset value
 float probeOffsetGetValue(void)
 {
-  z_offset_value = getParameter(P_PROBE_OFFSET, AXIS_INDEX_Z);
+  z_offset_value = infoParameters.ProbeOffset[AXIS_INDEX_Z];
 
   return z_offset_value;
 }

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -200,10 +200,10 @@ void ParseACKJsonParser::value(const char *value)
     case resp:
       if (strstr(value, (char *)"Steps/"))       //parse M92
       {
-        if ((value = strstr(value, (char *)"X: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_X,  atoi(value + 3));
-        if ((value = strstr(value, (char *)"Y: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Y,  atoi(value + 3));
-        if ((value = strstr(value, (char *)"Z: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_Z,  atoi(value + 3));
-        if ((value = strstr(value, (char *)"E: ")) != NULL ) setParameter(P_STEPS_PER_MM, AXIS_INDEX_E0, atoi(value + 3));
+        if ((value = strstr(value, (char *)"X: ")) != NULL ) infoParameters.StepsPerMM[AXIS_INDEX_X] = atoi(value + 3);
+        if ((value = strstr(value, (char *)"Y: ")) != NULL ) infoParameters.StepsPerMM[AXIS_INDEX_Y] = atoi(value + 3);
+        if ((value = strstr(value, (char *)"Z: ")) != NULL ) infoParameters.StepsPerMM[AXIS_INDEX_Z] = atoi(value + 3);
+        if ((value = strstr(value, (char *)"E: ")) != NULL ) infoParameters.StepsPerMM[AXIS_INDEX_E0] = atoi(value + 3);
       }
       else if ((string_start = strstr(value, (char *)"RepRapFirmware")) != NULL)    // parse M115
       {

--- a/TFT/src/User/API/coordinate.c
+++ b/TFT/src/User/API/coordinate.c
@@ -90,7 +90,7 @@ float coordinateGetExtruderActual(void)
 
 void coordinateSetExtruderActualSteps(float steps)
 {
-  curPosition.axis[E_AXIS] = extruderPostion = steps / getParameter(P_STEPS_PER_MM, E_AXIS);
+  curPosition.axis[E_AXIS] = extruderPostion = steps / infoParameters.StepsPerMM[E_AXIS];
 }
 
 float coordinateGetAxisActual(AXIS axis)

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1076,16 +1076,16 @@ void sendQueueCmd(void)
 
         case 200:  // M200 filament diameter
         {
-          if (cmd_seen('S')) setParameter(P_FILAMENT_DIAMETER, 0, cmd_float());
+          if (cmd_seen('S')) infoParameters.FilamentSetting[0] = cmd_float();
 
           uint8_t i = (cmd_seen('T')) ? cmd_value() : 0;
 
-          if (cmd_seen('D')) setParameter(P_FILAMENT_DIAMETER, 1 + i, cmd_float());
+          if (cmd_seen('D')) infoParameters.FilamentSetting[1 + i] = cmd_float();
 
           if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)
           {
             // filament_diameter > 0.01 to enable volumetric extrusion. Otherwise (<= 0.01), disable volumetric extrusion
-            setParameter(P_FILAMENT_DIAMETER, 0, getParameter(P_FILAMENT_DIAMETER, 1) > 0.01f ? 1 : 0);
+            infoParameters.FilamentSetting[0] = infoParameters.FilamentSetting[1] > 0.01f ? 1 : 0;
           }
           break;
         }
@@ -1112,17 +1112,17 @@ void sendQueueCmd(void)
         }
 
         case 204:  // M204 acceleration (units/s2)
-          if (cmd_seen('P')) setParameter(P_ACCELERATION, 0, cmd_float());
-          if (cmd_seen('R')) setParameter(P_ACCELERATION, 1, cmd_float());
-          if (cmd_seen('T')) setParameter(P_ACCELERATION, 2, cmd_float());
+          if (cmd_seen('P')) infoParameters.Acceleration[0] = cmd_float();
+          if (cmd_seen('R')) infoParameters.Acceleration[1] = cmd_float();
+          if (cmd_seen('T')) infoParameters.Acceleration[2] = cmd_float();
           break;
 
         case 205:  // M205 advanced settings
-          if (cmd_seen('X')) setParameter(P_JERK, AXIS_INDEX_X, cmd_float());
-          if (cmd_seen('Y')) setParameter(P_JERK, AXIS_INDEX_Y, cmd_float());
-          if (cmd_seen('Z')) setParameter(P_JERK, AXIS_INDEX_Z, cmd_float());
-          if (cmd_seen('E')) setParameter(P_JERK, AXIS_INDEX_E0, cmd_float());
-          if (cmd_seen('J')) setParameter(P_JUNCTION_DEVIATION, 0, cmd_float());
+          if (cmd_seen('X')) infoParameters.Jerk[AXIS_INDEX_X] = cmd_float();
+          if (cmd_seen('Y')) infoParameters.Jerk[AXIS_INDEX_Y] = cmd_float();
+          if (cmd_seen('Z')) infoParameters.Jerk[AXIS_INDEX_Z] = cmd_float();
+          if (cmd_seen('E')) infoParameters.Jerk[AXIS_INDEX_E0] = cmd_float();
+          if (cmd_seen('J')) infoParameters.JunctionDeviation[0] = cmd_float();
           break;
 
         case 206:  // M206 home offset
@@ -1163,7 +1163,7 @@ void sendQueueCmd(void)
         }
 
         case 209:  // M209 auto retract
-          if (cmd_seen('S')) setParameter(P_AUTO_RETRACT, 0, cmd_float());
+          if (cmd_seen('S')) infoParameters.AutoRetract[0] = cmd_float();
           break;
 
         case 220:  // M220
@@ -1224,7 +1224,7 @@ void sendQueueCmd(void)
 
         case 376:  // M376 (Reprap FW)
           if (infoMachineSettings.firmwareType == FW_REPRAPFW && cmd_seen('H'))
-            setParameter(P_ABL_STATE, 1, cmd_float());
+            infoParameters.ABLState[1] = cmd_float();
           break;
 
         case 292:  // M292
@@ -1269,9 +1269,9 @@ void sendQueueCmd(void)
               pValue = cmd_float();
 
               if (setAxis & SET_X)
-                  setParameter(P_INPUT_SHAPING, 0, pValue);
+                infoParameters.InputShaping[0] = pValue;
               if (setAxis & SET_Y)
-                  setParameter(P_INPUT_SHAPING, 2, pValue);
+                infoParameters.InputShaping[2] = pValue;
             }
 
             if (cmd_seen('D'))
@@ -1279,9 +1279,9 @@ void sendQueueCmd(void)
               pValue = cmd_float();
 
               if (setAxis & SET_X)
-                  setParameter(P_INPUT_SHAPING, 1, pValue);
+                infoParameters.InputShaping[1] = pValue;
               if (setAxis & SET_Y)
-                  setParameter(P_INPUT_SHAPING, 3, pValue);
+                infoParameters.InputShaping[3] = pValue;
             }
           }
         }
@@ -1296,9 +1296,9 @@ void sendQueueCmd(void)
           if (stepperIndex < 0)
             stepperIndex = 0;
 
-          if (cmd_seen('X')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_X + stepperIndex, isStealthChop);
-          if (cmd_seen('Y')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_Y + stepperIndex, isStealthChop);
-          if (cmd_seen('Z')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_Z + stepperIndex, isStealthChop);
+          if (cmd_seen('X')) infoParameters.StealthChop[STEPPER_INDEX_X + stepperIndex] = isStealthChop;
+          if (cmd_seen('Y')) infoParameters.StealthChop[STEPPER_INDEX_Y + stepperIndex] = isStealthChop;
+          if (cmd_seen('Z')) infoParameters.StealthChop[STEPPER_INDEX_Z + stepperIndex] = isStealthChop;
 
           stepperIndex = (cmd_seen('T')) ? cmd_value() : 0;
 
@@ -1307,7 +1307,7 @@ void sendQueueCmd(void)
           if (stepperIndex < 0)
             stepperIndex = 0;
 
-          if (cmd_seen('E')) setParameter(P_STEALTH_CHOP, STEPPER_INDEX_E0 + stepperIndex, isStealthChop);
+          if (cmd_seen('E')) infoParameters.StealthChop[STEPPER_INDEX_E0 + stepperIndex] = isStealthChop;
           break;
         }
 
@@ -1335,13 +1335,13 @@ void sendQueueCmd(void)
 
           if (param < P_DELTA_ENDSTOP)  // options not supported by M666
           {
-            if (cmd_seen('H')) setParameter(P_DELTA_CONFIGURATION, 0, cmd_float());
-            if (cmd_seen('S')) setParameter(P_DELTA_CONFIGURATION, 1, cmd_float());
-            if (cmd_seen('R')) setParameter(P_DELTA_CONFIGURATION, 2, cmd_float());
-            if (cmd_seen('L')) setParameter(P_DELTA_CONFIGURATION, 3, cmd_float());
-            if (cmd_seen('A')) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_X, cmd_float());
-            if (cmd_seen('B')) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_Y, cmd_float());
-            if (cmd_seen('C')) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_Z, cmd_float());
+            if (cmd_seen('H')) infoParameters.DeltaConfiguration[0] = cmd_float();
+            if (cmd_seen('S')) infoParameters.DeltaConfiguration[1] = cmd_float();
+            if (cmd_seen('R')) infoParameters.DeltaConfiguration[2] = cmd_float();
+            if (cmd_seen('L')) infoParameters.DeltaConfiguration[3] = cmd_float();
+            if (cmd_seen('A')) infoParameters.DeltaDiagonalRod[AXIS_INDEX_X] = cmd_float();
+            if (cmd_seen('B')) infoParameters.DeltaDiagonalRod[AXIS_INDEX_Y] = cmd_float();
+            if (cmd_seen('C')) infoParameters.DeltaDiagonalRod[AXIS_INDEX_Z] = cmd_float();
           }
 
           if (cmd_seen('X')) setParameter(param, AXIS_INDEX_X, cmd_float());
@@ -1363,7 +1363,7 @@ void sendQueueCmd(void)
           uint8_t i = 0;
 
           if (cmd_seen('T')) i = cmd_value();
-          if (cmd_seen('K')) setParameter(P_LIN_ADV, i, cmd_float());
+          if (cmd_seen('K')) infoParameters.LinAdvance[i] = cmd_float();
           break;
         }
 
@@ -1447,7 +1447,7 @@ void sendQueueCmd(void)
                 uint8_t v = cmd_value();
 
                 if (v == 1 || v == 2)
-                  setParameter(P_ABL_STATE, 0, v & 1U);  // value will be 1 if v == 1, 0 if v == 2
+                  infoParameters.ABLState[0] = v & 1U;  // value will be 1 if v == 1, 0 if v == 2
               }
             }
             #if BED_LEVELING_TYPE == 4  // if UBL

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -821,15 +821,15 @@ void parseACK(void)
     // parse and store M420 V1 T1 or G29 S0 (mesh. Z offset:) or M503 (G29 S4 Zxx), MBL Z offset value (e.g. from Babystep menu)
     else if (ack_seen("mesh. Z offset:") || ack_seen("G29 S4 Z"))
     {
-      setParameter(P_MBL_OFFSET, 0, ack_value());
+      infoParameters.MblOffset[0] = ack_value();
     }
     // parse and store M290 (Probe Offset) or M503 (M851), probe offset value (e.g. from Babystep menu) and
     // X an Y probe offset for LevelCorner position limit
     else if (ack_seen("Probe Offset") || ack_starts_with("M851"))
     {
-      if (ack_seen("X")) setParameter(P_PROBE_OFFSET, AXIS_INDEX_X, ack_value());
-      if (ack_seen("Y")) setParameter(P_PROBE_OFFSET, AXIS_INDEX_Y, ack_value());
-      if (ack_seen("Z") || (ack_seen("Z:"))) setParameter(P_PROBE_OFFSET, AXIS_INDEX_Z, ack_value());
+      if (ack_seen("X")) infoParameters.ProbeOffset [AXIS_INDEX_X] = ack_value();
+      if (ack_seen("Y")) infoParameters.ProbeOffset [AXIS_INDEX_Y] = ack_value();
+      if (ack_seen("Z") || (ack_seen("Z:"))) infoParameters.ProbeOffset [AXIS_INDEX_Z] = ack_value();
     }
     // parse G29 (ABL) + M118, ABL completed message (ABL, BBL, UBL) (e.g. from ABL menu)
     else if (ack_seen("ABL Completed"))
@@ -875,16 +875,16 @@ void parseACK(void)
     // parse and store filament diameter
     else if (ack_starts_with("M200"))
     {
-      if (ack_starts_with("M200 S") || ack_seen("D0")) setParameter(P_FILAMENT_DIAMETER, 0, ack_value());
+      if (ack_starts_with("M200 S") || ack_seen("D0")) infoParameters.FilamentSetting[0] = ack_value();
 
       uint8_t i = (ack_seen("T")) ? ack_value() : 0;
 
-      if (ack_seen("D")) setParameter(P_FILAMENT_DIAMETER, 1 + i, ack_value());
+      if (ack_seen("D")) infoParameters.FilamentSetting[1 + i] = ack_value();
 
       if (infoMachineSettings.firmwareType == FW_SMOOTHIEWARE)
       {
         // filament_diameter > 0.01 to enable volumetric extrusion. Otherwise (<= 0.01), disable volumetric extrusion
-        setParameter(P_FILAMENT_DIAMETER, 0, getParameter(P_FILAMENT_DIAMETER, 1) > 0.01f ? 1 : 0);
+        infoParameters.FilamentSetting[0] =  infoParameters.FilamentSetting[1] > 0.01f ? 1 : 0;
       }
     }
     // parse and store axis steps-per-unit (steps/mm) (M92), max acceleration (units/s2) (M201) and max feedrate (units/s) (M203)
@@ -908,18 +908,18 @@ void parseACK(void)
     // parse and store acceleration (units/s2)
     else if (ack_starts_with("M204 P"))
     {
-                         setParameter(P_ACCELERATION, 0, ack_value());
-      if (ack_seen("R")) setParameter(P_ACCELERATION, 1, ack_value());
-      if (ack_seen("T")) setParameter(P_ACCELERATION, 2, ack_value());
+                         infoParameters.Acceleration[0] = ack_value();
+      if (ack_seen("R")) infoParameters.Acceleration[1] = ack_value();
+      if (ack_seen("T")) infoParameters.Acceleration[2] = ack_value();
     }
     // parse and store advanced settings
     else if (ack_starts_with("M205"))
     {
-      if (ack_seen("X")) setParameter(P_JERK, AXIS_INDEX_X, ack_value());
-      if (ack_seen("Y")) setParameter(P_JERK, AXIS_INDEX_Y, ack_value());
-      if (ack_seen("Z")) setParameter(P_JERK, AXIS_INDEX_Z, ack_value());
-      if (ack_seen("E")) setParameter(P_JERK, AXIS_INDEX_E0, ack_value());
-      if (ack_seen("J")) setParameter(P_JUNCTION_DEVIATION, 0, ack_value());
+      if (ack_seen("X")) infoParameters.Jerk[AXIS_INDEX_X] = ack_value();
+      if (ack_seen("Y")) infoParameters.Jerk[AXIS_INDEX_Y] = ack_value();
+      if (ack_seen("Z")) infoParameters.Jerk[AXIS_INDEX_Z] = ack_value();
+      if (ack_seen("E")) infoParameters.Jerk[AXIS_INDEX_E0] = ack_value();
+      if (ack_seen("J")) infoParameters.JunctionDeviation[0] = ack_value();
     }
     // parse and store home offset (M206) and hotend offset (M218)
     else if (ack_starts_with("M206 X") || ack_starts_with("M218 T1 X"))
@@ -951,7 +951,7 @@ void parseACK(void)
     // parse and store auto retract
     else if (ack_starts_with("M209 S"))
     {
-      setParameter(P_AUTO_RETRACT, 0, ack_value());
+      infoParameters.AutoRetract[0] = ack_value();
     }
     // parse and store hotend PID (M301), bed PID (M304)
     else if (ack_starts_with("M301") || ack_starts_with("M304"))
@@ -1002,9 +1002,9 @@ void parseACK(void)
         pValue = ack_value();
 
         if (setAxis & SET_X)
-            setParameter(P_INPUT_SHAPING, 0, pValue);
+            infoParameters.InputShaping[0] = pValue;
         if (setAxis & SET_Y)
-            setParameter(P_INPUT_SHAPING, 2, pValue);
+            infoParameters.InputShaping[2] = pValue;
       }
 
       if (ack_seen("D"))
@@ -1012,9 +1012,9 @@ void parseACK(void)
         pValue = ack_value();
 
         if (setAxis & SET_X)
-            setParameter(P_INPUT_SHAPING, 1, pValue);
+            infoParameters.InputShaping[1] = pValue;
         if (setAxis & SET_Y)
-            setParameter(P_INPUT_SHAPING, 3, pValue);
+            infoParameters.InputShaping[3] = pValue;
       }
     }
     // parse and store Delta configuration / Delta tower angle (M665) and Delta endstop adjustments (M666)
@@ -1028,13 +1028,13 @@ void parseACK(void)
 
       if (param < P_DELTA_ENDSTOP)  // options not supported by M666
       {
-        if (ack_seen("H")) setParameter(P_DELTA_CONFIGURATION, 0, ack_value());
-        if (ack_seen("S")) setParameter(P_DELTA_CONFIGURATION, 1, ack_value());
-        if (ack_seen("R")) setParameter(P_DELTA_CONFIGURATION, 2, ack_value());
-        if (ack_seen("L")) setParameter(P_DELTA_CONFIGURATION, 3, ack_value());
-        if (ack_seen("A")) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_X, ack_value());
-        if (ack_seen("B")) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_Y, ack_value());
-        if (ack_seen("C")) setParameter(P_DELTA_DIAGONAL_ROD, AXIS_INDEX_Z, ack_value());
+        if (ack_seen("H")) infoParameters.DeltaConfiguration[0] = ack_value();
+        if (ack_seen("S")) infoParameters.DeltaConfiguration[1] = ack_value();
+        if (ack_seen("R")) infoParameters.DeltaConfiguration[2] = ack_value();
+        if (ack_seen("L")) infoParameters.DeltaConfiguration[3] = ack_value();
+        if (ack_seen("A")) infoParameters.DeltaDiagonalRod[AXIS_INDEX_X] = ack_value();
+        if (ack_seen("B")) infoParameters.DeltaDiagonalRod[AXIS_INDEX_Y] = ack_value();
+        if (ack_seen("C")) infoParameters.DeltaDiagonalRod[AXIS_INDEX_Z] = ack_value();
       }
 
       if (ack_seen("X")) setParameter(param, AXIS_INDEX_X, ack_value());
@@ -1044,8 +1044,8 @@ void parseACK(void)
     // parse and store ABL on/off state & Z fade value on M503
     else if (ack_starts_with("M420 S"))
     {
-                                  setParameter(P_ABL_STATE, 0, ack_value());
-      if (ack_continue_seen("Z")) setParameter(P_ABL_STATE, 1, ack_value());
+                                  infoParameters.ABLState[0] = ack_value();
+      if (ack_continue_seen("Z")) infoParameters.ABLState[1] = ack_value();
     }
     // parse and store TMC stepping mode
     else if (ack_seen("Driver stepping mode:"))  // poll stelthchop settings separately
@@ -1068,14 +1068,14 @@ void parseACK(void)
           stepperIndex += ack_value() - 1;
       }
 
-      setParameter(P_STEALTH_CHOP, stepperIndex, isStealthChop);
+      infoParameters.StealthChop[stepperIndex] = isStealthChop;
     }
     // parse and store linear advance factor
     else if (ack_starts_with("M900"))
     {
       uint8_t i = (ack_seen("T")) ? ack_value() : 0;
 
-      if (ack_seen("K")) setParameter(P_LIN_ADV, i, ack_value());
+      if (ack_seen("K")) infoParameters.LinAdvance[i] = ack_value();
     }
     // parse and store stepper motor current (M906), TMC hybrid threshold speed (M913) and TMC bump sensitivity (M914)
     else if (ack_starts_with("M906") || ack_starts_with("M913") || ack_starts_with("M914"))
@@ -1271,16 +1271,16 @@ void parseACK(void)
       // parse and store M420 V1 T1 or M420 Sxx, ABL state (e.g. from Bed Leveling menu)
       else if (ack_continue_seen("Bed Leveling"))
       {
-        setParameter(P_ABL_STATE, 0, ack_continue_seen("ON") ? ENABLED : DISABLED);
+        infoParameters.ABLState[0] = ack_continue_seen("ON") ? ENABLED : DISABLED;
       }
       else if (ack_continue_seen("Fade Height"))
       {
-        setParameter(P_ABL_STATE, 1, ack_value());
+        infoParameters.ABLState[1] = ack_value();
       }
       // newer Marlin (e.g. 2.0.9.3) returns this ACK for M900 command
       else if (ack_continue_seen("Advance K="))
       {
-        setParameter(P_LIN_ADV, heatGetCurrentTool(), ack_value());
+        infoParameters.LinAdvance[heatGetCurrentTool()] = ack_value();
       }
       else if (!processKnownEcho())  // if no known echo was found and processed, then popup the echo message
       {
@@ -1296,15 +1296,15 @@ void parseACK(void)
       // parse and store volumetric extrusion M200 response of Smoothieware
       else if (ack_seen("Volumetric extrusion is disabled"))
       {
-        setParameter(P_FILAMENT_DIAMETER, 0, 0);
-        setParameter(P_FILAMENT_DIAMETER, 1, 0.0f);
+        infoParameters.FilamentSetting[0] = 0;
+        infoParameters.FilamentSetting[1] = 0.0f;
       }
       // parse and store volumetric extrusion M200 response of Smoothieware
       else if (ack_seen("Filament Diameter:"))
       {
-        setParameter(P_FILAMENT_DIAMETER, 1, ack_value());
+        infoParameters.FilamentSetting[1] = ack_value();
         // filament_diameter > 0.01 to enable volumetric extrusion. Otherwise (<= 0.01), disable volumetric extrusion
-        setParameter(P_FILAMENT_DIAMETER, 0, getParameter(P_FILAMENT_DIAMETER, 1) > 0.01f ? 1 : 0);
+        infoParameters.FilamentSetting[0] =  infoParameters.FilamentSetting[1] > 0.01f ? 1 : 0;
       }
     }
 

--- a/TFT/src/User/Menu/Babystep.c
+++ b/TFT/src/User/Menu/Babystep.c
@@ -56,7 +56,7 @@ float babyMblOffsetSetValue(float value)
 // Get current Z offset value for MBL bl type
 float babyMblOffsetGetValue(void)
 {
-  return getParameter(P_MBL_OFFSET, 0);
+  return infoParameters.MblOffset[0];
 }
 
 void menuBabystep(void)

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -3,7 +3,7 @@
 
 void blUpdateState(MENUITEMS * menu)
 {
-  if (getParameter(P_ABL_STATE, 0) == ENABLED)
+  if (infoParameters.ABLState[0] == ENABLED)
   {
     menu->items[3].icon = ICON_LEVELING_ON;
     menu->items[3].label.index = LABEL_BL_ENABLE;
@@ -74,7 +74,7 @@ void menuBedLeveling(void)
 
   if (index3And4Support)
   {
-    levelStateOld = getParameter(P_ABL_STATE, 0);
+    levelStateOld = infoParameters.ABLState[0];
     blUpdateState(&bedLevelingItems);  // update icon & label 3
 
     bedLevelingItems.items[4].icon = ICON_Z_FADE;
@@ -123,7 +123,7 @@ void menuBedLeveling(void)
       case KEY_ICON_3:
         if (index3And4Support)
         {
-          if (getParameter(P_ABL_STATE, 0) == ENABLED)
+          if (infoParameters.ABLState[0] == ENABLED)
             storeCmd(infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S0\n" : "G29 S2\n");
           else
             storeCmd(infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S1\n" : "G29 S1\n");
@@ -134,9 +134,9 @@ void menuBedLeveling(void)
       {
         if (index3And4Support)
         {
-          float val = editFloatValue(Z_FADE_MIN_VALUE, Z_FADE_MAX_VALUE, 0.0f, getParameter(P_ABL_STATE, 1));
+          float val = editFloatValue(Z_FADE_MIN_VALUE, Z_FADE_MAX_VALUE, 0.0f, infoParameters.ABLState[1]);
 
-          if (val != getParameter(P_ABL_STATE, 1))
+          if (val != infoParameters.ABLState[1])
             storeCmd(infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 Z%.2f\n" : "M376 H%.2f\n", val);
 
           menuDrawPage(&bedLevelingItems);
@@ -170,9 +170,9 @@ void menuBedLeveling(void)
         break;
     }
 
-    if (index3And4Support && levelStateOld != getParameter(P_ABL_STATE, 0))
+    if (index3And4Support && levelStateOld != infoParameters.ABLState[0])
     {
-      levelStateOld = getParameter(P_ABL_STATE, 0);
+      levelStateOld = infoParameters.ABLState[0];
 
       blUpdateState(&bedLevelingItems);
       menuDrawItem(&bedLevelingItems.items[3], 3);

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -11,8 +11,8 @@ int16_t origLevelEdge = -1;
 uint8_t getLevelEdgeMin(void)
 {
   // min edge limit for the probe with probe offset set in parseACK.c
-  return MAX(ABS((int16_t)getParameter(P_PROBE_OFFSET, AXIS_INDEX_X)),
-             ABS((int16_t)getParameter(P_PROBE_OFFSET, AXIS_INDEX_Y))) + 1;
+  return MAX(ABS((int16_t)infoParameters.ProbeOffset[AXIS_INDEX_X]),
+             ABS((int16_t)infoParameters.ProbeOffset[AXIS_INDEX_Y])) + 1;
 }
 
 uint8_t getLevelEdgeDefault(void)

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -215,7 +215,7 @@ void menuNewExtruderESteps(void)
   float now = measured_length = REMAINING_LEN;
   float old_esteps, new_esteps;  // get the value of the E-steps
 
-  old_esteps = getParameter(P_STEPS_PER_MM, E_AXIS);  // get the value of the E-steps
+  old_esteps = infoParameters.StepsPerMM[E_AXIS];  // get the value of the E-steps
 
   newExtruderESteps.items[KEY_ICON_5] = itemMoveLen[extStep_index];
 


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

Almost 500 bytes of flash size reduction by removing unnecessary usage of `getParameter()` and `setParameter()` functions.

### Benefits

- lower compiled FW size

### Related Issues

- none
