### PR TITLE
Power loss recovery - bugfix

### DIFF
--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -97,38 +97,34 @@ bool powerFailedInitData(void)
     if (infoBreakPoint.pause)
       z_raised += infoSettings.pause_z_raise;
 
-    mustStoreCacheCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + z_raised);  // infoCacheCmd.queue[8 - 11]
-    mustStoreCacheCmd("G1 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
-    if (infoSettings.plr_home)
+    mustStoreCacheCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + z_raised);                 // infoCacheCmd.queue[8]
+    mustStoreCacheCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);  // infoCacheCmd.queue[9]
+    if (infoSettings.plr_home)                                                                // infoCacheCmd.queue[10 - 11]
     {
       mustStoreCacheCmd("G28\n");
-      mustStoreCacheCmd("G1 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
+      mustStoreCacheCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
     }
     else
     {
       mustStoreCacheCmd("G28 R0 XY\n");
     }
 
-    mustStoreCacheCmd("M83\n");  // infoCacheCmd.queue[12 - 17]
-    mustStoreCacheCmd("G1 E30 F300\n");
-    mustStoreCacheCmd("G1 E-%.5f F4800\n", infoSettings.pause_retract_len);
-    mustStoreCacheCmd("G1 X%.3f Y%.3f Z%.3f F3000\n",
+
+    mustStoreCacheCmd("G1 E30 F300\n");                                      // infoCacheCmd.queue[12]
+    mustStoreCacheCmd("G1 E-%.5f F4800\n", infoSettings.pause_retract_len);  // infoCacheCmd.queue[13]
+    mustStoreCacheCmd("G0 X%.3f Y%.3f Z%.3f F3000\n",
                       infoBreakPoint.axis[X_AXIS],
                       infoBreakPoint.axis[Y_AXIS],
-                      infoBreakPoint.axis[Z_AXIS]);
-    mustStoreCacheCmd("G1 E%.5f F4800\n", infoSettings.resume_purge_len);
-    mustStoreCacheCmd("G92 E%.5f\nG1 F%d\n", infoBreakPoint.axis[E_AXIS], infoBreakPoint.feedrate);
+                      infoBreakPoint.axis[Z_AXIS]);                          // infoCacheCmd.queue[14]
+    mustStoreCacheCmd("G1 E%.5f F4800\n", infoSettings.resume_purge_len);    // infoCacheCmd.queue[15]
+    mustStoreCacheCmd("G92 E%.5f\n", infoBreakPoint.axis[E_AXIS]);           // infoCacheCmd.queue[16]
+    mustStoreCacheCmd("G0 F%d\n", infoBreakPoint.feedrate);                  // infoCacheCmd.queue[17]
 
-    if (infoBreakPoint.relative_e == false)  // infoCacheCmd.queue[18]
-    {
-      mustStoreCacheCmd("M82\n");
-    }
+    // G90/91 sets the extruder also, so keep these two in this order
+    //
+    mustStoreCacheCmd(infoBreakPoint.relative == true ? "G91\n" : "G90\n");    // infoCacheCmd.queue[18]
+    mustStoreCacheCmd(infoBreakPoint.relative_e == true ? "M83\n" : "M82\n");  // infoCacheCmd.queue[19]
 
-    // infoCacheCmd.queue[19]  max length = 0 - 19.
-    if (infoBreakPoint.relative == true)
-    {
-      mustStoreCacheCmd("G91\n");
-    }
     // End of cache
     // The length of the gcode stored in the cache should be less than max length = 20
     // Otherwise, if there are M109/M190/M191 blocking the queue, it will cause "Busy processing, please wait..." and bring bad user experience

--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -66,22 +66,14 @@ bool powerFailedInitData(void)
 
   setPrintModelIcon(model_icon);
 
-  for (uint8_t i = 0; i < infoSettings.fan_count; i++)
-  {
-    if (infoBreakPoint.fan[i] != 0)
-    {
-      mustStoreCacheCmd(fanCmd[i], infoBreakPoint.fan[i]);
-    }
-  }
+  mustStoreCacheCmd("%s\n", toolChange[infoBreakPoint.tool]);  // infoCacheCmd.queue[0]
 
-  mustStoreCacheCmd("%s\n", toolChange[infoBreakPoint.tool]);
-
-  for (uint8_t i = MAX_HEATER_COUNT - 1; i >= MAX_HOTEND_COUNT; i--)  // Bed & Chamber infoCacheCmd.queue[0 - 1]
+  for (uint8_t i = MAX_HEATER_COUNT - 1; i >= MAX_HOTEND_COUNT; i--)  // Bed & Chamber infoCacheCmd.queue[1 - 2]
   {
     if (infoBreakPoint.target[i] != 0)
       mustStoreCacheCmd("%s S%d\n", heatWaitCmd[i], infoBreakPoint.target[i]);
   }
-  for (int8_t i = infoSettings.hotend_count - 1; i >= 0; i--)  // Tool nozzle infoCacheCmd.queue[2 - 7]
+  for (int8_t i = infoSettings.hotend_count - 1; i >= 0; i--)  // Tool nozzle infoCacheCmd.queue[3 - 8]
   {
     if (infoBreakPoint.target[i] != 0)
       mustStoreCacheCmd("%s S%d\n", heatWaitCmd[i], infoBreakPoint.target[i]);
@@ -97,38 +89,47 @@ bool powerFailedInitData(void)
     if (infoBreakPoint.pause)
       z_raised += infoSettings.pause_z_raise;
 
-    mustStoreCacheCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + z_raised);                 // infoCacheCmd.queue[8]
-    mustStoreCacheCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);  // infoCacheCmd.queue[9]
-    if (infoSettings.plr_home)                                                                // infoCacheCmd.queue[10 - 11]
+    mustStoreCmd("G92 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + z_raised);
+    mustStoreCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
+    if (infoSettings.plr_home)
     {
-      mustStoreCacheCmd("G28\n");
-      mustStoreCacheCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
+      mustStoreCmd("G28\n");
+      mustStoreCmd("G0 Z%.3f\n", infoBreakPoint.axis[Z_AXIS] + infoSettings.plr_z_raise);
     }
     else
     {
-      mustStoreCacheCmd("G28 R0 XY\n");
+      mustStoreCmd("G28 R0 XY\n");
     }
 
-
-    mustStoreCacheCmd("G1 E30 F300\n");                                      // infoCacheCmd.queue[12]
-    mustStoreCacheCmd("G1 E-%.5f F4800\n", infoSettings.pause_retract_len);  // infoCacheCmd.queue[13]
+    mustStoreCacheCmd("M83\n");                                              // infoCacheCmd.queue[9]
+    mustStoreCacheCmd("G1 E30 F300\n");                                      // infoCacheCmd.queue[10]
+    mustStoreCacheCmd("G1 E-%.5f F4800\n", infoSettings.pause_retract_len);  // infoCacheCmd.queue[11]
     mustStoreCacheCmd("G0 X%.3f Y%.3f Z%.3f F3000\n",
                       infoBreakPoint.axis[X_AXIS],
                       infoBreakPoint.axis[Y_AXIS],
-                      infoBreakPoint.axis[Z_AXIS]);                          // infoCacheCmd.queue[14]
-    mustStoreCacheCmd("G1 E%.5f F4800\n", infoSettings.resume_purge_len);    // infoCacheCmd.queue[15]
-    mustStoreCacheCmd("G92 E%.5f\n", infoBreakPoint.axis[E_AXIS]);           // infoCacheCmd.queue[16]
-    mustStoreCacheCmd("G0 F%d\n", infoBreakPoint.feedrate);                  // infoCacheCmd.queue[17]
+                      infoBreakPoint.axis[Z_AXIS]);                          // infoCacheCmd.queue[12]
+    mustStoreCacheCmd("G1 E%.5f F4800\n", infoSettings.resume_purge_len);    // infoCacheCmd.queue[13]
+    mustStoreCacheCmd("G92 E%.5f\n", infoBreakPoint.axis[E_AXIS]);           // infoCacheCmd.queue[14]
+    mustStoreCacheCmd("G0 F%d\n", infoBreakPoint.feedrate);                  // infoCacheCmd.queue[15]
 
     // G90/91 sets the extruder also, so keep these two in this order
     //
