### PR TITLE
Extension hide refactor; restore "strncpy" function alternatives

### DIFF
--- a/TFT/src/User/API/BabystepControl.c
+++ b/TFT/src/User/API/BabystepControl.c
@@ -7,7 +7,7 @@ static float babystep_value = BABYSTEP_DEFAULT_VALUE;
 #define BABYSTEP_CMD_SMW "G43.2 Z%.2f\n"
 
 // Set current babystep value
-void babystepSetValue(float value)
+void babystepSetValue(const float value)
 {
   babystep_value = value;
 }

--- a/TFT/src/User/API/BabystepControl.h
+++ b/TFT/src/User/API/BabystepControl.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stdint.h>
 
 // Set current babystep value
-void babystepSetValue(float value);
+void babystepSetValue(const float value);
 
 // Get current babystep value
 float babystepGetValue(void);

--- a/TFT/src/User/API/Notification.c
+++ b/TFT/src/User/API/Notification.c
@@ -25,7 +25,7 @@ void addToast(DIALOG_TYPE style, char * text)
   LCD_WAKE();
 
   TOAST t;
-  strncpy_no_pad(t.text, text, TOAST_MSG_LENGTH);
+  strscpy(t.text, text, TOAST_MSG_LENGTH);
   t.style = style;
   t.isNew = true;
   toastlist[nextToastIndex] = t;
@@ -146,8 +146,8 @@ void addNotification(DIALOG_TYPE style, char *title, char *text, bool ShowDialog
 
   // store message
   msglist[nextMsgIndex].style  = style;
-  strncpy_no_pad(msglist[nextMsgIndex].text, text, MAX_MSG_LENGTH);
-  strncpy_no_pad(msglist[nextMsgIndex].title, title, MAX_MSG_TITLE_LENGTH);
+  strscpy(msglist[nextMsgIndex].text, text, MAX_MSG_LENGTH);
+  strscpy(msglist[nextMsgIndex].title, title, MAX_MSG_TITLE_LENGTH);
 
   if (ShowDialog && MENU_IS_NOT(menuNotification))
     popupReminder(style, (uint8_t *)title, (uint8_t *)msglist[nextMsgIndex].text);

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -303,7 +303,7 @@ void initPrintSummary(void)
   infoPrintSummary = (PRINT_SUMMARY){.name[0] = '\0', 0, 0, 0, 0, false};
 
   // save print filename (short or long filename)
-  sprintf(infoPrintSummary.name, "%." STRINGIFY(SUMMARY_NAME_LEN) "s", getPrintFilename());
+  strscpy(infoPrintSummary.name, getPrintFilename(), SUMMARY_NAME_LEN);
 }
 
 void preparePrintSummary(void)

--- a/TFT/src/User/API/Vfs/vfs.c
+++ b/TFT/src/User/API/Vfs/vfs.c
@@ -217,7 +217,7 @@ bool addFile(bool isFile, const char * shortName, const char * longName)
   if (sName == NULL)  // in case of error, exit
     return false;
 
-  strncpy_pad(sName, shortName, sNameLen);  // copy to "sName" and set to NULL the flag for filename extension check, if any
+  strxcpy(sName, shortName, sNameLen);  // copy to "sName" and set to NULL the flag for filename extension check, if any
 
   //
   // get long name, if any
@@ -237,7 +237,7 @@ bool addFile(bool isFile, const char * shortName, const char * longName)
       return false;
     }
 
-    strncpy_pad(lName, longName, lNameLen);  // copy to "lName" and set to NULL the flag for filename extension check, if any
+    strxcpy(lName, longName, lNameLen);  // copy to "lName" and set to NULL the flag for filename extension check, if any
   }
 
   //
@@ -286,8 +286,8 @@ char * hideExtension(char * filename)
 
     // if filename provides a supported filename extension then
     // check extra byte for filename extension check. If 0, no filename extension was previously hidden
-    if (extPos != NULL && filename[strlen(filename) + 1] == '\0')
-      filename[extPos - filename] = 0;  // temporary hide filename extension
+    if (extPos != NULL && strchr(filename, '\0')[1] == '\0')
+      *extPos = 0;  // temporary hide filename extension
   }
 
   return filename;
@@ -357,7 +357,7 @@ bool getPrintTitle(char * buf, uint8_t len)
     return false;
   }
 
-  strncpy_pad(buf, getFS(), len);  // set source and set the flag for filename extension check
+  strxcpy(buf, getFS(), len);  // set source and set the flag for filename extension check
   strcat(buf, strPtr);             // append filename
   hideExtension(buf);              // hide filename extension if filename extension feature is disabled
 

--- a/TFT/src/User/API/Vfs/vfs.h
+++ b/TFT/src/User/API/Vfs/vfs.h
@@ -65,13 +65,12 @@ bool addFile(bool isFile, const char * shortName, const char * longName);  // ad
 
 // called in Print.c
 char * getFoldername(uint8_t index);             // return the long folder name if exists, otherwise the short one
