### PR TITLE
Improved VFS API

### DIFF
--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -37,8 +37,7 @@ bool powerFailedGetRestore(void)
 
 void powerFailedSetDriverSource(void)
 {
-  strcpy(powerFailedFileName, getFS());
-  strcat(powerFailedFileName, BREAK_POINT_FILE);
+  sprintf(powerFailedFileName, "%s%s", getFS(), BREAK_POINT_FILE);
 }
 
 bool powerFailedInitData(void)

--- a/TFT/src/User/API/Vfs/vfs.c
+++ b/TFT/src/User/API/Vfs/vfs.c
@@ -185,6 +185,81 @@ char * isSupportedFile(const char * filename)
   return extPos;
 }
 
+// add a file name or folder name to file list
+bool addFile(bool isFile, const char * shortName, const char * longName)
+{
+  if (isFile == true)  // if file
+  {
+    // if file list is full or filename doesn't provide a supported filename extension
+    if (infoFile.fileCount >= FILE_NUM || isSupportedFile(shortName) == NULL)
+      return false;
+  }
+  else  // if folder
+  {
+    if (infoFile.folderCount >= FOLDER_NUM)  // if folder list is full
+      return false;
+  }
+
+  // "+ 2": space for terminating null character and the flag for filename extension check
+  // "+ 1": space for terminating null character
+  uint8_t extraLen = isFile ? 2 : 1;
+  char * sName;
+  char * lName = NULL;  // initialize to NULL in case long filename is not provided
+
+  //
+  // get short name
+  //
+
+  uint8_t sNameLen = strlen(shortName) + extraLen;
+
+  sName = malloc(sNameLen);
+
+  if (sName == NULL)  // in case of error, exit
+    return false;
+
+  strncpy(sName, shortName, sNameLen);  // copy to "sName" and set to NULL the flag for filename extension check, if any
+
+  //
+  // get long name, if any
+  //
+
+  if (longName != NULL)  // if long filename is provided
+  {
+    uint8_t lNameLen = strlen(longName) + extraLen;
+
+    lName = malloc(lNameLen);
+
+    if (lName == NULL)  // in case of error, free the buffer allocated for "sName" and exit
+    {
+      if (sName != NULL)
+        free(sName);
+
+      return false;
+    }
+
+    strncpy(lName, longName, lNameLen);  // copy to "lName" and set to NULL the flag for filename extension check, if any
+  }
+
+  //
+  // copy to destination
+  //
+
+  if (isFile)
+  {
+    infoFile.file[infoFile.fileCount] = sName;
+    infoFile.longFile[infoFile.fileCount] = lName;
+    infoFile.fileCount++;
+  }
+  else
+  {
+    infoFile.folder[infoFile.folderCount] = sName;
+    infoFile.longFolder[infoFile.folderCount] = lName;
+    infoFile.folderCount++;
+  }
+
+  return true;
+}
+
 // return the long folder name if exists, otherwise the short one
 char * getFoldername(uint8_t index)
 {
@@ -211,7 +286,7 @@ char * hideExtension(char * filename)
 
     // if filename provides a supported filename extension then
     // check extra byte for filename extension check. If 0, no filename extension was previously hidden
-    if (extPos != NULL && filename[strlen(filename) + 1] == 0)
+    if (extPos != NULL && filename[strlen(filename) + 1] == '\0')
       filename[extPos - filename] = 0;  // temporary hide filename extension
   }
 
@@ -223,7 +298,7 @@ char * restoreExtension(char * filename)
   if (infoSettings.filename_extension == 0)  // if filename extension is disabled
   {
     // check extra byte for filename extension check. If 0, no filename extension was previously hidden
-    if (filename[strlen(filename) + 1] != 0)
+    if (filename[strlen(filename) + 1] != '\0')
       filename[strlen(filename)] = '.';  // restore filename extension
   }
 