-    mustStoreCacheCmd(infoBreakPoint.relative == true ? "G91\n" : "G90\n");    // infoCacheCmd.queue[18]
-    mustStoreCacheCmd(infoBreakPoint.relative_e == true ? "M83\n" : "M82\n");  // infoCacheCmd.queue[19]
+    mustStoreCacheCmd(infoBreakPoint.relative == true ? "G91\n" : "G90\n");  // infoCacheCmd.queue[16]
+    if (infoBreakPoint.relative_e == false) mustStoreCacheCmd("M82\n");      // infoCacheCmd.queue[17]
 
-    // End of cache
-    // The length of the gcode stored in the cache should be less than max length = 20
-    // Otherwise, if there are M109/M190/M191 blocking the queue, it will cause "Busy processing, please wait..." and bring bad user experience
   }
+
+  for (uint8_t i = 0; i < infoSettings.fan_count; i++)
+  {
+    if (infoBreakPoint.fan[i] != 0)
+    {
+      mustStoreCmd(fanCmd[i], infoBreakPoint.fan[i]);
+    }
+  }
+
+  // end of cache
+  // The length of the gcode stored in the cache should be less than max length (=20)
+  // otherwise it will cause "Busy processing, please wait..." and TFT freeze.
 
   f_close(&fp);
   return true;

--- a/TFT/src/User/API/PowerFailed.c
+++ b/TFT/src/User/API/PowerFailed.c
@@ -153,17 +153,17 @@ bool powerFailedExist(void)
   return true;
 }
 
