### PR TITLE
MPC method follow-up

### DIFF
--- a/TFT/src/User/Menu/MPC.c
+++ b/TFT/src/User/Menu/MPC.c
@@ -127,7 +127,7 @@ void menuSetMpcParam(void)
       case KEY_ICON_2:
         parameter->method = (parameter->method + 1) % MPC_METHOD_COUNT;
         setDynamicTextValue(2, mpcMethod_label[parameter->method]);
-        listViewRefreshMenu();
+        listViewRefreshItem(curIndex);
         break;
 
       case KEY_BACK:
@@ -232,12 +232,11 @@ void menuMPC(void)
 
       LED_SetEventColor(&ledRed, false);  // set (neopixel) LED light to RED
       LCD_SET_KNOB_LED_IDLE(false);       // set infoSettings.knob_led_idle temporary to OFF
+
+      popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
     }
     else if (mpcTuning.status == ONGOING)
     {
-      if (getMenuType() != MENU_TYPE_SPLASH)
-        popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
-
       if (mpcTuning.result != NO_RESULT)
       {
         mpcTuning.status = DONE;


### PR DESCRIPTION
### Requirements

 - MKS or BTT TFT
 - Marlin with MPC enabled

### Description

PR #2791 implemented the choice of MPC algorithm method. Selecting the preferred MPC method makes the whole screen flicker. This PR fixes it.

There's also a minuscule, tiny, itsy-bitsy, 8 byte FW size reduction due to removing an `if` conditional by relocating a "busy processing" splash screen function call in the MPC module.

### Benefits

No flickering screen selecting the preferred MPC method.

### Related Issues

None reported, own finding.
