### PR TITLE
Bug fixes on top of last merged PRs

### DIFF
--- a/TFT/src/User/API/BabystepControl.c
+++ b/TFT/src/User/API/BabystepControl.c
@@ -7,7 +7,7 @@ static float babystep_value = BABYSTEP_DEFAULT_VALUE;
 #define BABYSTEP_CMD_SMW "G43.2 Z%.2f\n"
 
 // Set current babystep value
-void babystepSetValue(const float value)
+void babystepSetValue(float value)
 {
   babystep_value = value;
 }

--- a/TFT/src/User/API/HomeOffsetControl.c
+++ b/TFT/src/User/API/HomeOffsetControl.c
@@ -56,10 +56,11 @@ float homeOffsetGetValue(void)
 // Reset Z offset value to default value
 float homeOffsetResetValue(void)
 {
-  if (z_offset_value != HOME_Z_OFFSET_DEFAULT_VALUE)  // if already default value, nothing to do
+  if (z_offset_value != HOME_Z_OFFSET_DEFAULT_VALUE)  // if not default value
   {
     sendParameterCmd(P_HOME_OFFSET, AXIS_INDEX_Z, HOME_Z_OFFSET_DEFAULT_VALUE);  // set Z home offset value
     mustStoreCmd("G1 Z%.2f\n", z_offset_value - HOME_Z_OFFSET_DEFAULT_VALUE);    // move nozzle
+
     z_offset_value = HOME_Z_OFFSET_DEFAULT_VALUE;
   }
 

--- a/TFT/src/User/API/Notification.c
+++ b/TFT/src/User/API/Notification.c
@@ -25,7 +25,7 @@ void addToast(DIALOG_TYPE style, char * text)
   LCD_WAKE();
 
   TOAST t;
-  strxcpy(t.text, text, TOAST_MSG_LENGTH);
+  strncpy_no_pad(t.text, text, TOAST_MSG_LENGTH);
   t.style = style;
   t.isNew = true;
   toastlist[nextToastIndex] = t;
@@ -146,8 +146,8 @@ void addNotification(DIALOG_TYPE style, char *title, char *text, bool ShowDialog
 
   // store message
   msglist[nextMsgIndex].style  = style;
-  strxcpy(msglist[nextMsgIndex].text, text, MAX_MSG_LENGTH);
-  strxcpy(msglist[nextMsgIndex].title, title, MAX_MSG_TITLE_LENGTH);
+  strncpy_no_pad(msglist[nextMsgIndex].text, text, MAX_MSG_LENGTH);
+  strncpy_no_pad(msglist[nextMsgIndex].title, title, MAX_MSG_TITLE_LENGTH);
 
   if (ShowDialog && MENU_IS_NOT(menuNotification))
     popupReminder(style, (uint8_t *)title, (uint8_t *)msglist[nextMsgIndex].text);

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -80,7 +80,7 @@ float probeOffsetGetValue(void)
 // Reset Z offset value to default value
 float probeOffsetResetValue(void)
 {
-  if (z_offset_value != PROBE_Z_OFFSET_DEFAULT_VALUE)  // if already default value, nothing to do
+  if (z_offset_value != PROBE_Z_OFFSET_DEFAULT_VALUE)  // if not default value
   {
     sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, PROBE_Z_OFFSET_DEFAULT_VALUE);  // set Z probe offset value
     mustStoreCmd("G1 Z%.2f\n", PROBE_Z_OFFSET_DEFAULT_VALUE - z_offset_value);     // move nozzle

--- a/TFT/src/User/API/ProbeOffsetControl.c
+++ b/TFT/src/User/API/ProbeOffsetControl.c
@@ -84,6 +84,7 @@ float probeOffsetResetValue(void)
   {
     sendParameterCmd(P_PROBE_OFFSET, AXIS_INDEX_Z, PROBE_Z_OFFSET_DEFAULT_VALUE);  // set Z probe offset value
     mustStoreCmd("G1 Z%.2f\n", PROBE_Z_OFFSET_DEFAULT_VALUE - z_offset_value);     // move nozzle
+
     z_offset_value = PROBE_Z_OFFSET_DEFAULT_VALUE;
   }
 

--- a/TFT/src/User/API/Vfs/vfs.c
+++ b/TFT/src/User/API/Vfs/vfs.c
@@ -217,7 +217,7 @@ bool addFile(bool isFile, const char * shortName, const char * longName)
   if (sName == NULL)  // in case of error, exit
     return false;
 
-  strxcpy(sName, shortName, sNameLen);  // copy to "sName" and set to NULL the flag for filename extension check, if any
+  strncpy_pad(sName, shortName, sNameLen);  // copy to "sName" and set to NULL the flag for filename extension check, if any
 
   //
   // get long name, if any
@@ -237,7 +237,7 @@ bool addFile(bool isFile, const char * shortName, const char * longName)
       return false;
     }
 
-    strxcpy(lName, longName, lNameLen);  // copy to "lName" and set to NULL the flag for filename extension check, if any
+    strncpy_pad(lName, longName, lNameLen);  // copy to "lName" and set to NULL the flag for filename extension check, if any
   }
 
   //
@@ -357,9 +357,9 @@ bool getPrintTitle(char * buf, uint8_t len)
     return false;
   }
 