-bool powerFailedCreate(char *path)
+void powerFailedCreate(char *path)
 {
   UINT br;
 
   powerFailedSetDriverSource();
 
   create_ok = false;
-  if (!infoSettings.plr) return false;                    // if PLR is disabled
-  if (infoFile.source >= FS_ONBOARD_MEDIA) return false;  // onboard media not supported now
+  if (!infoSettings.plr) return;                    // if PLR is disabled
+  if (infoFile.source >= FS_ONBOARD_MEDIA) return;  // onboard media not supported now
 
-  if (f_open(&fpPowerFailed, powerFailedFileName, FA_OPEN_ALWAYS | FA_WRITE) != FR_OK) return false;
+  if (f_open(&fpPowerFailed, powerFailedFileName, FA_OPEN_ALWAYS | FA_WRITE) != FR_OK) return;
 
   f_write(&fpPowerFailed, path, MAX_PATH_LEN, &br);
   uint8_t model_icon = isPrintModelIcon();
@@ -172,7 +172,6 @@ bool powerFailedCreate(char *path)
   f_sync(&fpPowerFailed);
 
   create_ok = true;
-  return true;
 }
 
 void powerFailedCache(uint32_t offset)

--- a/TFT/src/User/API/PowerFailed.h
+++ b/TFT/src/User/API/PowerFailed.h
@@ -25,7 +25,7 @@ bool powerFailedGetRestore(void);          // get the value of current print res
 bool powerFailedInitData(void);
 
 bool powerFailedExist(void);
-bool powerFailedCreate(char *path) ;
+void powerFailedCreate(char *path) ;
 void powerFailedCache(uint32_t offset);
 void powerFailedClose(void);
 void powerFailedDelete(void);

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -441,7 +441,7 @@ bool startPrintFromRemoteHost(const char * filename)
 
 bool startPrint(void)
 {
-  bool printRestore = false;
+  bool printRestoring = false;
 
   // always clean infoPrinting first and then set the needed attributes
   clearInfoPrint();
@@ -472,14 +472,14 @@ bool startPrint(void)
         // try to load PLR info from file in order to restore the print from the failed point.
         // It finally disables print restore flag (one shot flag) for the next print.
         // The flag must always be explicitly re-enabled (e.g by powerFailedSetRestore function)
-        powerFailedInitData();
-
-        if (powerFailedCreate(infoFile.path))    // if PLR feature is enabled, open a new PLR file
+        if (powerFailedInitData())
         {
-          printRestore = true;
-          powerFailedlSeek(&infoPrinting.file);  // seek on PLR file
+          printRestoring = true;
+          powerFailedlSeek(&infoPrinting.file);  // set the printing file to the backed up position
         }
-      }
+
+        powerFailedCreate(infoFile.path);  // if PLR feature is enabled, open a new PLR file
+     }
 
       break;
 
@@ -499,7 +499,7 @@ bool startPrint(void)
   infoPrinting.printing = true;
 
   // execute pre print start tasks
-  if (!printRestore && GET_BIT(infoSettings.send_gcodes, SEND_GCODES_START_PRINT))  // PLR continue printing, CAN NOT use start gcode
+  if (!printRestoring && GET_BIT(infoSettings.send_gcodes, SEND_GCODES_START_PRINT))  // PLR continue printing, CAN NOT use start gcode
     sendPrintCodes(0);
 
   if (infoFile.source == FS_ONBOARD_MEDIA)

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -108,7 +108,7 @@ void mustStoreCmd(const char * format, ...)
   if (cmdQueue.count >= CMD_QUEUE_SIZE)
   {
     setReminderMsg(LABEL_BUSY, SYS_STATUS_BUSY);
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+    TASK_LOOP_WHILE(cmdQueue.count >= CMD_QUEUE_SIZE);  // wait for a free slot in the command queue in case it is currently full
   }
 
   va_list va;
@@ -178,7 +178,7 @@ void mustStoreCacheCmd(const char * format, ...)
   if (cmdCache.count >= CMD_QUEUE_SIZE)
   {
     setReminderMsg(LABEL_BUSY, SYS_STATUS_BUSY);
-    loopProcessToCondition(&isFullCmdQueue);  // wait for a free slot in the queue in case the queue is currently full
+    TASK_LOOP_WHILE(cmdCache.count >= CMD_QUEUE_SIZE);  // wait for a free slot in the cache queue in case it is currently full
   }
 
   va_list va;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

- PR #1959 introduced a bug in the power loss print restart procedure. Because of this bug there's a high chance of missed/skipped initial commands for a PLR print.
- PR #2419 introduced a bug, after a power failure during print if a new PLR backup file cannot be created than the print will restore from the beginning, not from the backed up position 
- PR #2596 introduced a bug, if PLR is enabled than start gcode defined in config.ini is not executed
- if X, Y, Z are relative coordinates than upon a PLR the E is also set to relative regardless if it was relative or absolute
- the number of cached commands for PLR can exceed the maximum number available in the cache leading to TFT freeze

This PR fixes these bugs.

### Benefits

PLR

### Related Issues

There were reports about PLR hiccups.
