### PR TITLE
Serial bugfix on init/deinit

### DIFF
--- a/TFT/src/User/API/SerialConnection.c
+++ b/TFT/src/User/API/SerialConnection.c
@@ -22,51 +22,32 @@ const SERIAL_PORT_INFO serialPort[SERIAL_PORT_COUNT] = {
 const uint32_t baudrateValues[BAUDRATE_COUNT] =    { 0,     2400,   9600,   19200,   38400,   57600,   115200,   250000,   500000,   1000000};
 const char * const baudrateNames[BAUDRATE_COUNT] = {"OFF", "2400", "9600", "19200", "38400", "57600", "115200", "250000", "500000", "1000000"};
 
-static inline void Serial_InitPrimary(void)
-{
-  InfoHost_Init(false);  // initialize infoHost when disconnected
-
-  Serial_Config(serialPort[PORT_1].port, serialPort[PORT_1].cacheSize, baudrateValues[infoSettings.serial_port[PORT_1]]);
-}
-
-static inline void Serial_DeInitPrimary(void)
-{
-  Serial_DeConfig(serialPort[PORT_1].port);
-}
-
 void Serial_Init(SERIAL_PORT_INDEX portIndex)
 {
   if (!WITHIN(portIndex, ALL_PORTS, SERIAL_PORT_COUNT - 1))
     return;
 
-  if (portIndex <= PORT_1)  // if primary, all serial ports or all supplementary serial ports
+  if (portIndex == PORT_1 || portIndex == ALL_PORTS)
   {
-    if (portIndex != SUP_PORTS)  // if primary or all serial ports, initialize the primary serial port
-      Serial_InitPrimary();
+    Serial_Config(serialPort[PORT_1].port, serialPort[PORT_1].cacheSize, baudrateValues[infoSettings.serial_port[PORT_1]]);
 
-    #ifdef SERIAL_PORT_2
-      if (portIndex != PORT_1)  // if ALL_PORTS or SUP_PORTS, initialize all the supplementary serial ports
-      {
-        for (portIndex = PORT_2; portIndex < SERIAL_PORT_COUNT; portIndex++)
-        {
-          // the supplementary serial ports should be enabled according to config.ini.
-          // Disable the serial port when it is not in use and/or not connected to a device (floating) to
-          // avoid to receive and process wrong data due to possible electromagnetic interference (EMI).
-          if (infoSettings.serial_port[portIndex] > 0)  // if serial port is enabled
-            Serial_Config(serialPort[portIndex].port, serialPort[portIndex].cacheSize,
-                          baudrateValues[infoSettings.serial_port[portIndex]]);
-        }
-      }
-    #endif
+    InfoHost_Init(false);  // initialize infoHost when disconnected
+    coordinateSetKnown(false);
   }
+
   #ifdef SERIAL_PORT_2
-    else  // if supplementary serial port
+    for (SERIAL_PORT_INDEX tmpIndex = PORT_2; tmpIndex < SERIAL_PORT_COUNT; tmpIndex++)
     {
-      if (infoSettings.serial_port[portIndex] > 0)  // if serial port is enabled
-      {
-        Serial_Config(serialPort[portIndex].port, serialPort[portIndex].cacheSize,
-                      baudrateValues[infoSettings.serial_port[portIndex]]);
-      }
+      // the supplementary serial ports should be enabled according to config.ini.
+      // Disable the serial port when it is not in use and/or not connected to a device (floating) to
+      // avoid to receive and process wrong data due to possible electromagnetic interference (EMI).
+
+      if (infoSettings.serial_port[tmpIndex] == 0)  // if serial port not enabled, skip
+        continue;
+
+      if (portIndex == tmpIndex || portIndex < PORT_1)
+        Serial_Config(serialPort[tmpIndex].port, serialPort[tmpIndex].cacheSize,
+                            baudrateValues[infoSettings.serial_port[tmpIndex]]);
     }
   #endif
 }
@@ -76,25 +57,14 @@ void Serial_DeInit(SERIAL_PORT_INDEX portIndex)
   if (!WITHIN(portIndex, ALL_PORTS, SERIAL_PORT_COUNT - 1))
     return;
 
-  if (portIndex <= PORT_1)  // if primary, all serial ports or all supplementary serial ports
-  {
-    if (portIndex != SUP_PORTS)  // if primary or all serial ports, deinitialize the primary serial port
-      Serial_DeInitPrimary();
+  if (portIndex == PORT_1 || portIndex == ALL_PORTS)
+    Serial_DeConfig(serialPort[PORT_1].port);
 
-    #ifdef SERIAL_PORT_2
-      if (portIndex != PORT_1)  // if ALL_PORTS or SUP_PORTS, deinitialize all the supplementary serial ports
-      {
-        for (portIndex = PORT_2; portIndex < SERIAL_PORT_COUNT; portIndex++)
-        {
-          Serial_DeConfig(serialPort[portIndex].port);
-        }
-      }
-    #endif
-  }
   #ifdef SERIAL_PORT_2
-    else  // if supplementary serial port
+    for (SERIAL_PORT_INDEX tmpIndex = PORT_2; tmpIndex < SERIAL_PORT_COUNT; tmpIndex++)
     {
-      Serial_DeConfig(serialPort[portIndex].port);
+      if (portIndex == tmpIndex || portIndex < PORT_1)
+        Serial_DeConfig(serialPort[tmpIndex].port);
     }
   #endif
 }

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -18,20 +18,27 @@ void menuDisconnect(void)
   GUI_DispStringInRect(20, LCD_HEIGHT - (BYTE_HEIGHT * 2), LCD_WIDTH - 20, LCD_HEIGHT, textSelect(LABEL_TOUCH_TO_EXIT));
 
   Serial_DeInit(ALL_PORTS);
+
   while (!isPress())
   {
     #ifdef LCD_LED_PWM_CHANNEL
       LCD_CheckDimming();
     #endif
   }
+
+  #ifdef BUZZER_PIN
+    BUZZER_PLAY(SOUND_KEYPRESS);
+    loopBuzzer();
+  #endif
+
   while (isPress())
   {
     #ifdef LCD_LED_PWM_CHANNEL
       LCD_CheckDimming();
     #endif
   }
-  Serial_Init(ALL_PORTS);
 
+  Serial_Init(ALL_PORTS);
   CLOSE_MENU();
 }
 


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

Serial init/deinit can cause the TFT to hang. This PR fixes this issue.

#### Steps to reproduce such a hang

1. Go to Menu -> Settings -> Connection
2. Press "Disconnect"
3. Press screen again as soon as the TFT displays the message about the disconnected state
4. Repeat from step 2. and eventually the TFT will hang
