### PR TITLE
Fixed MeshEditor menu

### DIFF
--- a/TFT/src/User/Menu/BLTouch.h
+++ b/TFT/src/User/Menu/BLTouch.h
@@ -12,7 +12,9 @@ typedef enum
   HS_DISABLED
 } BLT_HS_MODE;
 
+// called by parseAck() to notify BLTouch mode status
 void setHSmode(BLT_HS_MODE hsMode);
+
 void menuBLTouch(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/Fan.c
+++ b/TFT/src/User/Menu/Fan.c
@@ -1,6 +1,12 @@
 #include "Fan.h"
 #include "includes.h"
 
+typedef struct
+{
+  uint8_t cur;
+  uint8_t set;
+} LASTFAN;
+
 static uint8_t fan_index = 0;
 
 void menuFan(void)

--- a/TFT/src/User/Menu/Fan.h
+++ b/TFT/src/User/Menu/Fan.h
@@ -5,14 +5,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-
-typedef struct
-{
-  uint8_t cur;
-  uint8_t set;
-} LASTFAN;
-
 void menuFan(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/FeatureSettings.c
+++ b/TFT/src/User/Menu/FeatureSettings.c
@@ -51,6 +51,13 @@ typedef enum
   SKEY_COUNT                  // keep this always at the end
 } SKEY_LIST;
 
+void resetSettings(void)
+{
+  initSettings();
+  storePara();
+  popupReminder(DIALOG_TYPE_SUCCESS, LABEL_INFO, LABEL_SETTINGS_RESET_DONE);
+}
+
 // perform action on button press
 void updateFeatureSettings(uint8_t item_index)
 {
@@ -197,13 +204,6 @@ void loadFeatureSettings(LISTITEM * item, uint16_t item_index, uint8_t itemPos)
     }
   }
 }  // loadFeatureSettings