-char * getFilename(uint8_t index);               // return the long file name if exists, otherwise the short one
-char * hideFilenameExtension(uint8_t index);     // hide the extension of the file name and return a pointer to that file name
-char * restoreFilenameExtension(uint8_t index);  // restore the extension of the file name and return a pointer to that file name
+char * getFilename(uint16_t index);              // return the long file name if exists, otherwise the short one
+char * hideExtension(char * filename);           // hide the extension of the file name and return a pointer to that file name
+char * restoreExtension(char * filename);        // restore the extension of the file name and return a pointer to that file name
 
 // called in PrintingMenu.c
 char * getPrintFilename(void);                // get print filename according to print originator (remote or local to TFT)
-bool getPrintTitle(char * buf, uint8_t len);  // get print title according to print originator (remote or local to TFT)
 
 // called in menu.c
 bool volumeExists(uint8_t src);

--- a/TFT/src/User/API/interfaceCmd.c
+++ b/TFT/src/User/API/interfaceCmd.c
@@ -161,7 +161,7 @@ bool storeCmdFromUART(const CMD cmd, const SERIAL_PORT_INDEX portIndex)
     return false;
   }
 
-  strncpy_no_pad(cmdQueue.queue[cmdQueue.index_w].gcode, cmd, CMD_MAX_SIZE);
+  strscpy(cmdQueue.queue[cmdQueue.index_w].gcode, cmd, CMD_MAX_SIZE);
 
   cmdQueue.queue[cmdQueue.index_w].port_index = portIndex;
   cmdQueue.index_w = (cmdQueue.index_w + 1) % CMD_QUEUE_SIZE;
@@ -845,7 +845,7 @@ void sendQueueCmd(void)
             bool hasE, hasA;
 
             // make a copy to work on
-            strncpy_no_pad(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
+            strscpy(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
 
             // retrieve message text and flags of M118 gcode
             msgText = parseM118(rawMsg, &hasE, &hasA);
@@ -992,7 +992,7 @@ void sendQueueCmd(void)
             const char * msgText;
 
             // make a copy to work on
-            strncpy_no_pad(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
+            strscpy(rawMsg, &cmd_ptr[cmd_base_index + 4], CMD_MAX_SIZE);
 
             // retrieve message text
             stripChecksum(rawMsg);

--- a/TFT/src/User/API/parseACK.c
+++ b/TFT/src/User/API/parseACK.c
@@ -764,11 +764,11 @@ void parseACK(void)
       sprintf(tmpMsg, "Mean: %0.5f", ack_value());
 
       if (ack_continue_seen("Min: "))
-        sprintf(&tmpMsg[strlen(tmpMsg)], "\nMin: %0.5f", ack_value());
+        sprintf(strchr(tmpMsg, '\0'), "\nMin: %0.5f", ack_value());
       if (ack_continue_seen("Max: "))
-        sprintf(&tmpMsg[strlen(tmpMsg)], "\nMax: %0.5f", ack_value());
+        sprintf(strchr(tmpMsg, '\0'), "\nMax: %0.5f", ack_value());
       if (ack_continue_seen("Range: "))
-        sprintf(&tmpMsg[strlen(tmpMsg)], "\nRange: %0.5f", ack_value());
+        sprintf(strchr(tmpMsg, '\0'), "\nRange: %0.5f", ack_value());
 
       popupReminder(DIALOG_TYPE_INFO, (uint8_t *)"Repeatability Test", (uint8_t *)tmpMsg);
     }

--- a/TFT/src/User/Fatfs/myfatfs.c
+++ b/TFT/src/User/Fatfs/myfatfs.c
@@ -211,7 +211,7 @@ bool f_remove_full_dir(const TCHAR* path)
   char dirBuffer[BUFFER_SIZE];
   FILINFO tmpInfo;
 
-  strncpy_no_pad(dirBuffer, path, BUFFER_SIZE);
+  strscpy(dirBuffer, path, BUFFER_SIZE);
   if (f_remove_node(dirBuffer, BUFFER_SIZE, &tmpInfo) == FR_OK)
   {
     return true;

--- a/TFT/src/User/Menu/ABL.c
+++ b/TFT/src/User/Menu/ABL.c
@@ -24,7 +24,7 @@ void ablUpdateStatus(bool succeeded)
       savingEnabled = false;
       tempTitle.index = LABEL_ABL_SETTINGS_UBL;
 
-      sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_BL_SMART_FILL));
+      sprintf(strchr(tempMsg, '\0'), "\n %s", textSelect(LABEL_BL_SMART_FILL));
       break;
 
     default:
@@ -37,7 +37,7 @@ void ablUpdateStatus(bool succeeded)
 
     if (savingEnabled && infoMachineSettings.EEPROM == 1)
     {
-      sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
+      sprintf(strchr(tempMsg, '\0'), "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
 
       popupDialog(DIALOG_TYPE_SUCCESS, tempTitle.index, (uint8_t *) tempMsg, LABEL_CONFIRM, LABEL_CANCEL, saveEepromSettings, NULL, NULL);
     }

--- a/TFT/src/User/Menu/BedLeveling.c
+++ b/TFT/src/User/Menu/BedLeveling.c
@@ -123,8 +123,8 @@ void menuBedLeveling(void)
       case KEY_ICON_3:
         if (levelStateNew != UNDEFINED)
           storeCmd((levelStateNew == ENABLED) ?
-                   (infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S0\n" : "G29 S2\n") :
-                   (infoMachineSettings.firmwareType != FW_REPRAPFW ? "M420 S1\n" : "G29 S1\n"));
+                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S0\n" : "G29 S2\n") :
+                   (infoMachineSettings.firmwareType == FW_MARLIN ? "M420 S1\n" : "G29 S1\n"));
 
         break;
 

--- a/TFT/src/User/Menu/MBL.c
+++ b/TFT/src/User/Menu/MBL.c
@@ -63,7 +63,7 @@ void mblUpdateStatus(bool succeeded)
 
     if (infoMachineSettings.EEPROM == 1)
     {
-      sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
+      sprintf(strchr(tempMsg, '\0'), "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
 
       popupDialog(DIALOG_TYPE_SUCCESS, LABEL_MBL_SETTINGS, (uint8_t *) tempMsg, LABEL_CONFIRM, LABEL_CANCEL, saveEepromSettings, NULL, NULL);
     }
@@ -85,7 +85,7 @@ void mblNotifyError(bool isStarted)
 {
   LABELCHAR(tempMsg, LABEL_MBL);
 
-  sprintf(&tempMsg[strlen(tempMsg)], " %s", isStarted ? textSelect(LABEL_ON) : textSelect(LABEL_OFF));
+  sprintf(strchr(tempMsg, '\0'), " %s", isStarted ? textSelect(LABEL_ON) : textSelect(LABEL_OFF));
 
   addToast(DIALOG_TYPE_ERROR, tempMsg);
 }

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -64,7 +64,7 @@ void pidResultAction(void)
     memset(pidHeaterTarget, 0, sizeof(pidHeaterTarget));  // reset pidHeaterTarget[] to 0
 
     LABELCHAR(tempMsg, LABEL_TIMEOUT_REACHED);
-    sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_BUSY));
+    sprintf(strchr(tempMsg, '\0'), "\n %s", textSelect(LABEL_BUSY));
     BUZZER_PLAY(SOUND_NOTIFY);
     popupReminder(DIALOG_TYPE_ALERT, LABEL_PID_TITLE, (uint8_t *) tempMsg);
   }
