### PR TITLE
Bug fix on partial message retrieval

### DIFF
--- a/TFT/src/User/API/SerialConnection.c
+++ b/TFT/src/User/API/SerialConnection.c
@@ -176,7 +176,7 @@ uint16_t Serial_Get(SERIAL_PORT_INDEX portIndex, char * buf, uint16_t bufSize)
   //
   // NOTES:
   //   - this scenario typically happens when the TFT receives a burst of messages (e.g. the output for "M420 V1 T1").
-  //     The first fully received message (terminated by "\n") triggers the L1 cache as available
+  //     The first fully received message (terminated by "\n") is enough to trigger the L1 cache as available
   //     (infoHost.rx_ok[portIndex] set to "true") for reading
   //   - it is more safe to leave the following code line commented out just to avoid any possibility the
   //     L1 cache's interrupt handler is receiving (and triggering L1 cache as available) in the meanwhile


### PR DESCRIPTION
**BUG FIXES:**
* wrong retrieval of partial message from L1 cache: this scenario typically happens when the TFT receives a burst of messages (e.g. the output for "M420 V1 T1"). The first fully received message (terminated by "\n") is enough to trigger the L1 cache as available (infoHost.rx_ok[portIndex] set to "true") for reading. As consequence, the partial retrieved message is not properly processed by the TFT (e.g. a partial echo message is displayed as an error popup, a truncated message breaks the expected handling etc...).
E.g. the wrong number of rows sometimes displayed on Mesh Edit menu (see attached picture) (e.g. a 6x7 grid instead of the expected 7x7) was caused by this bug.
Probably, the bug occurs more often on not fast TFTs and/or too fast/burst communication speed with main boards.
The bug fix could fix some unusual bugs reported by users.

**PR STATE:** ready for merge

![IMG_20230506_185107](https://user-images.githubusercontent.com/64427768/236667743-227dc0e9-f885-4ff1-ba0d-f8e5470da209.jpg)