-
-void resetSettings(void)
-{
-  initSettings();
-  storePara();
-  popupReminder(DIALOG_TYPE_SUCCESS, LABEL_INFO, LABEL_SETTINGS_RESET_DONE);
-}
 
 void menuFeatureSettings(void)
 {

--- a/TFT/src/User/Menu/FeatureSettings.h
+++ b/TFT/src/User/Menu/FeatureSettings.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-void resetSettings(void);
 void menuFeatureSettings(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -250,7 +250,7 @@ const char * meshErrorMsg[] = {"Invalid mesh"};  // list of possible error respo
 
 static MESH_DATA *meshData = NULL;
 
-void meshInitData(void)
+static inline void meshInitData(void)
 {
   if (meshData == NULL)
     return;
@@ -270,7 +270,7 @@ void meshInitData(void)
   meshData->gDelta = meshData->gEnd - meshData->gStart;
   meshData->bDelta = meshData->bEnd - meshData->bStart;
 
-  // meshData->status = ME_DATA_IDLE;  // left here for code understanding, init done already by memset()
+  // meshData->status = ME_DATA_IDLE;  // init already done by memset() (ME_DATA_IDLE is 0 as the value used by memset())
 }
 
 static inline void meshAllocData(void)
@@ -357,29 +357,39 @@ void meshSaveCallback(void)
     menuUBLSave();
   else if (infoMachineSettings.leveling != BL_DISABLED)
     saveEepromSettings();
+
+  if (meshData != NULL)
+    memcpy(meshData->oriData, meshData->curData, sizeof(meshData->curData));  // align data only after save confirmation
 }
 
-void meshUpdateIndex(MESH_KEY_VALUES key_num)
+static inline void meshUpdateIndex(MESH_KEY_VALUES key_num)
 {
   switch (key_num)
   {
     case ME_KEY_UP:
-       meshData->row = (meshData->rowsNum + meshData->row - 1) % meshData->rowsNum;
-       break;
+      meshData->row = (meshData->rowsNum + meshData->row - 1) % meshData->rowsNum;
+      break;
 
     case ME_KEY_DOWN:
-       meshData->row = (meshData->row + 1) % meshData->rowsNum;
-       break;
+      meshData->row = (meshData->row + 1) % meshData->rowsNum;
+      break;
 
     case ME_KEY_PREV:
     case ME_KEY_DECREASE:
-       meshData->col = (meshData->colsNum + meshData->col - 1) % meshData->colsNum;
-       break;
-
     case ME_KEY_NEXT:
     case ME_KEY_INCREASE:
-       meshData->col = (meshData->col + 1) % meshData->colsNum;
-       break;
+    {
+      uint16_t index;
+
+      if (key_num == ME_KEY_PREV || key_num == ME_KEY_DECREASE)
+        index = meshData->index > 0 ? meshData->index - 1 : meshData->dataSize - 1;
+      else
+        index = meshData->index < meshData->dataSize - 1 ? meshData->index + 1 : 0;
+
+      meshData->col = index % meshData->colsNum;
+      meshData->row = index / meshData->colsNum;
+      break;
+    }
 
     default:
       break;
@@ -388,34 +398,52 @@ void meshUpdateIndex(MESH_KEY_VALUES key_num)
   meshData->index = meshData->row * meshData->colsNum + meshData->col;
 }
 
-static inline uint16_t meshGetRealRow(void)
+uint16_t meshGetJ(void)
 {
-  return meshData->rowsInverted ? (meshData->rowsNum - 1) - meshData->row : meshData->row;
+  // J index (independent by data format) to be used by G42 (mesh tuner menu) and M421 (meshSetValue() function).
+  // Bed's top left point -> J = max row index
+  // Bed's bottom left point -> J = 0
+  return (meshData->rowsNum - 1) - meshData->row;
 }
 
 static inline void meshSetValue(void)
 {
-  storeCmd("M421 I%d J%d Z%.3f\n", meshData->col, meshGetRealRow(), meshData->curData[meshData->index]);
+  storeCmd("M421 I%d J%d Z%.3f\n", meshData->col, meshGetJ(), meshData->curData[meshData->index]);
 }
 
 static inline void meshUpdateValueMinMax(void)
 {
-  meshData->valueMin = meshData->valueMax = 0;
+  float value;
+  bool isValueChanged = true;  // initialized to "true" just to set meshData->valueDelta at least one time
+
+  meshData->valueMin = meshData->valueMax = meshData->curData[0];  // init initial min/max values
 
   for (uint16_t i = 0; i < meshData->dataSize; i++)
   {
-    if(meshData->curData[i] < meshData->valueMin)
-      meshData->valueMin = meshData->curData[i];
-    if(meshData->curData[i] > meshData->valueMax)
-      meshData->valueMax = meshData->curData[i];
-  }
+    value = meshData->curData[i];
+    isValueChanged = false;
 
-  meshData->valueDelta = meshData->valueMax - meshData->valueMin;
+    if (value < meshData->valueMin)
+    {
+      meshData->valueMin = value;
+
+      isValueChanged = true;
+    }
+    else if (value > meshData->valueMax)
+    {
+      meshData->valueMax = value;
+
+      isValueChanged = true;
+    }
+
+    if (isValueChanged)
+      meshData->valueDelta = meshData->valueMax - meshData->valueMin;
+  }
 }
 
 uint16_t mapRGBdata(uint16_t * rgbStart, int16_t * rgbDelta, float * valueDiff, float * valueDelta)
 {
-  return *rgbStart + *valueDiff * *rgbDelta / *valueDelta;
+  return *rgbStart + (*valueDiff * *rgbDelta) / *valueDelta;
 }
 
 uint16_t meshGetRGBColor(const float value)
@@ -496,7 +524,7 @@ void meshDrawInfo(const bool drawMinMax)
   drawStandardValue(&meshInfoRect[ME_INFO_CUR], VALUE_FLOAT, &meshData->curData[meshData->index], FONT_SIZE_LARGE, MESH_FONT_COLOR, MESH_BORDER_COLOR, 4, true);
 }
 
-void meshDrawButton(const uint8_t index, const uint8_t isPressed)
+static inline void meshDrawButton(const uint8_t index, const uint8_t isPressed)
 {
   if (index >= ME_KEY_NUM)
     return;
@@ -524,14 +552,14 @@ void meshDrawButton(const uint8_t index, const uint8_t isPressed)
   GUI_SetColor(MESH_FONT_COLOR);
 }
 
