### PR TITLE
bug fixes on Mesh Editor, Move and on IDEX Incorrect extrude low temp warning (#2789)

### DIFF
--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -74,7 +74,7 @@ bool powerFailedInitData(void)
     }
   }
 
-  mustStoreCacheCmd("%s\n", tool_change[infoBreakPoint.tool]);
+  mustStoreCacheCmd("%s\n", toolChange[infoBreakPoint.tool]);
 
   for (uint8_t i = MAX_HEATER_COUNT - 1; i >= MAX_HOTEND_COUNT; i--)  // Bed & Chamber infoCacheCmd.queue[0 - 1]
   {

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -1,6 +1,8 @@
 #include "Temperature.h"
 #include "includes.h"
 
+const char *const toolChange[]                    = TOOL_CHANGE;
+const char *const extruderDisplayID[]             = EXTRUDER_ID;
 const char *const heaterID[MAX_HEATER_COUNT]      = HEAT_SIGN_ID;
 const char *const heatDisplayID[MAX_HEATER_COUNT] = HEAT_DISPLAY_ID;
 const char *const heatShortID[MAX_HEATER_COUNT]   = HEAT_SHORT_ID;

--- a/TFT/src/User/API/Temperature.h
+++ b/TFT/src/User/API/Temperature.h
@@ -65,6 +65,8 @@ typedef struct
   uint8_t toolIndex;
 } HEATER;
 
+extern const char *const toolChange[];
+extern const char *const extruderDisplayID[];
 extern const char *const heaterID[];
 extern const char *const heatDisplayID[];
 extern const char *const heatShortID[];

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -16,7 +16,7 @@ void menuExtrude(void)
       {ICON_NULL,                    LABEL_NULL},
       {ICON_NULL,                    LABEL_NULL},
       {ICON_LOAD,                    LABEL_LOAD},
-      {ICON_NULL,                    LABEL_NULL},
+      {ICON_HEAT,                    LABEL_HEAT},
       {ICON_E_5_MM,                  LABEL_5_MM},
       {ICON_NORMAL_SPEED,            LABEL_NORMAL},
       {ICON_BACK,                    LABEL_BACK},
@@ -27,8 +27,12 @@ void menuExtrude(void)
   float extrLength = 0.0f;
   float extrAmount = 0.0f;
 
-  extrudeItems.items[KEY_ICON_4].icon = (infoSettings.ext_count > 1) ? ICON_NOZZLE : ICON_HEAT;
-  extrudeItems.items[KEY_ICON_4].label.index = (infoSettings.ext_count > 1) ? LABEL_NOZZLE : LABEL_HEAT;
+  if (infoSettings.ext_count > 1)
+  {
+    extrudeItems.items[KEY_ICON_4].icon = ICON_NOZZLE;
+    extrudeItems.items[KEY_ICON_4].label.index = LABEL_NOZZLE;
+  }
+
   extrudeItems.items[KEY_ICON_5] = itemExtLenSteps[extlenSteps_index];
   extrudeItems.items[KEY_ICON_6] = itemSpeed[itemSpeed_index];
 

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -1,8 +1,6 @@
 #include "Extrude.h"
 #include "includes.h"
 
-const char *const extruderDisplayID[] = EXTRUDER_ID;
-const char *const tool_change[] = TOOL_CHANGE;
 static uint8_t curExtruder_index = 0;
 static uint8_t extlenSteps_index = 1;
 static uint8_t itemSpeed_index = 1;
@@ -70,6 +68,7 @@ void menuExtrude(void)
 
       case KEY_INFOBOX:
         extrLength = editFloatValue(0 - extlenSteps[COUNT(extlenSteps) - 1], extlenSteps[COUNT(extlenSteps) - 1], 0, 0);
+
         extruderReDraw(curExtruder_index, extrAmount, true);
         break;
 