-  strxcpy(buf, getFS(), len);  // set source and set the flag for filename extension check
-  strcat(buf, strPtr);         // append filename
-  hideExtension(buf);          // hide filename extension if filename extension feature is disabled
+  strncpy_pad(buf, getFS(), len);  // set source and set the flag for filename extension check
+  strcat(buf, strPtr);             // append filename
+  hideExtension(buf);              // hide filename extension if filename extension feature is disabled
 
   return true;
 }

--- a/TFT/src/User/API/Vfs/vfs.h
+++ b/TFT/src/User/API/Vfs/vfs.h
@@ -66,10 +66,8 @@ bool addFile(bool isFile, const char * shortName, const char * longName);  // ad
 // called in Print.c
 char * getFoldername(uint8_t index);             // return the long folder name if exists, otherwise the short one
 char * getFilename(uint8_t index);               // return the long file name if exists, otherwise the short one
-char * hideFilenameExtension(uint8_t index);     // given the index, hide the extension of that file name and return a pointer to that file name
-char * restoreFilenameExtension(uint8_t index);  // given the index, restore the extension of that file name and return a pointer to that file name
-char * hideExtension(char * filename);           // hide the extension of the file name and return a pointer to that file name
-char * restoreExtension(char * filename);        // restore the extension of the file name and return a pointer to that file name
+char * hideFilenameExtension(uint8_t index);     // hide the extension of the file name and return a pointer to that file name
+char * restoreFilenameExtension(uint8_t index);  // restore the extension of the file name and return a pointer to that file name
 
 // called in PrintingMenu.c
 char * getPrintFilename(void);                // get print filename according to print originator (remote or local to TFT)

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -162,7 +162,7 @@ bool storeCmdFromUART(const CMD cmd, const SERIAL_PORT_INDEX portIndex)
     return false;
   }
 
-  strxcpy(cmdQueue.queue[cmdQueue.index_w].gcode, cmd, CMD_MAX_SIZE);
+  strncpy_no_pad(cmdQueue.queue[cmdQueue.index_w].gcode, cmd, CMD_MAX_SIZE);
 
   cmdQueue.queue[cmdQueue.index_w].port_index = portIndex;
   cmdQueue.index_w = (cmdQueue.index_w + 1) % CMD_QUEUE_SIZE;
@@ -852,7 +852,7 @@ void sendQueueCmd(void)
             bool hasE, hasA;
 
             // make a copy to work on