-void meshDrawKeyboard(void)
+static inline void meshDrawKeyboard(void)
 {
   // draw buttons
   GUI_SetTextMode(GUI_TEXTMODE_TRANS);
 
   for (uint8_t i = 0; i < ME_KEY_NUM; i++)
   {
-    if (i > ME_KEY_EDIT)                                   // if not a unicode string
+    if (i > ME_KEY_EDIT)  // if not a unicode string
       drawStandardValue(&meshKeyRect[i], VALUE_STRING, meshKeyString[i], FONT_SIZE_LARGE, MESH_FONT_COLOR, MESH_BG_COLOR, 3, true);
   }
 
@@ -557,11 +585,11 @@ void meshDrawMenu(void)
   GUI_SetColor(MESH_BORDER_COLOR);
 
   // draw area borders
-  GUI_DrawPrect(&meshAreaRect[ME_AREA_GRID]);              // draw grid area borders
-  GUI_DrawPrect(&meshAreaRect[ME_AREA_INFO]);              // draw info area borders
-  GUI_DrawPrect(&meshAreaRect[ME_AREA_KEY]);               // draw key borders
+  GUI_DrawPrect(&meshAreaRect[ME_AREA_GRID]);     // draw grid area borders
+  GUI_DrawPrect(&meshAreaRect[ME_AREA_INFO]);     // draw info area borders
+  GUI_DrawPrect(&meshAreaRect[ME_AREA_KEY]);      // draw key borders
   #ifdef PORTRAIT_MODE
-    GUI_DrawPrect(&meshAreaRect[ME_AREA_ARROW]);           // draw arrow area borders
+    GUI_DrawPrect(&meshAreaRect[ME_AREA_ARROW]);  // draw arrow area borders
   #endif
 
   // draw value area borders (outer)
@@ -587,7 +615,7 @@ void meshSave(void)
     popupDialog(DIALOG_TYPE_QUESTION, (uint8_t *) meshData->saveTitle, LABEL_EEPROM_SAVE_INFO, LABEL_CONFIRM, LABEL_CANCEL, meshSaveCallback, NULL, NULL);
 }
 