@@ -87,7 +87,7 @@ void pidResultAction(void)
 
       if (infoMachineSettings.EEPROM == 1)
       {
-        sprintf(&tempMsg[strlen(tempMsg)], "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
+        sprintf(strchr(tempMsg, '\0'), "\n %s", textSelect(LABEL_EEPROM_SAVE_INFO));
 
         popupDialog(DIALOG_TYPE_SUCCESS, LABEL_PID_TITLE, (uint8_t *) tempMsg, LABEL_CONFIRM, LABEL_CANCEL, saveEepromSettings, NULL, NULL);
       }
@@ -101,7 +101,7 @@ void pidResultAction(void)
       #ifdef ENABLE_PID_STATUS_UPDATE_NOTIFICATION
         LABELCHAR(tempMsg, LABEL_PID_TITLE);
 
-        sprintf(&tempMsg[strlen(tempMsg)], " %s", textSelect(LABEL_PROCESS_COMPLETED));
+        sprintf(strchr(tempMsg, '\0'), " %s", textSelect(LABEL_PROCESS_COMPLETED));
         BUZZER_PLAY(SOUND_NOTIFY);
         addToast(DIALOG_TYPE_INFO, tempMsg);
       #endif

--- a/TFT/src/User/Menu/Popup.c
+++ b/TFT/src/User/Menu/Popup.c
@@ -126,12 +126,12 @@ void menuDialog(void)
 
 void _setDialogTitleStr(uint8_t * str)
 {
-  strncpy_no_pad((char *)popup_title, (char *)str, sizeof(popup_title));
+  strscpy((char *)popup_title, (char *)str, sizeof(popup_title));
 }
 
 void _setDialogMsgStr(uint8_t * str)
 {
-  strncpy_no_pad((char *)popup_msg, (char *)str, sizeof(popup_msg));
+  strscpy((char *)popup_msg, (char *)str, sizeof(popup_msg));
 }
 
 uint8_t *getDialogMsgStr()
@@ -141,40 +141,40 @@ uint8_t *getDialogMsgStr()
 
 void _setDialogOkTextStr(uint8_t * str)
 {
-  strncpy_no_pad((char *)popup_ok, (char *)str, sizeof(popup_ok));
+  strscpy((char *)popup_ok, (char *)str, sizeof(popup_ok));
 }
 
 void _setDialogCancelTextStr(uint8_t * str)
 {
-  strncpy_no_pad((char *)popup_cancel, (char *)str, sizeof(popup_cancel));
+  strscpy((char *)popup_cancel, (char *)str, sizeof(popup_cancel));
 }
 
 void _setDialogTitleLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strncpy_no_pad((char *)popup_title, (char *)tempstr, sizeof(popup_title));
+  strscpy((char *)popup_title, (char *)tempstr, sizeof(popup_title));
 }
 
 void _setDialogMsgLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strncpy_no_pad((char *)popup_msg, (char *)tempstr, sizeof(popup_msg));