--- a/TFT/src/User/API/Vfs/vfs.h
+++ b/TFT/src/User/API/Vfs/vfs.h
@@ -52,17 +52,16 @@ extern MYFILE infoFile;
 void setPrintModelIcon(bool exist);
 bool isPrintModelIcon(void);
 
-TCHAR * getFS(void);                            // get FS's ID of current source
-bool mountFS(void);                             // mount FS of current source
-bool scanPrintFiles(void);                      // scan files in current source and create a file list
-void clearInfoFile(void);                       // clear and free memory for file list
+TCHAR * getFS(void);                                                       // get FS's ID of current source
+bool mountFS(void);                                                        // mount FS of current source
+bool scanPrintFiles(void);                                                 // scan files in current source and create a file list
+void clearInfoFile(void);                                                  // clear and free memory for file list
 
-void resetInfoFile(void);                       // clear file list and path
-char * getPathTail(void);                       // skip path information, if any
-bool enterFolder(const char * path);            // check and open folder
-void exitFolder(void);                          // close folder
-bool isRootFolder(void);                        // check if current folder is root
-char * isSupportedFile(const char * filename);  // check if filename provides a supported filename extension
+void resetInfoFile(void);                                                  // clear file list and path
+bool enterFolder(const char * path);                                       // check and open folder
+void exitFolder(void);                                                     // close folder
+bool isRootFolder(void);                                                   // check if current folder is root
+bool addFile(bool isFile, const char * shortName, const char * longName);  // add a file name or folder name to file list
 
 // called in Print.c
 char * getFoldername(uint8_t index);             // return the long folder name if exists, otherwise the short one

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -154,9 +154,7 @@ bool Get_NewestGcode(const TCHAR* path)
       if (nextdirpath == NULL)
         break;
 
-      strcpy(nextdirpath, path);
-      strcat(nextdirpath, "/");
-      strcat(nextdirpath, finfo.fname);
+      sprintf(nextdirpath, "%s/%s", path, finfo.fname);
 
       status |= Get_NewestGcode(nextdirpath);
       free(nextdirpath);
@@ -176,9 +174,8 @@ bool Get_NewestGcode(const TCHAR* path)
       if (len + strlen(finfo.fname) + 2 > MAX_PATH_LEN)
         break;
 
-      strcpy(infoFile.path, path);
-      strcat(infoFile.path, "/");
-      strcat(infoFile.path, finfo.fname);
+      sprintf(infoFile.path, "%s/%s", path, finfo.fname);
+
       status = 1;
     }
   }

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -90,9 +90,9 @@ bool mountUSBDisk(void)
  */
 bool scanPrintFilesFatFs(void)
 {
-  FILINFO finfo;
   DIR dir;
-  uint32_t folderDate[FILE_NUM];
+  FILINFO finfo;
+  uint32_t folderDate[FOLDER_NUM];
   uint32_t fileDate[FILE_NUM];
 
   clearInfoFile();

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -14,14 +14,12 @@ FATFS fatfs[FF_VOLUMES];  // FATFS work area
  */
 bool compareFile(char * name1, uint32_t date1, char * name2, uint32_t date2)
 {
-  // sort by date
-  if (infoSettings.files_sort_by <= SORT_DATE_OLD_FIRST)
+  if (infoSettings.files_sort_by <= SORT_DATE_OLD_FIRST)  // sort by date
   {
     // file with most recent date displays first in newest first and last in oldest first
     return ((date1 > date2) == GET_BIT(infoSettings.files_sort_by, 0));
   }
-  // sort by name
-  else
+  else  // sort by name
   {
     uint16_t maxlen = (strlen(name1) < strlen(name2)) ? strlen(name1) : strlen(name2);
 
@@ -35,8 +33,33 @@ bool compareFile(char * name1, uint32_t date1, char * name2, uint32_t date2)
       if (a != b)
         return ((a < b) == GET_BIT(infoSettings.files_sort_by, 0));
     }
+
     // file with longer name displays last in ascending order and first in descending order
     return ((strlen(name1) < strlen(name2)) == GET_BIT(infoSettings.files_sort_by, 0));
+  }
+}
+
+/**
+ * sort file list
+ */
+void sortFile(uint16_t fileCount, TCHAR * fileName[], uint32_t fileDate[])
+{
+  for (int i = 1; i < fileCount; i++)
+  {
+    // compare file date with each other
+    for (int j = i;
+         j > 0 && compareFile(fileName[j - 1], fileDate[j - 1], fileName[j], fileDate[j]);
+         j--)
+    {
+      // swap places if not in order
+      char * tmp = fileName[j - 1];
+      int32_t tmpInt = fileDate[j - 1];
+
+      fileName[j - 1] = fileName[j];
+      fileName[j] = tmp;
+      fileDate[j - 1] = fileDate[j];
+      fileDate[j] = tmpInt;
+    }
   }
 }
 
