### PR TITLE
Remove SERIAL_FLOAT_PRECISION Requirement

### DIFF
--- a/Copy to SD Card root directory to update/config.ini
+++ b/Copy to SD Card root directory to update/config.ini
@@ -55,7 +55,6 @@
 #
 # Options to support dialog with host:
 #   EMERGENCY_PARSER (in Configuration_adv.h)
-#   SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
 #   HOST_ACTION_COMMANDS (in Configuration_adv.h)
 #   HOST_PROMPT_SUPPORT (in Configuration_adv.h)
 #   HOST_STATUS_NOTIFICATIONS (in Configuration_adv.h)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ the following options must be enabled in Marlin firmware.
 **Options to support dialog with host:**
 
 `EMERGENCY_PARSER` (in Configuration_adv.h)<br>
-`SERIAL_FLOAT_PRECISION 4` (in Configuration_adv.h)<br>
 `HOST_ACTION_COMMANDS` (in Configuration_adv.h)<br>
 `HOST_PROMPT_SUPPORT` (in Configuration_adv.h)<br>
 `HOST_STATUS_NOTIFICATIONS` (in Configuration_adv.h)<br>

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -55,7 +55,6 @@
 #
 # Options to support dialog with host:
 #   EMERGENCY_PARSER (in Configuration_adv.h)
-#   SERIAL_FLOAT_PRECISION 4 (in Configuration_adv.h)
 #   HOST_ACTION_COMMANDS (in Configuration_adv.h)
 #   HOST_PROMPT_SUPPORT (in Configuration_adv.h)
 #   HOST_STATUS_NOTIFICATIONS (in Configuration_adv.h)


### PR DESCRIPTION
### Description

Marlin will not report a temperature or position with more than two digits beyond the decimal place since it uses `_MIN(SERIAL_FLOAT_PRECISION, 2)` for temperature reporting and 2 will always be less than 4. Other values printed via serial are now hard-coded to use one or two digits.

### Benefits

Removes unnecessary Marlin config change.

### Related Issues

None. Discovered while working through other serial issues in Marlin.