+  strscpy((char *)popup_msg, (char *)tempstr, sizeof(popup_msg));
 }
 
 void _setDialogOkTextLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strncpy_no_pad((char *)popup_ok, (char *)tempstr, sizeof(popup_ok));
+  strscpy((char *)popup_ok, (char *)tempstr, sizeof(popup_ok));
 }
 
 void _setDialogCancelTextLabel(int16_t index)
 {
   uint8_t tempstr[MAX_LANG_LABEL_LENGTH] = {0};
   loadLabelText(tempstr, index);
-  strncpy_no_pad((char *)popup_cancel, (char *)tempstr, sizeof(popup_cancel));
+  strscpy((char *)popup_cancel, (char *)tempstr, sizeof(popup_cancel));
 }
 
 /**

--- a/TFT/src/User/Menu/Print.c
+++ b/TFT/src/User/Menu/Print.c
@@ -85,9 +85,7 @@ void gocdeIconDraw(void)
   // draw gcode files
   for (; (baseIndex + i < infoFile.folderCount + infoFile.fileCount) && (i < NUM_PER_PAGE); i++)
   {
-    restoreFilenameExtension(baseIndex + i - infoFile.folderCount);  // restore filename extension if filename extension feature is disabled
-
-    if (enterFolder(infoFile.file[baseIndex + i - infoFile.folderCount]) == false)  // always use short filename for file path
+    if (enterFolder(restoreExtension(infoFile.file[baseIndex + i - infoFile.folderCount])) == false)  // always use short filename for file path
       break;
 
     // if model preview bmp exists, display bmp directly without writing to flash
@@ -99,8 +97,7 @@ void gocdeIconDraw(void)
 
     exitFolder();
 
-    hideFilenameExtension(baseIndex + i - infoFile.folderCount);  // hide filename extension if filename extension feature is disabled
-    normalNameDisp(&gcodeRect[i], (uint8_t*)infoFile.file[baseIndex + i - infoFile.folderCount]);  // always use short filename
+    normalNameDisp(&gcodeRect[i], (uint8_t *)hideExtension(infoFile.file[baseIndex + i - infoFile.folderCount]));  // always use short filename
   }
 
   // clear blank icons
@@ -126,7 +123,7 @@ void gocdeListDraw(LISTITEM * item, uint16_t index, uint8_t itemPos)
     item->icon = CHARICON_FILE;
     item->itemType = LIST_LABEL;
     item->titlelabel.index = LABEL_DYNAMIC;
-    setDynamicLabel(itemPos, hideFilenameExtension(index - infoFile.folderCount));  // hide filename extension if filename extension feature is disabled
+    setDynamicLabel(itemPos, hideExtension(getFilename(index - infoFile.folderCount)));  // hide filename extension if filename extension feature is disabled
   }
 }
 
@@ -150,7 +147,7 @@ bool printPageItemSelected(uint16_t index)
   else if (index < infoFile.folderCount + infoFile.fileCount)  // gcode file
   {
     infoFile.fileIndex = index - infoFile.folderCount;
-    char * filename = restoreFilenameExtension(infoFile.fileIndex);  // restore filename extension if filename extension feature is disabled
+    char * filename = restoreExtension(getFilename(infoFile.fileIndex));  // restore filename extension if filename extension feature is disabled
 
     if (infoHost.connected != true || enterFolder(infoFile.file[infoFile.fileIndex]) == false)  // always use short filename for file path
     {

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -230,7 +230,7 @@ static void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
         if ((getPrintRemainingTime() == 0) || (progDisplayType != ELAPSED_REMAINING))
           snprintf(tempstrTop, 9, "%d%%      ", getPrintProgress());
         else
-          time_2_string(tempstrTop, TIME_FORMAT_STR, getPrintTime());
+          timeToString(tempstrTop, TIME_FORMAT_STR, getPrintTime());
         break;
 
       case ICON_POS_Z:
@@ -287,9 +287,9 @@ static void reDrawPrintingValue(uint8_t icon_pos, uint8_t draw_type)
 
       case ICON_POS_TIM:
         if ((getPrintRemainingTime() == 0) || (progDisplayType == PERCENTAGE_ELAPSED))
-          time_2_string(tempstrBottom, TIME_FORMAT_STR, getPrintTime());
+          timeToString(tempstrBottom, TIME_FORMAT_STR, getPrintTime());
         else
-          time_2_string(tempstrBottom, TIME_FORMAT_STR, getPrintRemainingTime());
+          timeToString(tempstrBottom, TIME_FORMAT_STR, getPrintRemainingTime());
         break;
 
       case ICON_POS_Z:
@@ -440,7 +440,7 @@ void printSummaryPopup(void)
   char showInfo[300];
   char tempstr[60];
 
-  time_2_string(showInfo, (char *)textSelect(LABEL_PRINT_TIME), infoPrintSummary.time);
+  timeToString(showInfo, (char *)textSelect(LABEL_PRINT_TIME), infoPrintSummary.time);
 
   if (isAborted() == true)
   {

--- a/TFT/src/User/Menu/PrintingMenu.c
+++ b/TFT/src/User/Menu/PrintingMenu.c
@@ -122,11 +122,19 @@ static void setLayerNumberTxt(char * layer_number_txt)
   }
 }
 
+// set the print title according to the print originator (remote or local to TFT)
+static void setPrintTitle(void)
+{
+  snprintf(title, MAX_TITLE_LEN, "%s%s%c", getFS(), getPrintFilename(), '\0');
+
+  hideExtension(title);
+}
+
 // initialize printing info before opening Printing menu
 static void initMenuPrinting(void)
 {
-  getPrintTitle(title, MAX_TITLE_LEN);  // get print title according to print originator (remote or local to TFT)
-  clearInfoFile();                      // as last, clear and free memory for file list
+  setPrintTitle();  // set the print title according to the print originator (remote or local to TFT)
+  clearInfoFile();  // as last, clear and free memory for file list
 
   progDisplayType = infoSettings.prog_disp_type;
 

--- a/TFT/src/User/Menu/StatusScreen.c
+++ b/TFT/src/User/Menu/StatusScreen.c
@@ -202,17 +202,17 @@ void drawStatus(void)
 
 void statusScreen_setMsg(const uint8_t *title, const uint8_t *msg)
 {
-  strncpy_no_pad(msgTitle, (char *)title, sizeof(msgTitle));
-  strncpy_no_pad(msgBody, (char *)msg, sizeof(msgBody));
+  strscpy(msgTitle, (char *)title, sizeof(msgTitle));
+  strscpy(msgBody, (char *)msg, sizeof(msgBody));
   msgNeedRefresh = true;
 }
 
 void statusScreen_setReady(void)
 {
-  strncpy_no_pad(msgTitle, (char *)textSelect(LABEL_STATUS), sizeof(msgTitle));
+  strscpy(msgTitle, (char *)textSelect(LABEL_STATUS), sizeof(msgTitle));
 
   if (infoHost.connected == false)
-    strncpy_no_pad(msgBody, (char *)textSelect(LABEL_UNCONNECTED), sizeof(msgBody));
+    strscpy(msgBody, (char *)textSelect(LABEL_UNCONNECTED), sizeof(msgBody));
   else
     snprintf(msgBody, sizeof(msgBody), "%s %s", (char *)machine_type, (char *)textSelect(LABEL_READY));
 

--- a/TFT/src/User/Menu/StatusScreen.h
+++ b/TFT/src/User/Menu/StatusScreen.h
@@ -11,14 +11,9 @@ extern "C" {
 extern const GUI_RECT msgRect;
 
 void menuStatus(void);
-void drawTemperature(void);
-void storegantry(int n, float val);
 void statusScreen_setMsg(const uint8_t *title,const uint8_t *msg);
 void statusScreen_setReady(void);
 void drawStatusScreenMsg(void);
-float getAxisLocation(uint8_t n);
-void gantry_dec(int n, float val);
-void gantry_inc(int n, float val);
 
 #ifdef __cplusplus
 }

--- a/TFT/src/User/Menu/Terminal.c
+++ b/TFT/src/User/Menu/Terminal.c
@@ -26,12 +26,6 @@ typedef struct
 
 typedef enum
 {
-  KEYBOARD_VIEW = 0,
-  TERMINAL_VIEW
-} TERMINAL_WINDOW;
-
-typedef enum
-{
   GKEY_PREV = 0,
   GKEY_NEXT,
   GKEY_CLEAR,
@@ -316,7 +310,12 @@ const uint16_t fontSrcColor[3][3] = {
 KEYBOARD_DATA * keyboardData;
 TERMINAL_DATA * terminalData;
 char * terminalBuf;
-TERMINAL_WINDOW curView = KEYBOARD_VIEW;
+
+enum
+{
+  KEYBOARD_VIEW = 0,
+  TERMINAL_VIEW
+} curView = KEYBOARD_VIEW;
 
 bool numpad =
   #if defined(KB_TYPE_QWERTY)

--- a/TFT/src/User/Menu/ZOffset.c
+++ b/TFT/src/User/Menu/ZOffset.c
@@ -14,9 +14,9 @@ void zOffsetNotifyError(bool isStarted)
     sprintf(tempMsg, "%s", textSelect(LABEL_HOME_OFFSET));
 
   if (!isStarted)
-    sprintf(&tempMsg[strlen(tempMsg)], " %s", textSelect(LABEL_OFF));
+    sprintf(strchr(tempMsg, '\0'), " %s", textSelect(LABEL_OFF));
   else
-    sprintf(&tempMsg[strlen(tempMsg)], " %s", textSelect(LABEL_ON));
+    sprintf(strchr(tempMsg, '\0'), " %s", textSelect(LABEL_ON));
 
   addToast(DIALOG_TYPE_ERROR, tempMsg);
 }

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -45,10 +45,12 @@ uint32_t calculateCRC16(const uint8_t *data, uint32_t length)
 /*
  * - always copy num-1 characters from source to destination
  *   regardless of null terminating character found in source
+ * - destination always ends with '\0'
+ *
+ * Note:
  * - to avoid overflows, the size of "destination" should be at least "num" bytes
  *   and the size of "source" should be at least "num-1" bytes, in both cases
  *   including the '\0' terminal character
- * - destination always ends with '\0'
  */
 void strxcpy(char * destination, const char * source, size_t num)
 {
@@ -62,6 +64,9 @@ void strxcpy(char * destination, const char * source, size_t num)
  * - copy source to destination but no more than width-1 characters
  * - if null terminating character found in source the rest is padded with 0
  * - destination always ends with '\0'
+ * Note:
+ * - to avoid overflows, the size of "destination" should be at least
+ *   "width" bytes, including the '\0' terminal character
  */
 void strwcpy(char * destination, const char * source, size_t width)
 {
@@ -79,6 +84,10 @@ void strwcpy(char * destination, const char * source, size_t width)
  * - copy source to destination but no more than size-1 characters
  * - if null terminating character found in source the copy stops there
  * - destination always ends with '\0'
+ * Note:
+ * - to avoid overflows, the dimension of "destination" should be
+ *   at least the "size" bytes or the size of "source", which one
+ *   is smaller (including the '\0' terminal character)
  */
 void strscpy(char * destination, const char * source, size_t size)
 {
@@ -245,10 +254,8 @@ void stripChecksum(char *str)
   // "/test/cap2.gcode  *36\n\0" -> "/test/cap2.gcode"
   // "/test/cap2.gcode  \n\0" -> "/test/cap2.gcode"
 
-  char *strPtr = strrchr(str, '*');  // e.g. "/test/cap2.gcode  *36\n\0" -> "*36\n\0"
-
-  if (strPtr == NULL)
-    strPtr = str + strlen(str);      // e.g. "/test/cap2.gcode  \n\0" -> "\0"
+  char *strPtr = strrchr(str, '*');
+  if (strPtr == NULL) strPtr = strchr(str, '\0');
 
   while (strPtr != str)
   {
@@ -264,6 +271,7 @@ void stripChecksum(char *str)
     }
   }
 
+  // Add the null terminator to remove any trailing unwanted characters
   // e.g. "  *36\n\0" -> "\0 *36\n\0"
   // e.g. "  \n\0" -> "\0 \n\0"
   //

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -42,7 +42,58 @@ uint32_t calculateCRC16(const uint8_t *data, uint32_t length)
   return crc;
 }
 
-// string convert to uint8, MSB ("2C" to 0x2C)
+/*
+ * - always copy num-1 characters from source to destination
+ *   regardless of null terminating character found in source
+ * - to avoid overflows, the size of "destination" should be at least "num" bytes
+ *   and the size of "source" should be at least "num-1" bytes, in both cases
+ *   including the '\0' terminal character
+ * - destination always ends with '\0'
+ */
+void strxcpy(char * destination, const char * source, size_t num)
+{
+  num -= !!num;
+
+  memcpy(destination, source, num);
+  destination[num] ='\0';
+}
+
+/*
+ * - copy source to destination but no more than width-1 characters
+ * - if null terminating character found in source the rest is padded with 0
+ * - destination always ends with '\0'
+ */
+void strwcpy(char * destination, const char * source, size_t width)
+{
+  width -= !!width;
+  while (width > 0 && *source != '\0')
+  {
+    *destination++ = *source++;
+    width--;
+  }
+
+  memset(destination, '\0', width + 1);
+}
+
+/*
+ * - copy source to destination but no more than size-1 characters
+ * - if null terminating character found in source the copy stops there
+ * - destination always ends with '\0'
+ */
+void strscpy(char * destination, const char * source, size_t size)
+{
+  size -= !!size;
+  while (size > 0 && *source != '\0')
+  {
+    *destination++ = *source++;
+    size--;
+  }
+
+  *destination = '\0';
+}
+
+// string convert to uint8, MSB
+// "2C" to 0x2C
 uint8_t string_2_uint8(const uint8_t *str)
 {
   uint8_t rtv = 0;
@@ -112,19 +163,8 @@ uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *str)
   return str;
 }
 
