### PR TITLE
Compilation bugfix

### DIFF
--- a/TFT/src/User/API/Vfs/vfs.h
+++ b/TFT/src/User/API/Vfs/vfs.h
@@ -66,8 +66,10 @@ bool addFile(bool isFile, const char * shortName, const char * longName);  // ad
 // called in Print.c
 char * getFoldername(uint8_t index);             // return the long folder name if exists, otherwise the short one
 char * getFilename(uint8_t index);               // return the long file name if exists, otherwise the short one
-char * hideFilenameExtension(uint8_t index);     // hide the extension of the file name and return a pointer to that file name
-char * restoreFilenameExtension(uint8_t index);  // restore the extension of the file name and return a pointer to that file name
+char * hideFilenameExtension(uint8_t index);     // given the index, hide the extension of that file name and return a pointer to that file name
+char * restoreFilenameExtension(uint8_t index);  // given the index, restore the extension of that file name and return a pointer to that file name
+char * hideExtension(char * filename);           // hide the extension of the file name and return a pointer to that file name
+char * restoreExtension(char * filename);        // restore the extension of the file name and return a pointer to that file name
 
 // called in PrintingMenu.c
 char * getPrintFilename(void);                // get print filename according to print originator (remote or local to TFT)


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

PR #2662 introduced a compilation bug, two functions have no interface definition (`hideExtension()` and `restoreExtension()`).
This PR makes the interface definitions of those two functions.

### Benefits

 - no compilation warning

### Related Issues

 - none reported
