### PR TITLE
Relax OS_Time IRQHandler

### DIFF
--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -132,7 +132,7 @@ uint32_t getPrintExpectedTime(void)
   return infoPrinting.expectedTime;
 }
 
-void updatePrintTime(void)
+void updatePrintTime(void)  // Handle in interrupt
 {
   if (infoPrinting.printing && !infoPrinting.paused)
   {

--- a/TFT/src/User/API/UI/TouchProcess.h
+++ b/TFT/src/User/API/UI/TouchProcess.h
@@ -25,20 +25,14 @@ enum
   KNOB_DEC,
 };
 
-#define KEY_CLICK        0x0000  // The key is defined as uint16_t , 16 (uint16_t 16bit)-3 (3 bits flag) = 13 bit, so uint16_t supports a maximum of 2 ^ 13 = 8192 key values
-#define KEY_DOUBLE_CLICK 0x2000  // The third bit is used to identify the double-click action
-#define KEY_LONG_RELEASE 0x4000  // The second bit is used to identify the release action after a long press
-#define KEY_LONG_CLICK   0x8000  // The first bit is used to identify the long press action
-
 extern bool touchSound;
 
 void TSC_Calibration(void);
-uint8_t isPress(void);
+bool isPress(void);
 uint16_t KEY_GetValue(uint8_t total_rect, const GUI_RECT *menuRect);
 uint16_t Key_value(uint8_t total_rect, const GUI_RECT *menuRect);
-uint16_t KNOB_GetRV(GUI_RECT *knob);
 
-void loopTouchScreen(void);
+void checkTouchScreen(void);  // WARNING, TIMER INTERRUPT ROUTINE CALLED ONCE A MILLISECOND
 
 extern void (*TSC_ReDrawIcon)(uint8_t position, uint8_t is_press);
 extern void TS_Get_Coordinates(uint16_t *x, uint16_t *y);

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1117,7 +1117,7 @@
  * Monitoring Debug
  * Uncomment/Enable to monitor/show system resources usage in Monitoring menu.
  */
-#define DEBUG_MONITORING  // Default: commented (disabled)
+//#define DEBUG_MONITORING  // Default: commented (disabled)
 
 /**
  * Generic Debug
@@ -1431,7 +1431,7 @@
  * Uncomment to enable a progress bar with 10% markers.
  * Comment to enable a standard progress bar.
  */
-#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
+//#define MARKED_PROGRESS_BAR  // Default: commented (disabled)
 
 /**
  * Live Text Common Color Layout (Status Screen menu)

--- a/TFT/src/User/os_timer.h
+++ b/TFT/src/User/os_timer.h
@@ -9,23 +9,8 @@ extern "C" {
 
 typedef void (*FP_TASK)(void *);
 
-typedef struct
-{
-  uint32_t time_ms;
-  uint32_t next_time;
-  FP_TASK  task;
-  void     *para;
-  uint8_t  is_exist;
-  uint8_t  is_repeat;
-} OS_TASK;
-
 void OS_TimerInitMs(void);
 uint32_t OS_GetTimeMs(void);
-
-void OS_TaskInit(OS_TASK *task, uint32_t time_ms, FP_TASK function, void *para);
-void OS_TaskLoop(OS_TASK *task);
-void OS_TaskEnable(OS_TASK *task, uint8_t is_exec, uint8_t is_repeat);
-void OS_TaskDisable(OS_TASK *task);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Requirements

BTT or MKS TFT.

### Description

This PR is an attempt to ease up the OS timer IRQ handler. Major credit goes to @rondlh who brought it to our attention here: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/2832. More than that @rondlh made several suggestions to make the IRQ handler lighter on the MCU, suggestions that are included in this PR.
The extra changes are:
 - remove modulo operation which is expensive  and replace it with bare simple arithmetic ones
 - ~remove the usage of any conditional and ternary from one of the functions called in that interrupt handler and replaced it with bare arithmetic operations~
 - moved the interrupt flag reset to the end of the operations to avoid any unpredictable behaviour of the IRQ handler

### Benefits

In theory it speeds up the TFT.
