### PR TITLE
Corner leveling and language bugfix

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -927,6 +927,12 @@ void parseACK(void)
       if (ack_continue_seen("Z: "))
         levelingSetProbedPoint(x, y, ack_value());  // save probed Z value
     }
+    // parse G30 coordinate unreachable message
+    else if (ack_seen("Z Probe Past Bed"))
+    {
+      levelingSetProbedPoint(-1, -1, 0);  // cancel waiting for coordinates
+      BUZZER_PLAY(SOUND_ERROR);
+    }
     #if DELTA_PROBE_TYPE != 0
       // parse and store Delta calibration settings
       else if (ack_seen("Calibration OK"))

--- a/TFT/src/User/Menu/LevelCorner.c
+++ b/TFT/src/User/Menu/LevelCorner.c
@@ -37,7 +37,7 @@ void refreshValue(MENUITEMS * levelItems, uint8_t index)
   menuDrawIconText(&levelItems->items[valIconIndex[index]], valIconIndex[index]);
 }
 
-void checkRefreshValue(MENUITEMS * levelItems)
+bool checkRefreshValue(MENUITEMS * levelItems)
 {
   LEVELING_POINT levelingPoint = levelingGetProbedPoint();
 
@@ -47,7 +47,11 @@ void checkRefreshValue(MENUITEMS * levelItems)
     refreshValue(levelItems, levelingPoint);
 
     levelingResetProbedPoint();  // reset to check for new updates
+
+    return true;
   }
+
+  return false;
 }
 
 // show M48 on icon
@@ -169,7 +173,7 @@ void menuLevelCorner(void)
           levelingProbePoint(i);
 
           // following loop needed to guarantee the value for each point beeing probed is updated at least one time on the menu
-          TASK_LOOP_WHILE(isNotEmptyCmdQueue(), checkRefreshValue(&levelCornerItems));
+          TASK_LOOP_WHILE(!checkRefreshValue(&levelCornerItems))
         }
 
         break;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

 - PR #2781 reintroduced a bug in corner leveling menu where if you check all the level corners at once ("Start" button) there's a risk of an infinite loop freezing the TFT.
 -  PR #2791 introduced a new word in the language files but the language sign wasn't updated

### Benefits

This PR fixes the above mentioned bugs.

### Related Issues

 - None reported yet.