-bool meshIsWaitingFirstData(void)
+static inline bool meshIsWaitingFirstData(void)
 { // just avoid to merge on the same "if" statement a check on NULL value and an access
   // to attributes of the data structure meshData due to different compiler optimization
   // settings (that could evaluate all the conditions in the "if" statement, causing a crash)
@@ -607,7 +635,7 @@ bool meshIsWaitingData(void)
   if (meshData == NULL)  // if mesh editor is not running
     return false;
 
-  if (meshData->status == ME_DATA_FULL || meshData->status == ME_DATA_FAILED)  // is not waiting for data
+  if (meshData->status == ME_DATA_FULL || meshData->status == ME_DATA_FAILED)  // if not waiting for data
     return false;
 
   return true;
@@ -645,7 +673,7 @@ uint16_t meshParseDataRow(char *dataRow, float *dataGrid, const uint16_t maxCoun
   return count;
 }
 
-void processGridData(void)
+static inline void processGridData(void)
 {
   if (meshData->rowsInverted)  // store grid data with the rows in inverse order
   {
@@ -668,7 +696,7 @@ void meshUpdateData(char *dataRow)
 {
   bool failed = false;
 
-  if (meshIsWaitingFirstData())  // if waiting mesh type/format data
+  if (meshIsWaitingFirstData())  // if waiting for mesh type/format data
   {
     meshData->parsedRows++;
 
@@ -681,6 +709,7 @@ void meshUpdateData(char *dataRow)
       if (processKnownDataFormat(dataRow))  // if known data format, change state to EMPTY to enable the mesh parsing
       {
         meshData->status = ME_DATA_EMPTY;
+
         meshData->parsedRows = 1;
       }
 
@@ -698,11 +727,12 @@ void meshUpdateData(char *dataRow)
 
     if (meshData->status == ME_DATA_EMPTY)  // if data grid is empty, parse the data row and set the data grid columns number
     {
-      count = meshParseDataRow(dataRow, meshData->oriData, MESH_GRID_MAX_POINTS_X);
+      count = meshParseDataRow(dataRow, &(meshData->oriData[0]), MESH_GRID_MAX_POINTS_X);
 
       if (count > 0)  // if number of columns in the parsed data row is at least 1, set the data grid columns number
       {
         meshData->status = ME_DATA_WAITING;
+
         meshData->colsNum = count;
         meshData->rowsNum = 1;
       }
@@ -711,7 +741,8 @@ void meshUpdateData(char *dataRow)
     {
       count = meshParseDataRow(dataRow, &(meshData->oriData[meshData->rowsNum * meshData->colsNum]), meshData->colsNum);
 
-      if (count == meshData->colsNum)  // if number of columns in the parsed data row matches the data grid columns number, update the data grid rows number
+      // if number of columns in the parsed data row matches the data grid columns number, update the data grid rows number
+      if (count == meshData->colsNum)
       {
         meshData->rowsNum++;
       }
@@ -719,9 +750,10 @@ void meshUpdateData(char *dataRow)
 
     meshData->parsedRows++;
 
+    // if zero columns are read or maximun rows numnber or maximum parsed rows number is reached
     if ((meshData->rowsNum >= 1 && count == 0) ||
       meshData->rowsNum == MESH_GRID_MAX_POINTS_Y ||
-      meshData->parsedRows >= MESH_MAX_PARSED_ROWS)  // if zero columns are read or maximun rows numnber or maximum parsed rows number is reached
+      meshData->parsedRows >= MESH_MAX_PARSED_ROWS)
     {
       if (meshData->colsNum == 0 || meshData->rowsNum == 0)  // if mesh grid is smaller than a 1x1 matrix, data grid is marked as failed
       {
@@ -743,10 +775,10 @@ void meshUpdateData(char *dataRow)
 
     meshData->status = ME_DATA_FAILED;
 
-    CLOSE_MENU();  // trigger exit from mesh editor menu
-
     snprintf(tempMsg, MAX_STRING_LENGTH, "%s\n-> %s", textSelect(LABEL_PROCESS_ABORTED), dataRow);
     popupReminder(DIALOG_TYPE_ERROR, LABEL_MESH_EDITOR, (uint8_t *) tempMsg);
+
+    CLOSE_MENU();  // trigger exit from mesh editor menu
   }
 }
 
@@ -794,7 +826,7 @@ void menuMeshEditor(void)
         if (coordinateIsKnown() == false)
           probeHeightHome();  // home, disable ABL and raise nozzle
 
-        meshData->curData[curIndex] = menuMeshTuner(meshData->col, meshGetRealRow(), meshData->curData[curIndex]);
+        meshData->curData[curIndex] = menuMeshTuner(meshData->col, meshGetJ(), meshData->curData[curIndex]);
         meshSetValue();
 
         meshDrawMenu();
@@ -816,11 +848,10 @@ void menuMeshEditor(void)
 
       case ME_KEY_SAVE:
         meshSave();
-        memcpy(meshData->oriData, meshData->curData, sizeof(meshData->curData));
         break;
 
       case ME_KEY_OK:
-        if (memcmp(meshData->oriData, meshData->curData, sizeof(meshData->curData)))
+        if (memcmp(meshData->oriData, meshData->curData, sizeof(meshData->curData)))  // if data changed
           meshSave();
 
         meshDeallocData();

--- a/TFT/src/User/Menu/MeshEditor.h
+++ b/TFT/src/User/Menu/MeshEditor.h
@@ -8,7 +8,6 @@ extern "C" {
 #include <stdbool.h>
 
 // called by parseAck()
-bool meshIsWaitingFirstData(void);
 bool meshIsWaitingData(void);
 void meshUpdateData(char *dataRow);
 

--- a/TFT/src/User/Menu/ParameterSettings.h
+++ b/TFT/src/User/Menu/ParameterSettings.h
@@ -5,8 +5,6 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
-
 void menuParameterSettings(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/PersistentInfo.c
+++ b/TFT/src/User/Menu/PersistentInfo.c
@@ -1,6 +1,11 @@
 #include "PersistentInfo.h"
 #include "includes.h"
 
+// global Info
+#define GLOBALICON_WIDTH    (BYTE_WIDTH * 2)
+#define GLOBALICON_HEIGHT   GLOBALICON_WIDTH
+#define GLOBALICON_INTERVAL 2
+
 // check current menu to avoid display info
 bool temperatureStatusValid(void)
 {

--- a/TFT/src/User/Menu/PersistentInfo.h
+++ b/TFT/src/User/Menu/PersistentInfo.h
@@ -5,12 +5,7 @@
 extern "C" {
 #endif
 
-#include "menu.h"
-
-// Global Info
-#define GLOBALICON_WIDTH    (BYTE_WIDTH * 2)
-#define GLOBALICON_HEIGHT   GLOBALICON_WIDTH
-#define GLOBALICON_INTERVAL 2
+#include <stdint.h>
 
 void loopTemperatureStatus(void);
 int16_t drawTemperatureStatus(void);

--- a/TFT/src/User/Menu/Pid.h
+++ b/TFT/src/User/Menu/Pid.h
@@ -5,8 +5,6 @@
 extern "C" {
 #endif
 
-#include <stdbool.h>
-
 typedef enum
 {
   PID_IDLE = 0,

--- a/TFT/src/User/Menu/PreheatMenu.h
+++ b/TFT/src/User/Menu/PreheatMenu.h
@@ -5,8 +5,8 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
-#include "menu.h"
 #include "Settings.h"
 
 void refreshPreheatIcon(PREHEAT_STORE * preheatStore, uint8_t index, bool redrawIcon);

--- a/TFT/src/User/Menu/ScreenSettings.h
+++ b/TFT/src/User/Menu/ScreenSettings.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 void menuScreenSettings(void);
-void menuLanguage(void);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/Menu/Speed.c
+++ b/TFT/src/User/Menu/Speed.c
@@ -1,6 +1,12 @@
 #include "Speed.h"
 #include "includes.h"
 
+typedef struct
+{
+  uint8_t cur;
+  uint8_t set;
+} LASTSPEED;
+
 const ITEM itemPercentType[SPEED_NUM] = {
   // icon                        label
   {ICON_MOVE,                    LABEL_PERCENTAGE_SPEED},

--- a/TFT/src/User/Menu/Speed.h
+++ b/TFT/src/User/Menu/Speed.h
@@ -7,12 +7,6 @@ extern "C" {
 
 #include <stdint.h>
 
-typedef struct
-{
-  uint8_t cur;
-  uint8_t set;
-} LASTSPEED;
-
 void setSpeedItemIndex(uint8_t index);
 void menuSpeed(void);
 

--- a/TFT/src/User/Menu/Terminal.c
+++ b/TFT/src/User/Menu/Terminal.c
@@ -630,6 +630,7 @@ static inline void menuKeyboardView(void)
       lastIndex = nowIndex;  // update gcode size
       gcodeBuf[nowIndex] = '\0';
       drawGcodeText(gcodeBuf);
+
       if (*gcodeBuf == '\0')  // text area empty
       {
         for (uint8_t i = 0; i < GKEY_SEND; i++)  // draw text box keys

--- a/TFT/src/User/Menu/TuneExtruder.h
+++ b/TFT/src/User/Menu/TuneExtruder.h
@@ -6,7 +6,6 @@ extern "C" {
 #endif
 
 void menuTuneExtruder(void);
-void menuNewExtruderESteps(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**BUGFIXES:**
* Fixed other bugs introduced by #2737:
  - wrong column index used for both SetMeshValue and MeshTuner
  - wrong color gradients  applied after changing a mesh with MeshTuner
  - missing save popup in some situations
  - broken navigation panel (no more possible to use the rotary encoder)
  - etc..
* minor cleanup: removed unneeded function declarations on some .h files

@bigtreetech: I'm not going to waste other time in the future for fixing something that was perfectly working and not needing any rework (no bug reported in years). For any other bug introduced by some contributors affected by an outstanding ego I will simply revert entirely to previous code. I will also avoid to provide specific details about the code logic and the fixed bugs just to avoid to tease the fancy such as the soap opera (a never ending story) reported in #2776. Thank you for your understanding.

**PR STATE:** Ready for merge