@@ -68,7 +91,6 @@ bool mountUSBDisk(void)
 bool scanPrintFilesFatFs(void)
 {
   FILINFO finfo;
-  uint16_t len = 0;
   DIR dir;
   uint32_t folderDate[FILE_NUM];
   uint32_t fileDate[FILE_NUM];
@@ -80,104 +102,32 @@ bool scanPrintFilesFatFs(void)
 
   for (;;)
   {
-    if (f_readdir(&dir, &finfo) != FR_OK || finfo.fname[0] == 0)
+    if (f_readdir(&dir, &finfo) != FR_OK || finfo.fname[0] == 0 ||
+        (infoFile.fileCount >= FILE_NUM && infoFile.folderCount >= FOLDER_NUM))
       break;
+
     if ((finfo.fattrib & AM_HID) != 0)
       continue;
-    if (infoFile.fileCount >= FILE_NUM && infoFile.folderCount >= FOLDER_NUM)
-      break;
 
-    len = strlen(finfo.fname) + 1;
     if ((finfo.fattrib & AM_DIR) == AM_DIR)  // if folder
     {
-      if (infoFile.folderCount >= FOLDER_NUM)
-        continue;
-
-      infoFile.folder[infoFile.folderCount] = malloc(len);
-      if (infoFile.folder[infoFile.folderCount] == NULL)
-        break;
-
-      // copy date/time modified
-      folderDate[infoFile.folderCount] = ((uint32_t)(finfo.fdate) << 16) | finfo.ftime;
-
-      // copy folder name
-      memcpy(infoFile.folder[infoFile.folderCount], finfo.fname, len);
-      infoFile.folderCount++;
+      if (addFile(false, finfo.fname, NULL) == true)  // if folder successfully added to folder list
+        folderDate[infoFile.folderCount - 1] = ((uint32_t)(finfo.fdate) << 16) | finfo.ftime;  // copy date/time modified
     }
     else  // if file
     {
-      if (infoFile.fileCount >= FILE_NUM)
-        continue;
-
-      if (isSupportedFile(finfo.fname) == NULL)  // if filename doesn't provide a supported filename extension
-        continue;
-
-      infoFile.file[infoFile.fileCount] = malloc(len + 1);  // plus one extra byte for filename extension check
-      if (infoFile.file[infoFile.fileCount] == NULL)
-        break;
-
-      // copy date/time modified
-      fileDate[infoFile.fileCount] = ((uint32_t)(finfo.fdate) << 16) | finfo.ftime;
-
-      // copy file name and set the flag for filename extension check
-      strncpy(infoFile.file[infoFile.fileCount], finfo.fname, len + 1);  // "+ 1": the flag for filename extension check
-      infoFile.longFile[infoFile.fileCount] = NULL;                      // long filename is not supported, so always set it to NULL
-      infoFile.fileCount++;
+      if (addFile(true, finfo.fname, NULL) == true)  // if file successfully added to file list
+        fileDate[infoFile.fileCount - 1] = ((uint32_t)(finfo.fdate) << 16) | finfo.ftime;  // copy date/time modified
     }
   }
 
   f_closedir(&dir);
 
-  // sort folder list
-  for (int i = 1; i < infoFile.folderCount; i++)
-  {
-    // compare folders with each other
-    for (int j = i;
-         j > 0 && compareFile(infoFile.folder[j - 1], folderDate[j - 1], infoFile.folder[j], folderDate[j]);
-         j--)
-    {
-      // swap places if not in order
-      char * tmp = infoFile.folder[j - 1];
-      infoFile.folder[j - 1] = infoFile.folder[j];
-      infoFile.folder[j] = tmp;
+  sortFile(infoFile.folderCount, infoFile.folder, folderDate);  // sort folder list
+  sortFile(infoFile.fileCount, infoFile.file, fileDate);        // sort file list
 
-      int32_t tmpInt = folderDate[j - 1];
-      folderDate[j - 1] = folderDate[j];
-      folderDate[j] = tmpInt;
-    }
-  }
-
-  // sort file list
-  for (int i = 1; i < infoFile.fileCount; i++)
-  {
-    // compare files with each other
-    for (int j = i;
-         j > 0 && compareFile(infoFile.file[j - 1], fileDate[j - 1], infoFile.file[j], fileDate[j]);
-         j--)
-    {
-      // swap places
-      char * tmp = infoFile.file[j - 1];
-      infoFile.file[j - 1] = infoFile.file[j];
-      infoFile.file[j] = tmp;
-
-      int32_t tmpInt = fileDate[j - 1];
-      fileDate[j - 1] = fileDate[j];
-      fileDate[j] = tmpInt;
-    }
-  }
   return true;
 }
