### PR TITLE
Tool change rework

### DIFF
--- a/TFT/src/User/API/AddonHardware.c
+++ b/TFT/src/User/API/AddonHardware.c
@@ -98,7 +98,7 @@ bool FIL_NormalRunoutDetect(void)
   else
   {
     bool pinState = false;
-    uint8_t toolNum = heatGetCurrentTool();
+    uint8_t toolNum = heatGetToolIndex();
 
     switch (toolNum)
     {

--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -201,7 +201,7 @@ void powerFailedCache(uint32_t offset)
     {
       infoBreakPoint.target[i] = heatGetTargetTemp(i);
     }
-    infoBreakPoint.tool = heatGetCurrentTool();
+    infoBreakPoint.tool = heatGetToolIndex();
 
     for (uint8_t i = 0; i < infoSettings.fan_count; i++)
     {

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -233,7 +233,7 @@ uint8_t updatePrintProgress(void)
 
     case PROG_RRF:
     case PROG_SLICER:
-      break;  // progress percentage already updated by the slicer of RRF direct percentage report ("fraction_printed")
+      break;  // progress percentage already updated by the slicer or RRF direct percentage report ("fraction_printed")
 
     case PROG_TIME:
       infoPrinting.progress = ((float)infoPrinting.elapsedTime / (infoPrinting.elapsedTime + infoPrinting.remainingTime)) * 100;

--- a/TFT/src/User/API/RRFParseACK.cpp
+++ b/TFT/src/User/API/RRFParseACK.cpp
@@ -152,7 +152,7 @@ void ParseACKJsonParser::value(const char *value)
       speedSetCurPercent(0, strtod((char *)value, NULL));
       break;
     case efactor:
-      if (index == heatGetCurrentTool())
+      if (index == heatGetToolIndex())
       {
         speedSetCurPercent(1, strtod((char *)value, NULL));
       }

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -46,7 +46,7 @@ void loopSpeed(void)
 
     if (GET_BIT(needSetPercent, i) && (OS_GetTimeMs() > nextSpeedTime))
     {
-      if (storeCmd("%s S%d D%d\n", speedCmd[i], setPercent[i], heatGetCurrentTool()))
+      if (storeCmd("%s S%d D%d\n", speedCmd[i], setPercent[i], heatGetToolIndex()))
       {
         SET_BIT_OFF(needSetPercent, i);
       }

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -1,13 +1,13 @@
 #include "Temperature.h"
 #include "includes.h"
 
-const char *const toolChange[]                    = TOOL_CHANGE;
-const char *const extruderDisplayID[]             = EXTRUDER_ID;
-const char *const heaterID[MAX_HEATER_COUNT]      = HEAT_SIGN_ID;
-const char *const heatDisplayID[MAX_HEATER_COUNT] = HEAT_DISPLAY_ID;
-const char *const heatShortID[MAX_HEATER_COUNT]   = HEAT_SHORT_ID;
-const char *const heatCmd[MAX_HEATER_COUNT]       = HEAT_CMD;
-const char *const heatWaitCmd[MAX_HEATER_COUNT]   = HEAT_WAIT_CMD;
+const char * const heaterID[MAX_HEATER_COUNT]      = HEAT_SIGN_ID;
+const char * const heatDisplayID[MAX_HEATER_COUNT] = HEAT_DISPLAY_ID;
+const char * const heatShortID[MAX_HEATER_COUNT]   = HEAT_SHORT_ID;
+const char * const heatCmd[MAX_HEATER_COUNT]       = HEAT_CMD;
+const char * const heatWaitCmd[MAX_HEATER_COUNT]   = HEAT_WAIT_CMD;
+const char * const extruderDisplayID[]             = EXTRUDER_ID;
+const char * const toolChange[]                    = TOOL_CHANGE;
 
 static HEATER  heater = {{}, NOZZLE0};
 static uint8_t heat_update_seconds = TEMPERATURE_QUERY_SLOW_SECONDS;
@@ -19,7 +19,7 @@ uint32_t nextHeatCheckTime = 0;
 
 #define AUTOREPORT_TIMEOUT (nextHeatCheckTime + 3000)  // update interval + 3 second grace period
 
-// Verify that the heater index is valid, and fix the index of multiple in and 1 out tool nozzles
+// verify that the heater index is valid, and fix the index of multiple in and 1 out tool nozzles
 static uint8_t heaterIndexFix(uint8_t index)
 {
   if (index == BED && infoSettings.bed_en)  // Bed
@@ -37,7 +37,7 @@ static uint8_t heaterIndexFix(uint8_t index)
   return INVALID_HEATER;  // Invalid heater
 }
 
-// Set target temperature
+// set target temperature
 void heatSetTargetTemp(uint8_t index, int16_t temp, TEMP_SOURCE tempSource)
 {
   index = heaterIndexFix(index);
@@ -74,7 +74,7 @@ void heatSetTargetTemp(uint8_t index, int16_t temp, TEMP_SOURCE tempSource)
   }
 }
 
-// Get target temperature
+// get target temperature
 uint16_t heatGetTargetTemp(uint8_t index)
 {
   index = heaterIndexFix(index);
@@ -85,7 +85,7 @@ uint16_t heatGetTargetTemp(uint8_t index)
   return heater.T[index].target;
 }
 
-// Set current temperature
+// set current temperature
 void heatSetCurrentTemp(uint8_t index, int16_t temp)
 {
   index = heaterIndexFix(index);
@@ -99,7 +99,7 @@ void heatSetCurrentTemp(uint8_t index, int16_t temp)
     updateNextHeatCheckTime();  // set next timeout for temperature auto-report
 }
 
-// Get current temperature
+// get current temperature
 int16_t heatGetCurrentTemp(uint8_t index)
 {
   index = heaterIndexFix(index);
@@ -110,7 +110,7 @@ int16_t heatGetCurrentTemp(uint8_t index)
   return heater.T[index].current;
 }
 
-// Disable all heaters/hotends
+// disable all heaters/hotends
 void heatCoolDown(void)
 {
   for (uint8_t i = 0; i < MAX_HEATER_COUNT; i++)
@@ -119,13 +119,13 @@ void heatCoolDown(void)
   }
 }
 
-// Is heating waiting to heat up
+// is heating waiting to heat up
 bool heatGetIsWaiting(uint8_t index)
 {
   return (heater.T[index].waiting == true);
 }
 
-// Check all heater if there is a heater waiting to be waited
+// check all heater if there is a heater waiting to be waited
 bool heatHasWaiting(void)
 {
   for (uint8_t i = 0; i < MAX_HEATER_COUNT; i++)
@@ -137,7 +137,7 @@ bool heatHasWaiting(void)
   return false;
 }
 
-// Set heater waiting status
+// set heater waiting status
 void heatSetIsWaiting(uint8_t index, bool isWaiting)
 {
   index = heaterIndexFix(index);
@@ -163,28 +163,37 @@ void heatClearIsWaiting(void)
   heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
 }
 
-// Set current Tool (Extruder)
-void heatSetCurrentTool(uint8_t tool)
+// set current tool (extruder)
+// used when tool change command is from TFT
+bool heatSetTool(const uint8_t toolIndex)
 {
-  if (tool >= infoSettings.ext_count)
-    return;
+  if (storeCmd("%s\n", toolChange[toolIndex]))
+  {
+    heater.toolIndex = toolIndex;
+    return true;
+  }
 
-  heater.toolIndex = tool;
+  return false;
 }
 
-// Get current Tool (Extruder)
-uint8_t heatGetCurrentTool(void)
+void heatSetToolIndex(const uint8_t toolIndex)
+{
+  heater.toolIndex = toolIndex;
+}
+
+// get current Tool (extruder)
+uint8_t heatGetToolIndex(void)
 {
   return heater.toolIndex;
 }
 
-// Get current hotend index in arry T[]
+// get current hotend index in arry T[]
 uint8_t heatGetCurrentHotend(void)
 {
   return (infoSettings.hotend_count == 1) ? NOZZLE0 : heater.toolIndex;
 }
 
-// Check whether the index is a valid heater index.
+// check whether the index is a valid heater index.
 bool heaterDisplayIsValid(uint8_t index)
 {
   if (index >= infoSettings.hotend_count && index < MAX_HOTEND_COUNT)
@@ -199,7 +208,7 @@ bool heaterDisplayIsValid(uint8_t index)
   return true;
 }
 
-// Set temperature update time interval
+// set temperature update time interval
 void heatSetUpdateSeconds(uint8_t seconds)
 {
   if (heat_update_seconds == seconds)
@@ -211,19 +220,19 @@ void heatSetUpdateSeconds(uint8_t seconds)
     heat_update_waiting = storeCmd("M155 S%u\n", heatGetUpdateSeconds());
 }
 
-// Get query temperature seconds
+// get query temperature seconds
 uint8_t heatGetUpdateSeconds(void)
 {
   return heat_update_seconds;
 }
 
-// Set query temperature seconds
+// set query temperature seconds
 void heatSyncUpdateSeconds(uint8_t seconds)
 {
   heat_update_seconds = seconds;
 }
 
-// Set whether we need to query the current temperature
+// set whether we need to query the current temperature
 void heatSetUpdateWaiting(bool isWaiting)
 {
   heat_update_waiting = isWaiting;

--- a/TFT/src/User/API/Temperature.h
+++ b/TFT/src/User/API/Temperature.h
@@ -65,13 +65,13 @@ typedef struct
   uint8_t toolIndex;
 } HEATER;
 
-extern const char *const toolChange[];
-extern const char *const extruderDisplayID[];
-extern const char *const heaterID[];
-extern const char *const heatDisplayID[];
-extern const char *const heatShortID[];
-extern const char *const heatCmd[];
-extern const char *const heatWaitCmd[];
+extern const char * const heaterID[];
+extern const char * const heatDisplayID[];
+extern const char * const heatShortID[];
+extern const char * const heatCmd[];
+extern const char * const heatWaitCmd[];
+extern const char * const extruderDisplayID[];
+extern const char * const toolChange[];
 
 void heatSetTargetTemp(uint8_t index, int16_t temp, TEMP_SOURCE tempSource);
 uint16_t heatGetTargetTemp(uint8_t index);
@@ -84,8 +84,9 @@ bool heatHasWaiting(void);
 void heatSetIsWaiting(uint8_t index, bool isWaiting);
 void heatClearIsWaiting(void);
 
-void heatSetCurrentTool(uint8_t tool);
-uint8_t heatGetCurrentTool(void);
+bool heatSetTool(const uint8_t tool);
+void heatSetToolIndex(const uint8_t toolIndex);
+uint8_t heatGetToolIndex(void);
 uint8_t heatGetCurrentHotend(void);
 bool heaterDisplayIsValid(uint8_t index);
 

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -1479,8 +1479,9 @@ void sendQueueCmd(void)
       break;  // end parsing G-codes
 
     case 'T':
-      heatSetCurrentTool(cmd_value());
+      heatSetToolIndex(cmd_value());
       break;
+
   }  // end parsing cmd
 
   if (sendCmd(false, avoid_terminal) == true)  // if command was sent

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1304,7 +1304,7 @@ void parseACK(void)
       // newer Marlin (e.g. 2.0.9.3) returns this ACK for M900 command
       else if (ack_continue_seen("Advance K="))
       {
-        setParameter(P_LIN_ADV, heatGetCurrentTool(), ack_value());
+        setParameter(P_LIN_ADV, heatGetToolIndex(), ack_value());
       }
       else if (!processKnownEcho())  // if no known echo was found and processed, then popup the echo message
       {

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -133,17 +133,8 @@ void menuExtrude(void)
         break;
     }
 
-    if (extrLength != 0)
+    if (extrLength != 0 && heatSetTool(curExtruder_index))
     {
-      if (curExtruder_index != heatGetCurrentTool())
-      {
-        mustStoreCmd("%s\n", toolChange[curExtruder_index]);
-
-        // set the tool index now (don't wait for the T0/T1 response, which comes too late)
-        // just to allow warmupNozzle() function checks the temperature for the selected tool
-        heatSetCurrentTool(curExtruder_index);
-      }
-
       switch (warmupNozzle())
       {
         case COLD:

--- a/TFT/src/User/Menu/LoadUnload.c
+++ b/TFT/src/User/Menu/LoadUnload.c
@@ -128,17 +128,8 @@ void menuLoadUnload(void)
           break;
       }
 
-      if ((lastCmd == UNLOAD_REQUESTED) || (lastCmd == LOAD_REQUESTED))
+      if ((lastCmd == UNLOAD_REQUESTED || lastCmd == LOAD_REQUESTED) && heatSetTool(tool_index))
       {
-        if (tool_index != heatGetCurrentTool())
-        {
-          mustStoreCmd("%s\n", toolChange[tool_index]);
-
-          // set the tool index now (don't wait for the T0/T1 response, which comes too late)
-          // just to allow warmupNozzle() function checks the temperature for the selected tool
-          heatSetCurrentTool(tool_index);
-        }
-
         switch (warmupNozzle())
         {
           case COLD:

--- a/TFT/src/User/Menu/MPC.c
+++ b/TFT/src/User/Menu/MPC.c
@@ -142,7 +142,7 @@ void menuSetMpcParam(void)
 
 void mpcStart(void)
 {
-  if (storeCmd("%s\n", toolChange[curTool_index]))
+  if (heatSetTool(curTool_index))
   {
     if (storeCmd("M306 T S%u\n", mpcParameter[curTool_index].method))
     {

--- a/TFT/src/User/Menu/TuneExtruder.c
+++ b/TFT/src/User/Menu/TuneExtruder.c
@@ -237,17 +237,8 @@ void menuTuneExtruder(void)
         break;
     }
 
-    if (loadRequested == true)
+    if (loadRequested == true && heatSetTool(tool_index))
     {
-      if (tool_index != heatGetCurrentTool())
-      {
-        mustStoreCmd("%s\n", toolChange[tool_index]);
-
-        // set the tool index now (don't wait for the T0/T1 response, which comes too late)
-        // just to allow warmupNozzle() function checks the temperature for the selected tool
-        heatSetCurrentTool(tool_index);
-      }
-
       switch (warmupNozzle())
       {
         case COLD:

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -308,12 +308,12 @@ float editFloatValue(float minValue, float maxValue, float resetValue, float val
 // set the hotend to the minimum extrusion temperature if user selected "OK"
 void heatToMinTemp(void)
 {
-  heatSetTargetTemp(heatGetCurrentTool(), infoSettings.min_ext_temp, FROM_GUI);
+  heatSetTargetTemp(heatGetToolIndex(), infoSettings.min_ext_temp, FROM_GUI);
 }
 
 NOZZLE_STATUS warmupNozzle(void)
 {
-  uint8_t toolIndex = heatGetCurrentTool();
+  uint8_t toolIndex = heatGetToolIndex();
 
   if (heatGetTargetTemp(toolIndex) < infoSettings.min_ext_temp)
   {


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This PR makes the tool change requested by the TFT bulletproof. Regardless of any exterior or interior changes occurred to the mainboard the TFT will have the correct tool selected, actions and checks applied to the desired tool.

### Benefits

 - The TFT will always work on the desired tool regardless of any prior changes made by the TFT of any external device connected to the mainboard or the TFT.
 - FW size reduction