### PR TITLE
Dual hotend persistent info update bugfix

### DIFF
--- a/TFT/src/User/Menu/PersistentInfo.c
+++ b/TFT/src/User/Menu/PersistentInfo.c
@@ -28,11 +28,24 @@ void loopTemperatureStatus(void)
   if (getMenuType() == MENU_TYPE_FULLSCREEN) return;
   if (!temperatureStatusValid()) return;
 
+  bool update = false;
+  static int16_t lastCurrent[3];
+  static int16_t lastTarget[3];
   uint8_t tmpHeater[3];  // chamber, bed, hotend
   uint8_t tmpIndex = 0;
 
-  if (infoSettings.hotend_count)  // global hotend
-    tmpHeater[tmpIndex++] = heatGetCurrentHotend();
+  if (infoSettings.hotend_count)
+  { // global hotend
+    if (infoSettings.hotend_count == 2 && !infoSettings.chamber_en)  // dual hotend
+    {
+      tmpHeater[tmpIndex++] = NOZZLE0;
+      tmpHeater[tmpIndex++] = NOZZLE1;
+    }
+    else  // single or mixing hotend
+    {
+      tmpHeater[tmpIndex++] = heatGetCurrentHotend();
+    }
+  }
 
   if (infoSettings.bed_en)  // global bed
     tmpHeater[tmpIndex++] = BED;
@@ -40,19 +53,17 @@ void loopTemperatureStatus(void)
   if (infoSettings.chamber_en)  // global chamber
     tmpHeater[tmpIndex++] = CHAMBER;
 
-  bool update = false;
-  static int16_t lastCurrent[3];
-  static int16_t lastTarget[3];
-
-  for (int8_t i = tmpIndex - 1; i >= 0; i--)
+  while (tmpIndex > 0)
   {
-    int16_t actCurrent = heatGetCurrentTemp(tmpHeater[i]);
-    int16_t actTarget = heatGetTargetTemp(tmpHeater[i]);
+    tmpIndex--;
 
-    if (lastCurrent[i] != actCurrent || lastTarget[i] != actTarget)
+    int16_t actCurrent = heatGetCurrentTemp(tmpHeater[tmpIndex]);
+    int16_t actTarget = heatGetTargetTemp(tmpHeater[tmpIndex]);
+
+    if (lastCurrent[tmpIndex] != actCurrent || lastTarget[tmpIndex] != actTarget)
     {
-      lastCurrent[i] = actCurrent;
-      lastTarget[i] = actTarget;
+      lastCurrent[tmpIndex] = actCurrent;
+      lastTarget[tmpIndex] = actTarget;
       update = true;
     }
   }
@@ -72,7 +83,7 @@ int16_t drawTemperatureStatus(void)
   uint8_t tmpIndex = 0;
 
   if (infoSettings.hotend_count)
-  {  // global hotend
+  { // global hotend
     if (infoSettings.hotend_count == 2 && !infoSettings.chamber_en)  // dual hotend
     {
       tmpIcon[tmpIndex] = ICON_GLOBAL_NOZZLE;
@@ -103,13 +114,15 @@ int16_t drawTemperatureStatus(void)
 
   GUI_SetBkColor(infoSettings.title_bg_color);
 
-  for (int8_t i = tmpIndex - 1; i >= 0; i--)
+  while (tmpIndex > 0)
   {
     char tempstr[10];
 
+    tmpIndex--;
+
     x_offset -= GLOBALICON_INTERVAL;
     GUI_ClearRect(x_offset, start_y, x_offset + GLOBALICON_INTERVAL, start_y + GLOBALICON_HEIGHT);
-    sprintf(tempstr, "%d/%d", heatGetCurrentTemp(tmpHeater[i]), heatGetTargetTemp(tmpHeater[i]));
+    sprintf(tempstr, "%d/%d", heatGetCurrentTemp(tmpHeater[tmpIndex]), heatGetTargetTemp(tmpHeater[tmpIndex]));
 
     x_offset -= GUI_StrPixelWidth((uint8_t *)tempstr);
     GUI_StrPixelWidth(LABEL_10_PERCENT);
@@ -118,7 +131,7 @@ int16_t drawTemperatureStatus(void)
     x_offset -= GLOBALICON_INTERVAL;
     GUI_ClearRect(x_offset, start_y, x_offset + GLOBALICON_INTERVAL, start_y + GLOBALICON_HEIGHT);
     x_offset -= GLOBALICON_WIDTH;
-    ICON_ReadDisplay(x_offset, start_y, tmpIcon[i]);  // icon
+    ICON_ReadDisplay(x_offset, start_y, tmpIcon[tmpIndex]);  // icon
   }
 
   GUI_SetBkColor(infoSettings.bg_color);


### PR DESCRIPTION
### Requirements

- BTT or MKS TFT
- dual hotend (IDEX)

### Description

In case of IDEX printer the persistent info doesn't show updated temperature for both hotends.

### Benefits

This PR fixes the bug mentioned, both hotend's temperature will be updated in the persistent info.

### Related Issues

Fixes #2804

#### Notes

Credit goes to @rondlh for finding where the issue laid.