-// convert time to string with given formatting
-void time_2_string(char *buf, char *str_format, uint32_t time)
-{
-  uint8_t hour = HOURS(time);
-  uint8_t min = MINUTES(time);
-  uint8_t sec = SECONDS(time);
-
-  sprintf(buf, str_format, hour, min, sec);
-}
-
-// light weight strtod() function without exponential support.
-// Convert string to double (without exponential support)
-double strtod_ligth(char *str, char **endptr)
+// convert string to double (without exponential support)
+double stringToDouble(char *str, char **endptr)
 {
   char *p = str;
   double val = 0.0;
@@ -174,44 +214,14 @@ double strtod_ligth(char *str, char **endptr)
   return val * sign;
 }
 
-// light weight and safe strncpy() function with padding:
-// - copy "src" to "dest" for a maximum of "n-1" characters
-// - if null terminating character is found in "src" the rest in "dest" is padded with '\0'
-// - "dest" always ends with '\0'
-void strncpy_pad(char *dest, const char *src, size_t n)
+// convert time to string with given formatting
+void timeToString(char *buf, char *strFormat, uint32_t time)
 {
-  // if "src" is not NULL, proceed first with the copy.
-  // Otherwise, proceed only padding "dest" with '\0'
-  if (src != NULL)
-  {
-    while (n > 1 && *src != '\0')
-    {
-      *dest++ = *src++;
-      n--;
-    }
-  }
+  uint8_t hour = HOURS(time);
+  uint8_t min = MINUTES(time);
+  uint8_t sec = SECONDS(time);
 
-  memset(dest, '\0', n);  // NOTE: safe even in case value 0 was passed for "n" (memset() function will do nothing)
-}
-
-// light weight and safe strncpy() function without padding:
-// - copy "src" to "dest" for a maximum of "n-1" characters
-// - if null terminating character is found in "src" the copy stops there
-// - "dest" always ends with '\0'
-void strncpy_no_pad(char *dest, const char *src, size_t n)
-{
-  // if "src" is not NULL, proceed with the copy
-  if (src != NULL)
-  {
-    while (n > 1 && *src != '\0')
-    {
-      *dest++ = *src++;
-      n--;
-    }
-  }
-
-  if (n != 0)  // safe in case value 0 was passed for "n"
-    *dest = '\0';
+  sprintf(buf, strFormat, hour, min, sec);
 }
 
 // strip out any leading " ", "/" or ":" character that might be in the string

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -60,7 +60,7 @@ extern "C" {
 #define MINUTES(t) (t % (60 * 60) / 60)  // minutes remaining to next hour
 #define SECONDS(t) (t % 60)              // seconds remaining to next minute
 
-#define strtod stringToDouble  // light weight strtod() function without exponential support
+#define strtod stringToDouble  // lightweight strtod() function without exponential support
 
 #define strncpy(...) \
   do { \
@@ -79,21 +79,21 @@ extern "C" {
 uint8_t inRange(int cur, int tag , int range);
 long map(long x, long in_min, long in_max, long out_min, long out_max);
 
-uint32_t calculateCRC16(const uint8_t *data, uint32_t length);  // calculate CRC16 checksum
+uint32_t calculateCRC16(const uint8_t *data, uint32_t length);
 
 void strxcpy(char * destination, const char * source, size_t num);
-void strwcpy(char * destination, const char * source, size_t num);  // lightweight and safe strncpy() function with padding
-void strscpy(char * destination, const char * source, size_t num);  // lightweight and safe strncpy() function without padding
+void strwcpy(char * destination, const char * source, size_t num);
+void strscpy(char * destination, const char * source, size_t num);
 
-uint8_t string_2_uint8(const uint8_t *string);  // string convert to uint8, MSB ("2C" to 0x2C)
-uint8_t *uint8_2_string(uint8_t num, uint8_t *string);  // uint8 convert to string, MSB (0x2C to "2C")
-uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);   // string convert to uint32, MSB
-uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string);  // uint32 convert to string, MSB
-void timeToString(char *buf, char *strFormat, uint32_t time);  // convert time to string with given formatting
-double stringToDouble(char *str, char **endptr);  // light weight strtod() function without exponential support
+uint8_t string_2_uint8(const uint8_t *string);
+uint8_t *uint8_2_string(uint8_t num, uint8_t *string);
+uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);
+uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string);
+void timeToString(char *buf, char *strFormat, uint32_t time);
+double stringToDouble(char *str, char **endptr);
 
