### PR TITLE
Bug fix on inverted leveling Y axis

### DIFF
--- a/TFT/src/User/API/LevelingControl.c
+++ b/TFT/src/User/API/LevelingControl.c
@@ -30,7 +30,8 @@ void levelingGetPointCoords(LEVELING_POINT_COORDS coords)
     x_right = temp;
   }
 
-  if (GET_BIT(infoSettings.inverted_axis, E_AXIS))  // leveling Y axis (E_AXIS -> index for param "inverted_axis LY<x>" in config.ini)
+  // leveling Y axis (E_AXIS -> index for param "inverted_axis LY<x>" in "config.ini")
+  if (GET_BIT(infoSettings.inverted_axis, E_AXIS))
   { // swap bottom and top
     int16_t temp = y_bottom;
     y_bottom = y_top;

--- a/TFT/src/User/API/LevelingControl.c
+++ b/TFT/src/User/API/LevelingControl.c
@@ -30,7 +30,7 @@ void levelingGetPointCoords(LEVELING_POINT_COORDS coords)
     x_right = temp;
   }
 
-  if (GET_BIT(infoSettings.inverted_axis, Y_AXIS))  // leveling Y axis
+  if (GET_BIT(infoSettings.inverted_axis, E_AXIS))  // leveling Y axis (E_AXIS -> index for param "inverted_axis LY<x>" in config.ini)
   { // swap bottom and top
     int16_t temp = y_bottom;
     y_bottom = y_top;

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -860,7 +860,9 @@ void parseConfigKey(uint16_t index)
       if (key_seen("X")) SET_BIT_VALUE(infoSettings.inverted_axis, X_AXIS, getOnOff());
       if (key_seen("Y")) SET_BIT_VALUE(infoSettings.inverted_axis, Y_AXIS, getOnOff());
       if (key_seen("Z")) SET_BIT_VALUE(infoSettings.inverted_axis, Z_AXIS, getOnOff());
-      if (key_seen("LY")) SET_BIT_VALUE(infoSettings.inverted_axis, E_AXIS, getOnOff());  // leveling Y axis
+
+      // leveling Y axis (E_AXIS -> index for param "inverted_axis LY<x>" in "config.ini")
+      if (key_seen("LY")) SET_BIT_VALUE(infoSettings.inverted_axis, E_AXIS, getOnOff());
       break;
 
     case C_INDEX_PROBING_Z_OFFSET:

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -131,7 +131,7 @@ bool nextScreenUpdate(uint32_t duration)
   }
 #endif
 
-void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance)
+void drawBorder(const GUI_RECT * rect, uint16_t color, uint16_t edgeDistance)
 {
   //uint16_t origColor = GUI_GetColor();
 
@@ -142,7 +142,7 @@ void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance)
   //GUI_SetColor(origColor);
 }
 
-void drawBackground(const GUI_RECT *rect, uint16_t bgColor, uint16_t edgeDistance)
+void drawBackground(const GUI_RECT * rect, uint16_t bgColor, uint16_t edgeDistance)
 {
   //uint16_t origBgColor = GUI_GetBkColor();
 
@@ -153,7 +153,7 @@ void drawBackground(const GUI_RECT *rect, uint16_t bgColor, uint16_t edgeDistanc
   //GUI_SetBkColor(origBgColor);
 }
 
-void drawStandardValue(const GUI_RECT *rect, VALUE_TYPE valType, const void *val, uint16_t font,
+void drawStandardValue(const GUI_RECT * rect, VALUE_TYPE valType, const void * val, uint16_t font,
                        uint16_t color, uint16_t bgColor, uint16_t edgeDistance, bool clearBgColor)
 {
   uint16_t origColor = GUI_GetColor();

--- a/TFT/src/User/Menu/common.h
+++ b/TFT/src/User/Menu/common.h
@@ -68,11 +68,11 @@ bool nextScreenUpdate(uint32_t duration);
   #define  INVERT_Z_AXIS_ICONS(menuItemsPtr)
 #endif
 
-void drawBorder(const GUI_RECT *rect, uint16_t color, uint16_t edgeDistance);
+void drawBorder(const GUI_RECT * rect, uint16_t color, uint16_t edgeDistance);
 
-void drawBackground(const GUI_RECT *rect, uint16_t bgColor, uint16_t edgeDistance);
+void drawBackground(const GUI_RECT * rect, uint16_t bgColor, uint16_t edgeDistance);
 
-void drawStandardValue(const GUI_RECT *rect, VALUE_TYPE valType, const void *val, uint16_t font,
+void drawStandardValue(const GUI_RECT * rect, VALUE_TYPE valType, const void * val, uint16_t font,
                        uint16_t color, uint16_t bgColor, uint16_t edgeDistance, bool clearBgColor);
 
 // Show/draw temperature in a standard menu

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -69,12 +69,12 @@ extern "C" {
 
 // call processes from the argument and than loopProcess() while condition is true
 // tasks from argument must be separated by ";" ("TASK_LOOP_WHILE(condition, task1(); task2(); ...))
-#define TASK_LOOP_WHILE(condition, ...)  \
-        while(condition)                 \
-        {                                \
-          __VA_ARGS__;                   \
-          loopProcess();                 \
-        }
+#define TASK_LOOP_WHILE(condition, ...) \
+  while (condition)                     \
+  {                                     \
+    __VA_ARGS__;                        \
+    loopProcess();                      \
+  }
 
 uint8_t inRange(int cur, int tag , int range);
 long map(long x, long in_min, long in_max, long out_min, long out_max);


### PR DESCRIPTION
**BUG FIXES:**
* Wrong inverted leveling Y axis: bug introduced by #2655 claimed as bug fix for a not existing bug introduced by PR #2233. The usual propaganda always based on "no bug report from real users" motivated by the life style::
  * you did something? I will change it without any reason and even without a perfect knowledge of the code! From now on I will start an infinite rework on that code!
  * you re-fixed something I completely messed up for no reason at all (e.g. #2737)? I will even continue to apply my personal changes (not fixing something wrong in your code such as in current #2776, #2778) on top of your real fixes (that I will never even find by myself as all the attempts made in #2786) even if you wasted your free time twice (5 days for original code + 5 for fixes requiring only 3 consecutive PRs)!
  * you have a look at the possible bugs reported by users and possibly try to find/fix a possible real bug? I will try to hijack the communication on my Discord channel (e.g. #2761) although BTT also provides the "Discussion" tab already available for "sharing" extra details!
  * you provide something here when really necessary/needed? I have nothing better to do in my free time so I will also invent PRs for no bugs ever reported, a fix/rework of something perfectly working, a replacement of perfectly working standard C functions with my perfectly broken new ones etc...! Who cares about bugs! they will be re-fixed by others sooner or later!

  Bug report #2742 reporting the broken logic was needed to re-fix something that was perfectly working. Just as an history recap, LY parameter properly introduced by BTT based on real FR requests. Unfortunately, even the presence of the comment "leveling Y axis" added in both `LevelingControl.c` and `config.c` source code was not enough to avoid the introduction of the bug.

fixes #2742

**PR STATE:** ready for merge
