### PR TITLE
MB Reset Fix

### DIFF
--- a/TFT/src/User/API/FanControl.c
+++ b/TFT/src/User/API/FanControl.c
@@ -13,8 +13,15 @@ static uint8_t needSetFanSpeed = 0;
 static bool ctrlFanQueryWait = false;
 static uint32_t nextCtrlFanTime = 0;
 
+void fanResetSpeed(void)
+{
+  needSetFanSpeed = 0;
+  memset(setFanSpeed, 0, sizeof(setFanSpeed));
+  memset(curFanSpeed, 0, sizeof(curFanSpeed));
+}
+
 // Check whether the index is a valid fan index.
-bool fanIsValid(uint8_t index)
+bool fanIsValid(const uint8_t index)
 {
   if (index >= infoSettings.fan_count && index < MAX_COOLING_FAN_COUNT)  // invalid cooling fan index
     return false;
@@ -26,45 +33,43 @@ bool fanIsValid(uint8_t index)
     return true;
 }
 
-void fanSetSpeed(uint8_t i, uint8_t speed)
+void fanSetSpeed(const uint8_t i, const uint8_t speed)
 {
   SET_BIT_VALUE(needSetFanSpeed, i, fanGetCurSpeed(i) != speed);
   setFanSpeed[i] = speed;
 }
 
-uint8_t fanGetSetSpeed(uint8_t i)
+uint8_t fanGetSetSpeed(const uint8_t i)
 {
   return setFanSpeed[i];
 }
 
-void fanSetPercent(uint8_t i, uint8_t percent)
+void fanSetPercent(const uint8_t i, const uint8_t percent)
 {
-  percent = NOBEYOND(0, percent, 100);
-  fanSetSpeed(i, (percent * infoSettings.fan_max[i]) / 100);
+  fanSetSpeed(i, (NOBEYOND(0, percent, 100) * infoSettings.fan_max[i]) / 100);
 }
 
-uint8_t fanGetSetPercent(uint8_t i)
+uint8_t fanGetSetPercent(const uint8_t i)
 {
   return (setFanSpeed[i] * 100.0f) / infoSettings.fan_max[i] + 0.5f;
 }
 
-void fanSetCurSpeed(uint8_t i, uint8_t speed)
+void fanSetCurSpeed(const uint8_t i, const uint8_t speed)
 {
   curFanSpeed[i] = speed;
 }
 
-uint8_t fanGetCurSpeed(uint8_t i)
+uint8_t fanGetCurSpeed(const uint8_t i)
 {
   return curFanSpeed[i];
 }
 
-void fanSetCurPercent(uint8_t i, uint8_t percent)
+void fanSetCurPercent(const uint8_t i, const uint8_t percent)
 {
-  percent = NOBEYOND(0, percent, 100);
-  curFanSpeed[i] = (percent * infoSettings.fan_max[i]) / 100;
+  curFanSpeed[i] = (NOBEYOND(0, percent, 100) * infoSettings.fan_max[i]) / 100;
 }
 
-uint8_t fanGetCurPercent(uint8_t i)
+uint8_t fanGetCurPercent(const uint8_t i)
 {
   return (curFanSpeed[i] * 100.0f) / infoSettings.fan_max[i] + 0.5f;
 }
@@ -85,7 +90,7 @@ void loopFan(void)
   }
 }
 
-void ctrlFanQuerySetWait(bool wait)
+void ctrlFanQuerySetWait(const bool wait)
 {
   ctrlFanQueryWait = wait;
 }