-const char *stripHead(const char *str);  // strip out any leading " ", "/" or ":" character that might be in the string
-void stripChecksum(char *str);           // strip out any trailing checksum that might be in the string
+const char *stripHead(const char *str);
+void stripChecksum(char *str);
 uint8_t getChecksum(char *str);
 bool validateChecksum(char *str);
 

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>  // for size_t
+#include <string.h>
 
 // Menu Macros
 #define OPEN_MENU(x)    infoMenu.menu[++infoMenu.cur] = x
@@ -60,11 +60,11 @@ extern "C" {
 #define MINUTES(t) (t % (60 * 60) / 60)  // minutes remaining to next hour
 #define SECONDS(t) (t % 60)              // seconds remaining to next minute
 
-#define strtod strtod_ligth  // light weight strtod() function without exponential support
+#define strtod stringToDouble  // light weight strtod() function without exponential support
 
 #define strncpy(...) \
   do { \
-    _Pragma("GCC error \"Error: strncpy() is deprecated! Use the alternatives like strncpy_pad() or strncpy_no_pad()\""); \
+    _Pragma("GCC error \"Error: strncpy() is deprecated! Use the alternatives like strxcpy(), strwcpy() or strscpy() according to your needs.\""); \
   } while (0)
 
 // call processes from the argument and than loopProcess() while condition is true
@@ -81,15 +81,16 @@ long map(long x, long in_min, long in_max, long out_min, long out_max);
 
 uint32_t calculateCRC16(const uint8_t *data, uint32_t length);  // calculate CRC16 checksum
 
-uint8_t string_2_uint8(const uint8_t *str);                               // string convert to uint8, MSB ("2C" to 0x2C)
-uint8_t *uint8_2_string(uint8_t num, uint8_t *str);                       // uint8 convert to string, MSB (0x2C to "2C")
-uint32_t string_2_uint32(const uint8_t *str, const uint8_t bytes_num);    // string convert to uint32, MSB
-uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *str);  // uint32 convert to string, MSB
-void time_2_string(char *buf, char *str_format, uint32_t time);           // convert time to string with given formatting
+void strxcpy(char * destination, const char * source, size_t num);
+void strwcpy(char * destination, const char * source, size_t num);  // lightweight and safe strncpy() function with padding
+void strscpy(char * destination, const char * source, size_t num);  // lightweight and safe strncpy() function without padding
 
