### PR TITLE
MB reset follow-up

### DIFF
--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -1347,6 +1347,7 @@ void parseACK(void)
         memset(&infoHost, 0, sizeof(infoHost));
         initMachineSettings();
         fanResetSpeed();
+        coordinateSetKnown(false);
         setReminderMsg(LABEL_UNCONNECTED, SYS_STATUS_DISCONNECTED);  // set the no printer attached reminder
       }
     }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This is a follow-up of PR #2783, on a MB reset event coordinate awareness has to be initialized to "not known" state also.