-
-/*
-void GUI_DispDate(uint16_t date, uint16_t time)
-{
-  char buf[100];
-  static uint8_t i=0;
-  sprintf(buf,"%d/%d/%d--%d:%d:%d",1980+(date>>9),(date>>5)&0xF,date&0x1F,time>>11,(time>>5)&0x3F,time&0x1F);
-  GUI_DispString(0,i,(uint8_t* )buf,0);
-  i+=16;
-}
-*/
 
 bool Get_NewestGcode(const TCHAR* path)
 {

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -212,15 +212,9 @@ void statusScreen_setReady(void)
   strncpy(msgTitle, (char *)textSelect(LABEL_STATUS), sizeof(msgTitle));
 
   if (infoHost.connected == false)
-  {
     strncpy(msgBody, (char *)textSelect(LABEL_UNCONNECTED), sizeof(msgBody));
-  }
   else
-  {
-    strncpy(msgBody, (char *)machine_type, sizeof(msgBody));
-    strcat(msgBody, " ");
-    strcat(msgBody, (char *)textSelect(LABEL_READY));
-  }
+    snprintf(msgBody, sizeof(msgBody), "%s %s", (char *)machine_type, (char *)textSelect(LABEL_READY));
 
   msgNeedRefresh = true;
 }


### PR DESCRIPTION
**IMPROVEMENTS:**
* VFS API: all handling logic on `infoFile` data struct (declared in `vfs.h`) is now properly hosted on `VFS` API. Previously, handling such as allocation of infoFile's attributes was provided on both `myfatfs` and `mygcodefs` APIs. The new `addFile` function provided in VFS API is now responsible for the allocation of infoFile's attributes. The changes allow also to hide (remove from vfs.h) some no more needed functions (e.g. `isSupportedFile`). The FLASH space usage is reduced by about 130 bytes.
* Some bug fixes on `scanPrintFilesFatFs` function: e.g. it was used FILE_NUM instead of FOLDER_NUM etc.
* Minor code sharing:  duplicated file sorting code used in `myfatfs .c` is now shared by the use of `sortFile` function
* bugfix on statusScreen_setReady(): possible buffer overflow on statusScreen_setReady() fixed using snprintf()

**PR STATE:** Ready for merge
