### PR TITLE
Terminal fixes

### DIFF
--- a/TFT/src/User/API/SerialConnection.c
+++ b/TFT/src/User/API/SerialConnection.c
@@ -112,7 +112,6 @@ void Serial_Forward(SERIAL_PORT_INDEX portIndex, const char * msg)
     Serial_Put(SERIAL_DEBUG_PORT, msg);
   #endif
 
-  uint16_t msgLen = MENU_IS(menuTerminal ? strlen(msg) : 0);  // retrieve message lenght if Terminal menu is currently displayed
   uint8_t portCount = SERIAL_PORT_COUNT;                      // by default, select all the serial ports
 
   if (portIndex == ALL_PORTS)         // if ALL_PORTS, forward the message to all the enabled serial ports
@@ -132,12 +131,8 @@ void Serial_Forward(SERIAL_PORT_INDEX portIndex, const char * msg)
           && serialPort[portIndex].port != SERIAL_DEBUG_PORT  // do not forward data to serial debug port
         #endif
         )
-    {
       Serial_Put(serialPort[portIndex].port, msg);  // pass on the message to the port
 
-      if (msgLen != 0)  // if Terminal menu is currently displayed
-        terminalCache(msg, msgLen, portIndex, SRC_TERMINAL_GCODE);
-    }
   }
 }
 

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1368,6 +1368,13 @@
 #define TERMINAL_KEYBOARD_LAYOUT 0  // Default: 0
 
 /**
+ * Suppress/allow terminal cache during keyboard view
+ *  - uncomment to disable terminal cache during keyboard view
+ *  - comment it to enable terminal cache during keyboard view
+ */
+#define TERMINAL_KEYBOARD_VIEW_SUPPRESS_ACK  // Default: uncommented (cache suppressed)
+
+/**
  * Progress Bar Color (Printing menu)
  * The color of the progress bar during print.
  *   Options: [Orange: 0, Yellow: 1, Red: 2, Green: 3, Blue: 4, Cyan: 5, Magenta: 6, Purple: 7, Lime: 8, Gray: 9]

--- a/TFT/src/User/Menu/Terminal.c
+++ b/TFT/src/User/Menu/Terminal.c
@@ -26,12 +26,6 @@ typedef struct
 
 typedef enum
 {
-  KEYBOARD_VIEW = 0,
-  TERMINAL_WINDOW,
-} TERMINAL_VIEW;
-
-typedef enum
-{
   GKEY_PREV = 0,
   GKEY_NEXT,
   GKEY_CLEAR,
@@ -316,7 +310,12 @@ const uint16_t fontSrcColor[3][3] = {
 KEYBOARD_DATA * keyboardData;
 TERMINAL_DATA * terminalData;
 char * terminalBuf;
-TERMINAL_VIEW curView = KEYBOARD_VIEW;
+
+enum
+{
+  KEYBOARD_VIEW = 0,
+  TERMINAL_VIEW,
+} curView = KEYBOARD_VIEW;
 
 bool numpad =
   #if defined(KB_TYPE_QWERTY)
@@ -588,11 +587,12 @@ static inline void menuKeyboardView(void)
             saveGcodeIndex = (saveGcodeIndex + 1) % MAX_GCODE_COUNT;     // move to next save index in the gcode history table
           }
 
-          handleCmd(strcat(gcodeBuf, "\n"));
+          strcpy(&gcodeBuf[nowIndex], "\n");
+          handleCmd(gcodeBuf);
         }
 
         keyboardData->gcodeIndex = saveGcodeIndex;  // save and update gcode index
-        curView = TERMINAL_WINDOW;
+        curView = TERMINAL_VIEW;
         break;
 
       case GKEY_ABC_123:
@@ -666,6 +666,12 @@ static inline void saveGcodeTerminalCache(const char * str, uint16_t strLen)
 
 void terminalCache(const char * stream, uint16_t streamLen, SERIAL_PORT_INDEX portIndex, TERMINAL_SRC src)
 {
+
+  #ifdef TERMINAL_KEYBOARD_VIEW_SUPPRESS_ACK
+    if (curView == KEYBOARD_VIEW)
+      return;
+  #endif
+
   char * srcId[SRC_TERMINAL_COUNT] = {"\5", "\6"};
 
   // copy string source identifier
@@ -821,7 +827,7 @@ static inline void terminalDrawMenu(void)
   terminalDrawPageNumber();
 }
 
-void menuTerminalWindow(void)
+void menuTerminalView(void)
 {
   #define CURSOR_START_X (terminalAreaRect[0].x0 + CURSOR_H_OFFSET)
 
@@ -837,7 +843,7 @@ void menuTerminalWindow(void)
 
   terminalDrawMenu();
 
-  while (curView == TERMINAL_WINDOW)
+  while (curView == TERMINAL_VIEW)
   {
     if (MENU_IS_NOT(menuTerminal))
       break;
@@ -1025,9 +1031,6 @@ void menuTerminal(void)
 
   while (MENU_IS(menuTerminal))
   {
-    if (curView == KEYBOARD_VIEW)
-      menuKeyboardView();
-    else if (curView == TERMINAL_WINDOW)
-      menuTerminalWindow();
+    (curView == KEYBOARD_VIEW) ?  menuKeyboardView() : menuTerminalView();
   }
 }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

 - PR #2678 introduced an unnecessary feature in "Terminal menu", all the forwarded messages to supplementary serial ports are displayed also in the terminal view. It clutters the terminal view, makes harder to follow the things you're interested in, displays all the mainboard's involuntary messages despite having disabled the option to show "temperature" and "wait" ACK in Terminal menu. 
This PR brings back "Terminal" the way it was before PR #2678.

 - Messages are added to terminal cache even if you're in the keyboard view so you might end up with already several pages already filled up by the time you get to the terminal view. This PR inhibits the cache filling whilst in the keyboard view. It is made configurable at compile time in "Configuration.h" by enabling or disabling `TERMINAL_KEYBOARD_VIEW_SUPPRESS_ACK` which is by default enabled (uncommented) meaning the suppression of saving messages to terminal cache while the keyboard view is active.

 - Itsy-bitsy FW size reduction

### Examples for the reason of this PR

Everything repeated:
![Repeated](https://user-images.githubusercontent.com/50251547/227601084-8e0acca0-74c3-4b89-b0b9-dd015875edf9.jpg)


"Wait" and temperature displayed even if that feature is disabled:
![ACK Off](https://user-images.githubusercontent.com/50251547/227600749-ea654c79-98f6-4272-a524-eeb8eabba9d8.jpg)

Numerous pages filled by the time I typed and sent M92:
![Pages Filled](https://user-images.githubusercontent.com/50251547/227601116-59642a55-878f-456c-b118-a794a7ea999b.jpg)