-            strxcpy(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
+            strncpy_no_pad(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
 
             // retrieve message text and flags of M118 gcode
             msgText = parseM118(rawMsg, &hasE, &hasA);
@@ -999,7 +999,7 @@ void sendQueueCmd(void)
             const char * msgText;
 
             // make a copy to work on
-            strxcpy(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
+            strncpy_no_pad(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
 
             // retrieve message text
             stripChecksum(rawMsg);
@@ -1404,6 +1404,7 @@ void sendQueueCmd(void)
         case 28:  // G28
           coordinateSetKnown(true);
           babystepSetValue(BABYSTEP_DEFAULT_VALUE);  // reset babystep
+
           if (infoMachineSettings.leveling != BL_DISABLED)
             storeCmd("M420\n");  // check bed leveling state
           break;

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1369,8 +1369,8 @@
 
 /**
  * Suppress/allow terminal cache during keyboard view
- *  - uncomment to disable terminal cache during keyboard view
- *  - comment it to enable terminal cache during keyboard view
+ * Uncomment to disable terminal cache during keyboard view.
+ * Comment to enable terminal cache during keyboard view.
  */
 #define TERMINAL_KEYBOARD_VIEW_SUPPRESS_ACK  // Default: uncommented (cache suppressed)
 

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -211,7 +211,7 @@ bool f_remove_full_dir(const TCHAR* path)
   char dirBuffer[BUFFER_SIZE];
   FILINFO tmpInfo;
 
-  strxcpy(dirBuffer, path, BUFFER_SIZE);
+  strncpy_no_pad(dirBuffer, path, BUFFER_SIZE);
   if (f_remove_node(dirBuffer, BUFFER_SIZE, &tmpInfo) == FR_OK)
   {
     return true;

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -123,8 +123,8 @@ void menuBedLeveling(void)
       case KEY_ICON_3:
         if (levelStateNew != UNDEFINED)
           storeCmd((levelStateNew == ENABLED) ?
-                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S0\n" : "G29 S2\n") :
-                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S1\n" : "G29 S1\n"));
+                   (infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S0\n" : "G29 S2\n") :
+                   (infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S1\n" : "G29 S1\n"));
 
         break;
 

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -121,9 +121,10 @@ void menuBedLeveling(void)
         break;
 
       case KEY_ICON_3:
-        if (levelStateNew != UNDEFINED) storeCmd((levelStateNew == ENABLED) ?
-          (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S0\n" : "G29 S2\n") :
-          (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S1\n" : "G29 S1\n"));
+        if (levelStateNew != UNDEFINED)
+          storeCmd((levelStateNew == ENABLED) ?
+                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S0\n" : "G29 S2\n") :
+                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S1\n" : "G29 S1\n"));
 
         break;
 

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -84,10 +84,7 @@ void mblNotifyError(bool isStarted)
 {
   LABELCHAR(tempMsg, LABEL_MBL);
 
-  if (isStarted)
-    sprintf(&tempMsg[strlen(tempMsg)], " %s", textSelect(LABEL_ON));
-  else
-    sprintf(&tempMsg[strlen(tempMsg)], " %s", textSelect(LABEL_OFF));
+  sprintf(&tempMsg[strlen(tempMsg)], " %s", isStarted ? textSelect(LABEL_ON) : textSelect(LABEL_OFF));
 
   addToast(DIALOG_TYPE_ERROR, tempMsg);
 }

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -126,12 +126,12 @@ void menuDialog(void)
 
 void _setDialogTitleStr(uint8_t * str)
 {
-  strxcpy((char *)popup_title, (char *)str, sizeof(popup_title));
+  strncpy_no_pad((char *)popup_title, (char *)str, sizeof(popup_title));
 }
 
 void _setDialogMsgStr(uint8_t * str)
 {
-  strxcpy((char *)popup_msg, (char *)str, sizeof(popup_msg));
+  strncpy_no_pad((char *)popup_msg, (char *)str, sizeof(popup_msg));
 }
 
 uint8_t *getDialogMsgStr()
@@ -141,40 +141,40 @@ uint8_t *getDialogMsgStr()
 
 void _setDialogOkTextStr(uint8_t * str)
 {
-  strxcpy((char *)popup_ok, (char *)str, sizeof(popup_ok));
+  strncpy_no_pad((char *)popup_ok, (char *)str, sizeof(popup_ok));
 }
 
 void _setDialogCancelTextStr(uint8_t * str)
 {
-  strxcpy((char *)popup_cancel, (char *)str, sizeof(popup_cancel));
+  strncpy_no_pad((char *)popup_cancel, (char *)str, sizeof(popup_cancel));
 }
 
 void _setDialogTitleLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strxcpy((char *)popup_title, (char *)tempstr, sizeof(popup_title));
+  strncpy_no_pad((char *)popup_title, (char *)tempstr, sizeof(popup_title));
 }
 
 void _setDialogMsgLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strxcpy((char *)popup_msg, (char *)tempstr, sizeof(popup_msg));
+  strncpy_no_pad((char *)popup_msg, (char *)tempstr, sizeof(popup_msg));
 }
 
 void _setDialogOkTextLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strxcpy((char *)popup_ok, (char *)tempstr, sizeof(popup_ok));
+  strncpy_no_pad((char *)popup_ok, (char *)tempstr, sizeof(popup_ok));
 }
 
 void _setDialogCancelTextLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strxcpy((char *)popup_cancel, (char *)tempstr, sizeof(popup_cancel));
+  strncpy_no_pad((char *)popup_cancel, (char *)tempstr, sizeof(popup_cancel));
 }
 
 /**

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -122,21 +122,12 @@ static void setLayerNumberTxt(char * layer_number_txt)
   }
 }
 
-// set print title according to print originator (remote or local to TFT)
-static void setPrintTitle(void)
-{
-  char * fileName = getPrintFilename();
-
-  hideExtension(fileName);  // hide filename extension if filename extension feature is disabled
-  snprintf(title, MAX_TITLE_LEN, "%s%s", getFS(), fileName);
-  restoreExtension(fileName);  // restore filename extension if filename extension feature is disabled
-}
-
 // initialize printing info before opening Printing menu
 static void initMenuPrinting(void)
 {
-  setPrintTitle();  // set print title according to print originator (remote or local to TFT)
-  clearInfoFile();  // as last, clear and free memory for file list
+  getPrintTitle(title, MAX_TITLE_LEN);  // get print title according to print originator (remote or local to TFT)
+  clearInfoFile();                      // as last, clear and free memory for file list
+
   progDisplayType = infoSettings.prog_disp_type;
 
   // layer number can be parsed only when TFT reads directly the G-code file

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -202,17 +202,17 @@ void drawStatus(void)
 
 void statusScreen_setMsg(const uint8_t *title, const uint8_t *msg)
 {
-  strxcpy(msgTitle, (char *)title, sizeof(msgTitle));
-  strxcpy(msgBody, (char *)msg, sizeof(msgBody));
+  strncpy_no_pad(msgTitle, (char *)title, sizeof(msgTitle));
+  strncpy_no_pad(msgBody, (char *)msg, sizeof(msgBody));
   msgNeedRefresh = true;
 }
 
 void statusScreen_setReady(void)
 {
-  strxcpy(msgTitle, (char *)textSelect(LABEL_STATUS), sizeof(msgTitle));
+  strncpy_no_pad(msgTitle, (char *)textSelect(LABEL_STATUS), sizeof(msgTitle));
 
   if (infoHost.connected == false)
-    strxcpy(msgBody, (char *)textSelect(LABEL_UNCONNECTED), sizeof(msgBody));
+    strncpy_no_pad(msgBody, (char *)textSelect(LABEL_UNCONNECTED), sizeof(msgBody));
   else
     snprintf(msgBody, sizeof(msgBody), "%s %s", (char *)machine_type, (char *)textSelect(LABEL_READY));
 

--- a/TFT/src/User/Menu/Terminal.c
+++ b/TFT/src/User/Menu/Terminal.c
@@ -26,6 +26,12 @@ typedef struct
 
 typedef enum
 {
+  KEYBOARD_VIEW = 0,
+  TERMINAL_VIEW
+} TERMINAL_WINDOW;
+
+typedef enum
+{
   GKEY_PREV = 0,
   GKEY_NEXT,
   GKEY_CLEAR,
@@ -310,12 +316,7 @@ const uint16_t fontSrcColor[3][3] = {
 KEYBOARD_DATA * keyboardData;
 TERMINAL_DATA * terminalData;
 char * terminalBuf;
-
-enum
-{
-  KEYBOARD_VIEW = 0,
-  TERMINAL_VIEW,
-} curView = KEYBOARD_VIEW;
+TERMINAL_WINDOW curView = KEYBOARD_VIEW;
 
 bool numpad =
   #if defined(KB_TYPE_QWERTY)
@@ -666,7 +667,6 @@ static inline void saveGcodeTerminalCache(const char * str, uint16_t strLen)
 
 void terminalCache(const char * stream, uint16_t streamLen, SERIAL_PORT_INDEX portIndex, TERMINAL_SRC src)
 {
-
   #ifdef TERMINAL_KEYBOARD_VIEW_SUPPRESS_ACK
     if (curView == KEYBOARD_VIEW)
       return;

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -1,9 +1,8 @@
-#include <stdlib.h>  // first to avoid conflicts with strtod function
+#include <stdlib.h>  // first to avoid conflicts with strtod() function
 
 #include "my_misc.h"
 #include "printf/printf.h"
 #include <stddef.h>
-#include <string.h>
 
 #define CRC_POLY 0xA001
 
@@ -41,53 +40,6 @@ uint32_t calculateCRC16(const uint8_t *data, uint32_t length)
     }
   }
   return crc;
-}
-
-/*
- * - always copy num-1 characters from source to destination
- *   regardless of null terminating character found in source
- * - destination always ends with '\0'
- */
-void strxcpy(char * destination, const char * source, size_t num)
-{
-  num -= !!num;
-
-  memcpy(destination, source, num);
-  destination[num] ='\0';
-}
-
-/*
- * - copy source to destination but no more than width-1 characters
- * - if null terminating character found in source the rest is padded with 0
- * - destination always ends with '\0'
- */
-void strwcpy(char * destination, const char * source, size_t width)
-{
-  width -= !!width;
-  while (width > 1 && *source != '\0')
-  {
-    *destination++ = *source++;
-    width--;
-  }
-
-  memset(destination, '\0', width);
-}
-
-/*
- * - copy source to destination but no more than size-1 characters
- * - if null terminating character found in source the copy stops there
- * - destination always ends with '\0'
- */
-void strscpy(char * destination, const char * source, size_t size)
-{
-  size -= !!size;
-  while (size > 1 && *source != '\0')
-  {
-    *destination++ = *source++;
-    size--;
-  }
-
-  *destination = '\0';
 }
 
 // string convert to uint8, MSB
@@ -162,8 +114,19 @@ uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string)
   return string;
 }
 
-// convert string to double (without exponential support)
-double stringToDouble(char *str, char **endptr)
+// convert time to string with given formatting
+void timeToString(char *buf, char *strFormat, uint32_t time)
+{
+  uint8_t hour = HOURS(time);
+  uint8_t min = MINUTES(time);
+  uint8_t sec = SECONDS(time);
+
+  sprintf(buf, strFormat, hour, min, sec);
+}
+
+// light weight strtod() function without exponential support.
+// Convert string to double (without exponential support)
+double strtod_ligth(char *str, char **endptr)
 {
   char *p = str;
   double val = 0.0;
@@ -213,14 +176,44 @@ double stringToDouble(char *str, char **endptr)
   return val * sign;
 }
 
-// convert time to string with given formatting
-void timeToString(char *buf, char *strFormat, uint32_t time)
+// light weight and safe strncpy() function with padding:
+// - copy "src" to "dest" for a maximum of "n-1" characters
+// - if null terminating character is found in "src" the rest in "dest" is padded with '\0'
+// - "dest" always ends with '\0'
+void strncpy_pad(char *dest, const char *src, size_t n)
 {
-  uint8_t hour = HOURS(time);
-  uint8_t min = MINUTES(time);
-  uint8_t sec = SECONDS(time);
+  // if "src" is not NULL, proceed first with the copy.
+  // Otherwise, proceed only padding "dest" with '\0'
+  if (src != NULL)
+  {
+    while (n > 1 && *src != '\0')
+    {
+      *dest++ = *src++;
+      n--;
+    }
+  }
 
-  sprintf(buf, strFormat, hour, min, sec);
+  memset(dest, '\0', n);  // NOTE: safe even in case value 0 was passed for "n" (memset() function will do nothing)
+}
+
+// light weight and safe strncpy() function without padding:
+// - copy "src" to "dest" for a maximum of "n-1" characters
+// - if null terminating character is found in "src" the copy stops there
+// - "dest" always ends with '\0'
+void strncpy_no_pad(char *dest, const char *src, size_t n)
+{
+  // if "src" is not NULL, proceed with the copy
+  if (src != NULL)
+  {
+    while (n > 1 && *src != '\0')
+    {
+      *dest++ = *src++;
+      n--;
+    }
+  }
+
+  if (n != 0)  // safe in case value 0 was passed for "n"
+    *dest = '\0';
 }
 
 // strip out any leading " ", "/" or ":" character that might be in the string

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
+#include <string.h>  // for size_t
 
 // Menu Macros
 #define OPEN_MENU(x)    infoMenu.menu[++infoMenu.cur] = x
@@ -60,11 +60,11 @@ extern "C" {
 #define MINUTES(t) (t % (60 * 60) / 60)  // minutes remaining to next hour
 #define SECONDS(t) (t % 60)              // seconds remaining to next minute
 
-#define strtod stringToDouble  // enable light weight string to double function without exponential support
+#define strtod strtod_ligth  // light weight strtod() function without exponential support
 
 #define strncpy(...) \
   do { \
-    _Pragma("GCC error \"Error: strncpy() is deprecated! Use the alternatives like strxcpy(), strwcpy() or strscpy().\""); \
+    _Pragma("GCC error \"Error: strncpy() is deprecated! Use the alternatives like strncpy_pad() or strncpy_no_pad()\""); \
   } while (0)
 
 uint8_t inRange(int cur, int tag , int range);
@@ -72,15 +72,15 @@ long map(long x, long in_min, long in_max, long out_min, long out_max);
 
 uint32_t calculateCRC16(const uint8_t *data, uint32_t length);  // Calculate CRC16 checksum
 
-void strxcpy(char * destination, const char * source, size_t num);
-void strwcpy(char * destination, const char * source, size_t num);
-void strscpy(char * destination, const char * source, size_t num);
 uint8_t string_2_uint8_t(const uint8_t *string);
 uint8_t *uint8_2_string(uint8_t num, uint8_t *string);
 uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);
 uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string);
-double stringToDouble(char *str, char **endptr);
 void timeToString(char *buf, char *strFormat, uint32_t time);
+
+double strtod_ligth(char *str, char **endptr);               // light weight strtod() function without exponential support
+void strncpy_pad(char *dest, const char *src, size_t n);     // light weight and safe strncpy() function with padding
+void strncpy_no_pad(char *dest, const char *src, size_t n);  // light weight and safe strncpy() function without padding
 
 const char *stripHead(const char *str);  // strip out any leading " ", "/" or ":" character that might be in the string
 void stripChecksum(char *str);           // strip out any trailing checksum that might be in the string


### PR DESCRIPTION
**BUG FIXES:**
* Fixed instability bug introduced by #2662: despite the safety code claimed by #2662, the changes applied by that PR (use of strxcpy() function) made the code unsafe. strxcpy is not applicable at all in VFS API where the source buffer's size is always less that the destination buffer's size. strxcpy is not safe in general, meaning an out of buffer read occurs when the source buffer's size is less than the destination buffer's size (as in VFS API). Also strwcpy() and strscpy() were not working (freeze or wrong displayed files navigating on  sd card/usb stick). Proper functions named strncpy_pad()/strncpy_no_pad() are now used
* Fixed instability bug provided by setPrintTitle() function (in Printing menu): the hideExtension()/restoreExtension() functions made visible on VFS API by #2662 are not applicable on a standard string buffer. Those functions are specific to manage the data defined in the API (they have been hided also for that reason). Previous code is restored
* No new mesh applied by MeshEdit menu: with the changes applied by #2737 the meshSetValue() function is now setting the mesh for the original mesh instead of the mesh value provided by MeshTuner menu. It means that none of the meshes set by MeshTuner menu is applied at all. Furthermore, pressing on save button the original data grid was restored instead of setting the current data grid as the new original data grid
* Fixed unmatching function declaration/definition in .h/.c introduced by #2654: Fixed babystepSetValue() signatures
* Other bug fixes: e.g. wrong check on BedLeveling menu introduced by #2766

**NOTE:** #2766 removed the CaseLightControl API properly created (as any other API) to decouple the GUI from the core functions (e.g. the that API was used in interfaceCmd API). Now, a return to the past (3 years ago) has been applied

**PR STATE:** ready for merge