@@ -82,11 +81,13 @@ void menuExtrude(void)
         if (infoSettings.ext_count > 1)
         {
           curExtruder_index = (curExtruder_index + 1) % infoSettings.ext_count;
+
           extruderReDraw(curExtruder_index, extrAmount, true);
         }
         else
         {
           heatSetCurrentIndex(curExtruder_index);  // preselect current nozzle for "Heat" menu
+
           OPEN_MENU(menuHeat);
           menuHeat();  // call from here to retain E axis parameters
 
@@ -117,9 +118,11 @@ void menuExtrude(void)
         break;
 
       case KEY_ICON_7:
-        COOLDOWN_TEMPERATURE();
-        CLOSE_MENU();
         eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
+
+        COOLDOWN_TEMPERATURE();
+
+        CLOSE_MENU();
         break;
 
       default:
@@ -130,7 +133,7 @@ void menuExtrude(void)
     {
       if (curExtruder_index != heatGetCurrentTool())
       {
-        mustStoreCmd("%s\n", tool_change[curExtruder_index]);
+        mustStoreCmd("%s\n", toolChange[curExtruder_index]);
 
         // set the tool index now (don't wait for the T0/T1 response, which comes too late)
         // just to allow warmupNozzle() function checks the temperature for the selected tool
@@ -150,13 +153,13 @@ void menuExtrude(void)
         case HEATED:
           if (storeCmd("G1 E%.5f F%d\n", extrLength, infoSettings.ext_speed[itemSpeed_index]))
           {
+            if (isPrinting() && isPaused())
+              setExtrusionDuringPause(true);
+
             extrAmount += extrLength;
             extrLength = 0;
+
             extruderReDraw(curExtruder_index, extrAmount, false);
-            if (isPrinting() && isPaused())
-            {
-              setExtrusionDuringPause(true);
-            }
           }
           break;
       }
@@ -171,10 +174,10 @@ void menuExtrude(void)
     mustStoreCmd("G0 F%d\n", eAxisBackup.feedrate);
 
     if (eAxisBackup.relative == false)
-      mustStoreCmd("M82\n");  // Set extruder to absolute
+      mustStoreCmd("M82\n");  // set extruder to absolute
   }
 
-  // Set slow update time if not waiting for target temperature
+  // set slow update time if not waiting for target temperature
   if (heatHasWaiting() == false)
     heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -129,7 +129,13 @@ void menuExtrude(void)
     if (extrLength != 0)
     {
       if (curExtruder_index != heatGetCurrentTool())
+      {
         mustStoreCmd("%s\n", tool_change[curExtruder_index]);
+
+        // set the tool index now (don't wait for the T0/T1 response, which comes too late)
+        // just to allow warmupNozzle() function checks the temperature for the selected tool
+        heatSetCurrentTool(curExtruder_index);
+      }
 
       switch (warmupNozzle())
       {

--- a/TFT/src/User/Menu/Extrude.h
+++ b/TFT/src/User/Menu/Extrude.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-extern const char *const tool_change[];
-extern const char *const extruderDisplayID[];
-
 void menuExtrude(void);
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -70,16 +70,18 @@ void menuLoadUnload(void)
     {
       switch (key_num)
       {
-        case KEY_ICON_0:  // Unload
+        case KEY_ICON_0:  // unload
           lastCmd = UNLOAD_REQUESTED;
           break;
 
-        case KEY_ICON_3:  // Load
+        case KEY_ICON_3:  // load
           lastCmd = LOAD_REQUESTED;
           break;
 
         case KEY_INFOBOX:  // edit nozzle temp
         {
+          lastCmd = NONE;
+
           int16_t actTarget = heatGetTargetTemp(tool_index);
           int16_t val = editIntValue(0, infoSettings.max_temp[tool_index], 0, actTarget);
 
@@ -87,34 +89,38 @@ void menuLoadUnload(void)
             heatSetTargetTemp(tool_index, val, FROM_GUI);
 
           temperatureReDraw(tool_index, NULL, true);
-          lastCmd = NONE;
           break;
         }
 
         case KEY_ICON_4:  // nozzle select
+          lastCmd = NONE;
           tool_index = (tool_index + 1) % infoSettings.hotend_count;
 
           temperatureReDraw(tool_index, NULL, true);
-          lastCmd = NONE;
           break;
 
         case KEY_ICON_5:  // heat menu
-          heatSetCurrentIndex(tool_index);  // preselect current nozzle for "Heat" menu
-          OPEN_MENU(menuHeat);
-          eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
           lastCmd = NONE;
+          eAxisBackup.handled = false;  // exiting from Extrude menu (user might never come back by "Back" long press in Heat menu)
+
+          heatSetCurrentIndex(tool_index);  // preselect current nozzle for "Heat" menu
+
+          OPEN_MENU(menuHeat);
           break;
 
         case KEY_ICON_6:  // cool down nozzle
-          heatCoolDown();
           lastCmd = NONE;
+
+          heatCoolDown();
           break;
 
         case KEY_ICON_7:  // back
-          COOLDOWN_TEMPERATURE();
           lastCmd = NONE;
-          CLOSE_MENU();
           eAxisBackup.handled = false;  // the user exited from menu (not any other process/popup/etc)
+
+          COOLDOWN_TEMPERATURE();
+
+          CLOSE_MENU();
           break;
 
         default:
@@ -126,7 +132,7 @@ void menuLoadUnload(void)
       {
         if (tool_index != heatGetCurrentTool())
         {
-          mustStoreCmd("%s\n", tool_change[tool_index]);
+          mustStoreCmd("%s\n", toolChange[tool_index]);
 
           // set the tool index now (don't wait for the T0/T1 response, which comes too late)
           // just to allow warmupNozzle() function checks the temperature for the selected tool
@@ -145,26 +151,25 @@ void menuLoadUnload(void)
           case HEATED:
             if (lastCmd == UNLOAD_REQUESTED)
             { // unload
+              lastCmd = UNLOAD_STARTED;
+
               if (infoMachineSettings.firmwareType != FW_REPRAPFW)
                 mustStoreCmd("M702\n");
               else
                 request_M98("sys/unload.g");
-
-              lastCmd = UNLOAD_STARTED;
             }
             else  // LOAD_REQUESTED
             { // load
+              lastCmd = LOAD_STARTED;
+
               if (infoMachineSettings.firmwareType != FW_REPRAPFW)
                 mustStoreCmd("M701\n");
               else
                 request_M98("sys/load.g");
+            }
 
-              lastCmd = LOAD_STARTED;
-            }
             if (isPrinting() && isPaused())
-            {
               setExtrusionDuringPause(true);
-            }
          }
       }
     }
@@ -173,11 +178,9 @@ void menuLoadUnload(void)
   }
 
   if (eAxisBackup.handled == false)  // the user exited from menu (not any other process/popup/etc)
-  {
     mustStoreCmd("G92 E%.5f\n", eAxisBackup.coordinate);  // reset E axis position in Marlin to pre - load/unload state
-  }
 
-  // Set slow update time if not waiting for target temperature
+  // set slow update time if not waiting for target temperature
   if (heatHasWaiting() == false)
     heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -125,7 +125,13 @@ void menuLoadUnload(void)
       if ((lastCmd == UNLOAD_REQUESTED) || (lastCmd == LOAD_REQUESTED))
       {
         if (tool_index != heatGetCurrentTool())
+        {
           mustStoreCmd("%s\n", tool_change[tool_index]);
+
+          // set the tool index now (don't wait for the T0/T1 response, which comes too late)
+          // just to allow warmupNozzle() function checks the temperature for the selected tool
+          heatSetCurrentTool(tool_index);
+        }
 
         switch (warmupNozzle())
         {

--- a/TFT/src/User/Menu/MPC.c
+++ b/TFT/src/User/Menu/MPC.c
@@ -41,7 +41,7 @@ void displayValues()
   char tmpStr[15];
 
   setFontSize(FONT_SIZE_LARGE);
-  GUI_DispString(exhibitRect.x0, exhibitRect.y0, (uint8_t *)tool_change[curTool_index]);
+  GUI_DispString(exhibitRect.x0, exhibitRect.y0, (uint8_t *)toolChange[curTool_index]);
   setFontSize(FONT_SIZE_NORMAL);
 
   snprintf(tmpStr, 10, "P: %d W  ", mpcParameter[curTool_index].heater_power);
@@ -127,7 +127,7 @@ void menuSetMpcParam(void)
 
 void mpcStart(void)
 {
-  if (storeCmd("%s\n", tool_change[curTool_index]))
+  if (storeCmd("%s\n", toolChange[curTool_index]))
   {
     if (storeCmd("M306 T\n"))
     {

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -786,6 +786,7 @@ void meshUpdateData(char * dataRow)
 void menuMeshEditor(void)
 {
   MESH_KEY_VALUES key_num = ME_KEY_IDLE;
+  bool forceExit = false;
   uint16_t oldIndex;
   uint16_t curIndex;
 
@@ -852,10 +853,8 @@ void menuMeshEditor(void)
         break;
 
       case ME_KEY_OK:
-        if (memcmp(meshData->oriData, meshData->curData, sizeof(meshData->curData)))  // if data changed
-          meshSave();
+        forceExit = true;
 
-        meshDeallocData();
         CLOSE_MENU();
         break;
 
@@ -875,6 +874,14 @@ void menuMeshEditor(void)
     }
 
     loopProcess();
+  }
+
+  if (forceExit)
+  {
+    if (memcmp(meshData->oriData, meshData->curData, sizeof(meshData->curData)))  // check for changes
+      meshSave();
+
+    meshDeallocData();  // finally, deallocate mesh data (meshData no more accessible)
   }
 
   // restore default

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -360,7 +360,7 @@ void meshSaveCallback(void)
   else if (infoMachineSettings.leveling != BL_DISABLED)
     saveEepromSettings();
 
-  if (meshData != NULL)
+  if (meshData != NULL)  // if data have not been released (e.g. data are released when mesh editor menu is forced to exit)
     memcpy(meshData->oriData, meshData->curData, sizeof(meshData->curData));  // align data only after save confirmation
 }
 
@@ -771,11 +771,12 @@ void meshUpdateData(char * dataRow)
 
   if (failed)
   {
-    char tempMsg[MAX_STRING_LENGTH];
-
     meshData->status = ME_DATA_FAILED;
 
+    char tempMsg[MAX_STRING_LENGTH];
+
     snprintf(tempMsg, MAX_STRING_LENGTH, "%s\n-> %s", textSelect(LABEL_PROCESS_ABORTED), dataRow);
+
     popupReminder(DIALOG_TYPE_ERROR, LABEL_MESH_EDITOR, (uint8_t *) tempMsg);
 
     // trigger exit from mesh editor menu. It avoids to loop in case of persistent error

--- a/TFT/src/User/Menu/MeshEditor.c
+++ b/TFT/src/User/Menu/MeshEditor.c
@@ -15,7 +15,7 @@ typedef struct
   const uint8_t colsToSkip;
   const uint8_t rowsToSkip;
   const bool rowsInverted;
-  const char *const echoMsg;
+  const char * const echoMsg;
 } MESH_DATA_FORMAT;
 
 typedef enum
@@ -163,32 +163,32 @@ const GUI_RECT meshGridRect = {MESH_GRID_X0, MESH_GRID_Y0, MESH_GRID_X0 + MESH_G
 
 const GUI_RECT meshInfoRect[ME_INFO_NUM] = {
 #ifdef KEYBOARD_ON_LEFT
-  {MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// min value
-  {MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 3 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// max value
-  {MESH_INFO_X0 + 0 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// original value
+  {MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // min value
+  {MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 3 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // max value
+  {MESH_INFO_X0 + 0 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // original value
 #else
-  {MESH_INFO_X0 + 0 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// min value
-  {MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// max value
-  {MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 3 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},// original value
+  {MESH_INFO_X0 + 0 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // min value
+  {MESH_INFO_X0 + 1 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // max value
+  {MESH_INFO_X0 + 2 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 0 * MESH_INFO_HEIGHT, MESH_INFO_X0 + 3 * MESH_INFO_WIDTH, MESH_INFO_Y0 + 1 * MESH_INFO_HEIGHT},  // original value
 #endif
 
   // current value
 #ifdef PORTRAIT_MODE
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},        // current value
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},          // current value
 #else
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},        // current value
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},          // current value
 #endif
 };
 
 const GUI_RECT meshKeyRect[ME_KEY_NUM] = {
 #ifdef PORTRAIT_MODE
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},        // SAVE
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},        // OK
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},        // RESET
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT},        // HOME
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},          // SAVE
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},          // OK
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},          // RESET
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT},          // HOME
 
   // current value
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},        // current value
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},          // current value
 
   // arrow keys
   {MESH_ARROW_X0 + 0 * MESH_ARROW_WIDTH, MESH_ARROW_Y0 + 0 * MESH_ARROW_HEIGHT, MESH_ARROW_X0 + 2 * MESH_ARROW_WIDTH, MESH_ARROW_Y0 + 1 * MESH_ARROW_HEIGHT},  // UP
@@ -197,25 +197,25 @@ const GUI_RECT meshKeyRect[ME_KEY_NUM] = {
   {MESH_ARROW_X0 + 0 * MESH_ARROW_WIDTH, MESH_ARROW_Y0 + 2 * MESH_ARROW_HEIGHT, MESH_ARROW_X0 + 2 * MESH_ARROW_WIDTH, MESH_ARROW_Y0 + 3 * MESH_ARROW_HEIGHT},  // DOWN
 #else
   #ifdef KEYBOARD_ON_LEFT
-    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},      // SAVE
-    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},      // OK
-    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},      // RESET
-    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},      // HOME
+    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},        // SAVE
+    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},        // OK
+    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},        // RESET
+    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},        // HOME
   #else