--- a/TFT/src/User/API/FanControl.h
+++ b/TFT/src/User/API/FanControl.h
@@ -17,17 +17,18 @@ extern "C" {
 extern const char* fanID[MAX_FAN_COUNT];
 extern const char* fanCmd[MAX_FAN_COUNT];
 
-bool fanIsValid(uint8_t index);
-void fanSetSpeed(uint8_t i, uint8_t speed);
-uint8_t fanGetSetSpeed(uint8_t i);
-void fanSetPercent(uint8_t i, uint8_t percent);
-uint8_t fanGetSetPercent(uint8_t i);
-void fanSetCurSpeed(uint8_t i, uint8_t speed);
-uint8_t fanGetCurSpeed(uint8_t i);
-void fanSetCurPercent(uint8_t i, uint8_t percent);
-uint8_t fanGetCurPercent(uint8_t i);
+void fanResetSpeed(void);
+bool fanIsValid(const uint8_t index);
+void fanSetSpeed(const uint8_t i, const uint8_t speed);
+uint8_t fanGetSetSpeed(const uint8_t i);
+void fanSetPercent(const uint8_t i, const uint8_t percent);
+uint8_t fanGetSetPercent(const uint8_t i);
+void fanSetCurSpeed(const uint8_t i, const uint8_t speed);
+uint8_t fanGetCurSpeed(const uint8_t i);
+void fanSetCurPercent(const uint8_t i, const uint8_t percent);
+uint8_t fanGetCurPercent(const uint8_t i);
 void loopFan(void);
-void ctrlFanQuerySetWait(bool wait);
+void ctrlFanQuerySetWait(const bool wait);
 void ctrlFanQuery(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -49,33 +49,35 @@ bool getRunoutAlarm(void)
   return filamentRunoutAlarm;
 }
 
-void clearQueueAndRunoutAlarm(void)
+void clearQueueAndMore(void)
 {
   clearCmdQueue();
   setRunoutAlarmFalse();
+  heatSetUpdateWaiting(false);
+  setPrintUpdateWaiting(false);
 }
 
 void breakAndContinue(void)
 {
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
   sendEmergencyCmd("M108\n");
 }
 
 void resumeAndPurge(void)
 {
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
   sendEmergencyCmd("M876 S0\n");
 }
 
 void resumeAndContinue(void)
 {
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
   sendEmergencyCmd("M876 S1\n");
 }
 
 void abortAndTerminate(void)
 {
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
 
   if (infoMachineSettings.firmwareType != FW_REPRAPFW)
   {
@@ -114,7 +116,7 @@ void loopBreakToCondition(CONDITION_CALLBACK condCallback)
 
   // remove any enqueued command that could come from a supplementary serial port or TFT media
   // (if printing from remote host or TFT media) during the loop above
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
 }
 
 void setPrintExpectedTime(uint32_t expectedTime)
@@ -566,7 +568,7 @@ void abortPrint(void)
 
   loopDetected = true;
 
-  clearQueueAndRunoutAlarm();
+  clearQueueAndMore();
 
   switch (infoFile.source)
   {

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -199,13 +199,11 @@ bool moveCacheToCmd(void)
   return true;
 }
 
-// Clear all gcode cmd in cmdQueue queue when printing is aborted.
+// Clear all gcode cmd in cmdQueue queue.
 void clearCmdQueue(void)
 {
   cmdQueue.count = cmdQueue.index_w = cmdQueue.index_r = 0;
   cmdCache.count = cmdCache.index_w = cmdCache.index_r = 0;
-  heatSetUpdateWaiting(false);
-  setPrintUpdateWaiting(false);
 }
 
 // Strip out any leading space from the passed command.

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1331,6 +1331,25 @@ void parseACK(void)
         setParameter(P_FILAMENT_DIAMETER, 0, getParameter(P_FILAMENT_DIAMETER, 1) > 0.01f ? 1 : 0);
       }
     }
+    // check for motherboard reset (external, software, etc)
+    else if (ack_seen("Reset"))
+    {
+      if (ack_seen("External") || ack_seen("Software") || ack_seen("Watchdog") || ack_seen("Brown out"))
+      {
+        /*
+         * Proceed to reset the command queue, host status, fan speeds and load default machine settings.
+         * These functions will also trigger the query of temperatures which together with the resets
+         * done will also trigger the query of the motherboard capabilities and settings. It is necessary
+         * to do so because after the motherboard reset things might have changed (ex. FW update by M997).
+         */
+
+        clearCmdQueue();
+        memset(&infoHost, 0, sizeof(infoHost));
+        initMachineSettings();
+        fanResetSpeed();
+        setReminderMsg(LABEL_UNCONNECTED, SYS_STATUS_DISCONNECTED);  // set the no printer attached reminder
+      }
+    }
 
   parse_end:
     if (!avoid_terminal && MENU_IS(menuTerminal))


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This PR fixes the TFT not communicating with the motherboard after it has ben reset (software reset, external reset, watchdog reset, brown out reset)

### Related Issues

Fixes #2779

### Credit

All credit goes to @rondlh, he found the problem and the solution for it, I just expanded it for more possible situations.

### Notes

~Marked as draft as it is waiting for user feedback~