-double strtod_ligth(char *str, char **endptr);               // light weight strtod() function without exponential support
-void strncpy_pad(char *dest, const char *src, size_t n);     // light weight and safe strncpy() function with padding
-void strncpy_no_pad(char *dest, const char *src, size_t n);  // light weight and safe strncpy() function without padding
+uint8_t string_2_uint8(const uint8_t *string);  // string convert to uint8, MSB ("2C" to 0x2C)
+uint8_t *uint8_2_string(uint8_t num, uint8_t *string);  // uint8 convert to string, MSB (0x2C to "2C")
+uint32_t string_2_uint32(const uint8_t *string, const uint8_t bytes_num);   // string convert to uint32, MSB
+uint8_t *uint32_2_string(uint32_t num, uint8_t bytes_num, uint8_t *string);  // uint32 convert to string, MSB
+void timeToString(char *buf, char *strFormat, uint32_t time);  // convert time to string with given formatting
+double stringToDouble(char *str, char **endptr);  // light weight strtod() function without exponential support
 
 const char *stripHead(const char *str);  // strip out any leading " ", "/" or ":" character that might be in the string
 void stripChecksum(char *str);           // strip out any trailing checksum that might be in the string


### PR DESCRIPTION
### Requirements

BTT or MKS TFT.

### Description