-    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},      // SAVE
-    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},      // OK
-    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},      // RESET
-    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},      // HOME
+    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},        // SAVE
+    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 0 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT},        // OK
+    {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},        // RESET
+    {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 1 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT},        // HOME
   #endif
 
   // current value
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},        // EDIT
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 2 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT},          // EDIT
 
   // arrow keys
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT},        // UP
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},        // PREV
-  {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},        // NEXT
-  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 6 * MESH_KEY_HEIGHT},        // DOWN
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 3 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT},          // UP
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},          // PREV
+  {MESH_KEY_X0 + 1 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 4 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT},          // NEXT
+  {MESH_KEY_X0 + 0 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 5 * MESH_KEY_HEIGHT, MESH_KEY_X0 + 2 * MESH_KEY_WIDTH, MESH_KEY_Y0 + 6 * MESH_KEY_HEIGHT},          // DOWN
 #endif
 };
 
@@ -228,7 +228,7 @@ const GUI_RECT meshAreaRect[ME_AREA_NUM] = {
 #endif
 };
 
-const char *const meshKeyString[ME_KEY_NUM] = {
+const char * const meshKeyString[ME_KEY_NUM] = {
   "\u08A7",  // SAVE
   "\u0894",  // OK
   "\u08A5",  // RESET
@@ -250,7 +250,7 @@ const MESH_DATA_FORMAT meshDataFormat[] = {
 
 const char * meshErrorMsg[] = {"Invalid mesh"};  // list of possible error responses to "M420 V1 T1" command
 
-static MESH_DATA *meshData = NULL;
+static MESH_DATA * meshData = NULL;
 
 static inline void meshInitData(void)
 {
@@ -263,11 +263,11 @@ static inline void meshInitData(void)
   uint16_t rgbEnd = infoSettings.mesh_max_color;    // RGB color in RGB 565 16 bit format
 
   meshData->rStart = (rgbStart >> 11) & 0b0000000000011111;
-  meshData->gStart = (rgbStart >> 5) & 0b0000000000111111;
-  meshData->bStart = (rgbStart) & 0b0000000000011111;
-  meshData->rEnd = (rgbEnd >> 11) & 0b0000000000011111;
-  meshData->gEnd = (rgbEnd >> 5) & 0b0000000000111111;
-  meshData->bEnd = (rgbEnd) & 0b0000000000011111;
+  meshData->gStart = (rgbStart >> 5)  & 0b0000000000111111;
+  meshData->bStart = (rgbStart)       & 0b0000000000011111;
+  meshData->rEnd =   (rgbEnd >> 11)   & 0b0000000000011111;
+  meshData->gEnd =   (rgbEnd >> 5)    & 0b0000000000111111;
+  meshData->bEnd =   (rgbEnd)         & 0b0000000000011111;
   meshData->rDelta = meshData->rEnd - meshData->rStart;
   meshData->gDelta = meshData->gEnd - meshData->gStart;
   meshData->bDelta = meshData->bEnd - meshData->bStart;
@@ -299,7 +299,7 @@ void meshDeallocData(void)
   }
 }
 
-static inline bool processKnownErrorMessage(const char *dataRow)
+static inline bool processKnownErrorMessage(const char * dataRow)
 {
   uint8_t dataCount = COUNT(meshErrorMsg);
 
@@ -312,7 +312,7 @@ static inline bool processKnownErrorMessage(const char *dataRow)
   return false;
 }
 
-static inline bool processKnownDataFormat(const char *dataRow)
+static inline bool processKnownDataFormat(const char * dataRow)
 {
   uint8_t dataCount = COUNT(meshDataFormat);
 
@@ -364,7 +364,7 @@ void meshSaveCallback(void)
     memcpy(meshData->oriData, meshData->curData, sizeof(meshData->curData));  // align data only after save confirmation
 }
 
-static inline void meshUpdateIndex(MESH_KEY_VALUES key_num)
+static inline void meshUpdateIndex(const MESH_KEY_VALUES key_num)
 {
   switch (key_num)
   {
@@ -408,42 +408,40 @@ uint16_t meshGetJ(void)
   return (meshData->rowsNum - 1) - meshData->row;
 }
 
-static inline void meshSetValue(void)
+bool meshSetValue(const float value)
 {
-  storeCmd("M421 I%d J%d Z%.3f\n", meshData->col, meshGetJ(), meshData->curData[meshData->index]);
+  if (meshData->curData[meshData->index] != value)  // if mesh value is changed
+  {
+    meshData->curData[meshData->index] = value;  // set new mesh value
+
+    mustStoreCmd("M421 I%d J%d Z%.3f\n", meshData->col, meshGetJ(), value);  // send new mesh value
+
+    return true;
+  }
+
+  return false;
 }
 
 static inline void meshUpdateValueMinMax(void)
 {
   float value;
-  bool isValueChanged = true;  // initialized to "true" just to set meshData->valueDelta at least one time
 
   meshData->valueMin = meshData->valueMax = meshData->curData[0];  // init initial min/max values
 
   for (uint16_t i = 0; i < meshData->dataSize; i++)
   {
     value = meshData->curData[i];
-    isValueChanged = false;
 
     if (value < meshData->valueMin)
-    {
       meshData->valueMin = value;
-
-      isValueChanged = true;
-    }
     else if (value > meshData->valueMax)
-    {
       meshData->valueMax = value;
-
-      isValueChanged = true;
-    }
-
-    if (isValueChanged)
-      meshData->valueDelta = meshData->valueMax - meshData->valueMin;
   }
+
+  meshData->valueDelta = meshData->valueMax - meshData->valueMin;
 }
 
-uint16_t mapRGBdata(uint16_t * rgbStart, int16_t * rgbDelta, float * valueDiff, float * valueDelta)
+uint16_t mapRGBdata(const uint16_t * rgbStart, const int16_t * rgbDelta, const float * valueDiff, const float * valueDelta)
 {
   return *rgbStart + (*valueDiff * *rgbDelta) / *valueDelta;
 }
@@ -643,14 +641,14 @@ bool meshIsWaitingData(void)
   return true;
 }
 
-uint16_t meshParseDataRow(char *dataRow, float *dataGrid, const uint16_t maxCount)
+uint16_t meshParseDataRow(char * dataRow, float * dataGrid, const uint16_t maxCount)
 {
   if (meshData->parsedRows < meshData->rowsToSkip)
     return 0;
 
   uint16_t count;
-  char *curPtr;
-  char *nextPtr;
+  char * curPtr;
+  char * nextPtr;
   float value;
 
   count = 0;
@@ -694,7 +692,7 @@ static inline void processGridData(void)
   }
 }
 
-void meshUpdateData(char *dataRow)
+void meshUpdateData(char * dataRow)
 {
   bool failed = false;
 
@@ -829,17 +827,15 @@ void menuMeshEditor(void)
         if (coordinateIsKnown() == false)
           probeHeightHome();  // home, disable ABL and raise nozzle
 
-        meshData->curData[curIndex] = menuMeshTuner(meshData->col, meshGetJ(), meshData->curData[curIndex]);
-        meshSetValue();
+        // call mesh tuner menu and set current mesh value, if changed
+        meshSetValue(menuMeshTuner(meshData->col, meshGetJ(), meshData->curData[curIndex]));
 
         meshDrawMenu();
         break;
 
       case ME_KEY_RESET:
-        if (meshData->curData[curIndex] != meshData->oriData[curIndex])
+        if (meshSetValue(meshData->oriData[curIndex]))  // set current mesh value to original value, if changed
         {
-          meshData->curData[curIndex] = meshData->oriData[curIndex];
-
           meshDrawGrid();
           meshDrawInfo(true);
         }
@@ -850,6 +846,8 @@ void menuMeshEditor(void)
         break;
 
       case ME_KEY_SAVE:
+        // we unconditionally allow to save the meshes on EEPROM (e.g. just in case we previously edited some
+        // meshes but we closed the mesh editor menu refusing to save)
         meshSave();
         break;
 

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -136,6 +136,7 @@ void menuMove(void)
   while (MENU_IS(menuMove))
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       #ifdef ALTERNATIVE_MOVE_MENU
@@ -146,8 +147,9 @@ void menuMove(void)
         case KEY_ICON_3:
           item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
           moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
-          menuDrawItem(&moveItems.items[key_num], key_num);
           amount = moveLenSteps[item_moveLen_index];
+
+          menuDrawItem(&moveItems.items[key_num], key_num);
           break;
 
         case KEY_ICON_4: storeMoveCmd(X_AXIS, -amount); break;  // X move decrease if no invert
@@ -163,6 +165,8 @@ void menuMove(void)
         case KEY_ICON_3:
           item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
           moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
+          amount = moveLenSteps[item_moveLen_index];
+
           menuDrawItem(&moveItems.items[key_num], key_num);
           break;
 

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -147,9 +147,10 @@ void menuMove(void)
         case KEY_ICON_3:
           item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
           moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
-          amount = moveLenSteps[item_moveLen_index];
 
           menuDrawItem(&moveItems.items[key_num], key_num);
+
+          amount = moveLenSteps[item_moveLen_index];
           break;
 
         case KEY_ICON_4: storeMoveCmd(X_AXIS, -amount); break;  // X move decrease if no invert
@@ -165,9 +166,10 @@ void menuMove(void)
         case KEY_ICON_3:
           item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
           moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
-          amount = moveLenSteps[item_moveLen_index];
 
           menuDrawItem(&moveItems.items[key_num], key_num);
+
+          amount = moveLenSteps[item_moveLen_index];
           break;
 
         case KEY_ICON_4: storeMoveCmd(X_AXIS, -amount); break;  // X move decrease if no invert

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -15,7 +15,7 @@ void showNewESteps(const float measured_length, const float old_esteps, float * 
 {
   char tempstr[20];
 
-  // First we calculate the new E-step value:
+  // first we calculate the new E-step value
   *new_esteps = (EXTRUDE_LEN * old_esteps) / (EXTRUDE_LEN - (measured_length - REMAINING_LEN));
 
   GUI_DispString(exhibitRect.x0, exhibitRect.y0, textSelect(LABEL_TUNE_EXT_MEASURED));
@@ -32,9 +32,9 @@ void showNewESteps(const float measured_length, const float old_esteps, float * 
 
 void menuNewExtruderESteps(void)
 {
-  // Extruder steps are not correct. Ask user for the amount that's extruded
-  // Automaticaly calculate new steps/mm when changing the measured distance
-  // When pressing save to eeprom the new steps will be saved.
+  // extruder steps are not correct. Ask user for the amount that's extruded.
+  // Automaticaly calculate new steps/mm when changing the measured distance.
+  // When pressing save to eeprom the new steps will be saved
   MENUITEMS newExtruderESteps = {
     // title
     LABEL_TUNE_EXT_ADJ_ESTEPS,
@@ -81,11 +81,13 @@ void menuNewExtruderESteps(void)
 
       case KEY_ICON_4:
       {
-        char tempMsg[120];
-        LABELCHAR(tempStr, LABEL_TUNE_EXT_ESTEPS_SAVED);
-
         sendParameterCmd(P_STEPS_PER_MM, AXIS_INDEX_E0, new_esteps);
+
+        char tempMsg[120];
+
+        LABELCHAR(tempStr, LABEL_TUNE_EXT_ESTEPS_SAVED);
         sprintf(tempMsg, tempStr, new_esteps);
+
         popupReminder(DIALOG_TYPE_QUESTION, newExtruderESteps.title.index, (uint8_t *) tempMsg);
         break;
       }
@@ -130,19 +132,21 @@ static inline void extrudeFilament(void)
     loopProcess();
   }
 
-  // Home extruder and set absolute positioning
+  // home extruder and set absolute positioning
   mustStoreScript("G28\nG90\n");
 
-  // Raise Z axis to pause height
+  // raise Z axis to pause height
   #if DELTA_PROBE_TYPE != 0
     mustStoreCmd("G0 Z200 F%d\n", infoSettings.pause_feedrate[FEEDRATE_Z]);
   #else
     mustStoreCmd("G0 Z%.3f F%d\n", coordinateGetAxisActual(Z_AXIS) + infoSettings.pause_z_raise,
                  infoSettings.pause_feedrate[FEEDRATE_Z]);
   #endif
-  // Move to pause location
+
+  // move to pause location
   mustStoreCmd("G0 X%.3f Y%.3f F%d\n", infoSettings.pause_pos[X_AXIS], infoSettings.pause_pos[Y_AXIS],
                infoSettings.pause_feedrate[FEEDRATE_XY]);
+
   // extrude 100MM
   mustStoreScript("M83\nG1 F100 E%.2f\nM82\n", EXTRUDE_LEN);
 
@@ -228,6 +232,7 @@ void menuTuneExtruder(void)
 
       case KEY_ICON_7:
         COOLDOWN_TEMPERATURE();
+
         CLOSE_MENU();
         break;
 
@@ -239,7 +244,7 @@ void menuTuneExtruder(void)
     {
       if (tool_index != heatGetCurrentTool())
       {
-        mustStoreCmd("%s\n", tool_change[tool_index]);
+        mustStoreCmd("%s\n", toolChange[tool_index]);
 
         // set the tool index now (don't wait for the T0/T1 response, which comes too late)
         // just to allow warmupNozzle() function checks the temperature for the selected tool
@@ -256,16 +261,17 @@ void menuTuneExtruder(void)
           break;
 
         case HEATED:
-          {
-            char tempMsg[120];
-
-            LABELCHAR(tempStr, LABEL_TUNE_EXT_MARK120MM);
-
-            sprintf(tempMsg, tempStr, textSelect(LABEL_EXTRUDE));
-            popupDialog(DIALOG_TYPE_QUESTION, tuneExtruderItems.title.index, (uint8_t *) tempMsg, LABEL_EXTRUDE, LABEL_CANCEL, extrudeFilament, NULL, NULL);
-          }
+        {
           loadRequested = false;
+
+          char tempMsg[120];
+
+          LABELCHAR(tempStr, LABEL_TUNE_EXT_MARK120MM);
+          sprintf(tempMsg, tempStr, textSelect(LABEL_EXTRUDE));
+
+          popupDialog(DIALOG_TYPE_QUESTION, tuneExtruderItems.title.index, (uint8_t *) tempMsg, LABEL_EXTRUDE, LABEL_CANCEL, extrudeFilament, NULL, NULL);
           break;
+        }
       }
     }
 
@@ -273,13 +279,14 @@ void menuTuneExtruder(void)
     {
       lastCurrent = actCurrent;
       lastTarget = actTarget;
+
       temperatureReDraw(tool_index, NULL, false);
     }
 
     loopProcess();
   }
 
-  // Set slow update time if not waiting for target temperature
+  // set slow update time if not waiting for target temperature
   if (heatHasWaiting() == false)
     heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -238,7 +238,13 @@ void menuTuneExtruder(void)
     if (loadRequested == true)
     {
       if (tool_index != heatGetCurrentTool())
+      {
         mustStoreCmd("%s\n", tool_change[tool_index]);
+
+        // set the tool index now (don't wait for the T0/T1 response, which comes too late)
+        // just to allow warmupNozzle() function checks the temperature for the selected tool
+        heatSetCurrentTool(tool_index);
+      }
 
       switch (warmupNozzle())
       {


### PR DESCRIPTION
**BUG FIXES:**
* broken "undo/restore" button on Mesh Editor menu: another bug introduced by #2737. In case a mesh value is changed, the undo/restore button doesn't restore the original value on Marlin side
* broken release of memory exiting from Mesh Editor: another bug introduced by #2737. It causes invalid access to mesh data already released (thus possible crashes/freezes/wrong TFT behavior etc...) and that visible delay when closing the menu (e.g. 1-2 seconds on less powerful TFTs)
* wrong move distance selection on Move menu with standard keyboard layout: bug introduced by #2766.
* IDEX Incorrect extrude low temp warning: bug reported and fixed in #2789 by **rondlh** (thank you for your work)
* minor cleanup on files affected by the bugs

**PR STATE:** ready for merge

fixes #2789