- The "strxcpy", "strscpy" and "strwcpy" alternatives for "strncpy" were restored. PR #2768 eliminated them. PR #2768 claims that "strxcpy is not applicable at all in VFS API". Well... "strxcpy" is EXACTLY there where it is best suited. It just adds that extra '\0' character needed for file extension hide and restoration functions.
The author of that PR probably missed that the source string also contains the '\0' terminal character and the "strxcpy" copies only "num - 1" characters. So if the source is a filename (not a folder name) "num" equals to the number of bytes in the filename (excepting the '\0' terminal character) plus two more bytes (num = strlen(filename) + 2). If you substract 1 for "num" (becasue "num - 1" bytes will copy "strxcpy" from source to destination) you will end up to copy "num - 1" bytes from source which equals to "strlen(filename) + 1" which equals to the bytes number in the filename plus the '\0' terminator character. No risk of any overflow here.
So not only that "strxcpy" is PERFECTLY SAFE and suitable for the job in VFS API but it is also faster compared to the offered alternative by PR https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/pull/2768. This also adds to the snappiness of the filelist.
The alternatives offered by PR #2768 are not as light as the ones they replaced and in some cases they fail to deliver the promised <"dest" always ends with '\0'> which results in an undefined/unsafe state of "dest" if it is not initialized beforehead. It's not the case with the functions of this PR.
- "setPrintTitle()" is back reworked and with a very small footprint (40 bytes smaller than the original "getPrintTitle()").
- The hide extension of the filenames got refactored resulting in a speed boost in file list procedure, by a rough estimation of at least 25% (the value is estimated, do not ask for scientific proof). The list creation and the navigation between pages in the list is more snappier. It is done by eliminating unnecessary extension hiding, restoration and nested functions.
- The following expression type &string[strlen(string)] has been replaced by strchr(string, '\0'). The expression &string[strlen(string)] first finds the '\0' terminal character in the "string" variable counting in the meantime the bytes checked than iterates variable "string" by the bytes resulted in the previous check than it gives back the address of the iteration result, actually giving the address of the null terminator character of the "string" variable. strchr(string, '\0') does EXACTLY that with only one search, it directly gives the address of the null terminator character of the "string" variable.
- PR #2768 claimed to fix "wrong check on BedLeveling menu" but there was nothing to fix. Maybe it was just a lack of code understanding... If X can be only A or B and it is not B than what is X? :)
Before checking if the firmware of the motherboard if it is Marlin or not there's a conditional if (levelStateNew != UNDEFINED) which limits the firmware to be either Marlin or Reprap. So if it's not Reprap, it's... you guessed right, it's Marlin! The fix of PR #2768 was not a fix so it's reverted.
