### PR TITLE
Move menu cosmetics

### DIFF
--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -667,6 +667,11 @@ void setMenu(MENU_TYPE menu_type, LABEL * title, uint16_t rectCount, const GUI_R
   #endif
 }
 
+SYS_STATUS getReminderStatus(void)
+{
+  return reminder.status;
+}
+
 void drawReminderMsg(void)
 {
   uint16_t msgRectOffset = (LCD_WIDTH - GUI_StrPixelWidth(reminder.inf)) / 2 - BYTE_WIDTH;

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -172,6 +172,7 @@ extern const GUI_RECT rect_of_titleBar[1];
 void setMenuType(MENU_TYPE type);
 MENU_TYPE getMenuType(void);
 
+SYS_STATUS getReminderStatus(void);
 void setReminderMsg(int16_t inf, SYS_STATUS status);
 void notificationDot(void);
 

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -31,18 +31,20 @@ void storeMoveCmd(const AXIS xyz, const float amount)
 
 void drawXYZ(void)
 {
+  if (getReminderStatus() != SYS_STATUS_IDLE || toastRunning()) return;
+
   char tempstr[30];
 
   GUI_SetColor(infoSettings.status_color);
 
   sprintf(tempstr, "X:%.2f  ", coordinateGetAxisActual(X_AXIS));
-  GUI_DispString(START_X + (OFFSET + 0) * SPACE_X + (OFFSET + 0) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
+  GUI_DispString(START_X + (OFFSET + 0) * SPACE_X + (OFFSET + 0) * ICON_WIDTH, (TITLE_END_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
   sprintf(tempstr, "Y:%.2f  ", coordinateGetAxisActual(Y_AXIS));
-  GUI_DispString(START_X + (OFFSET + 1) * SPACE_X + (OFFSET + 1) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
+  GUI_DispString(START_X + (OFFSET + 1) * SPACE_X + (OFFSET + 1) * ICON_WIDTH, (TITLE_END_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
   sprintf(tempstr, "Z:%.2f  ", coordinateGetAxisActual(Z_AXIS));
-  GUI_DispString(START_X + (OFFSET + 2) * SPACE_X + (OFFSET + 2) * ICON_WIDTH, (ICON_START_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
+  GUI_DispString(START_X + (OFFSET + 2) * SPACE_X + (OFFSET + 2) * ICON_WIDTH, (TITLE_END_Y - BYTE_HEIGHT) / 2, (uint8_t *)tempstr);
 
   GUI_SetColor(infoSettings.font_color);
 }
@@ -65,20 +67,20 @@ void menuMove(void)
     {
       #ifdef ALTERNATIVE_MOVE_MENU
         {ICON_Z_DEC,                   LABEL_Z_DEC},
-        {ICON_Y_INC,                   LABEL_Y_INC},
+        {ICON_Y_INC,                   LABEL_Y_DEC},
         {ICON_Z_INC,                   LABEL_Z_INC},
         {ICON_01_MM,                   LABEL_01_MM},
         {ICON_X_DEC,                   LABEL_X_DEC},
-        {ICON_Y_DEC,                   LABEL_Y_DEC},
+        {ICON_Y_DEC,                   LABEL_Y_INC},
         {ICON_X_INC,                   LABEL_X_INC},
         {ICON_BACK,                    LABEL_BACK},
       #else
         {ICON_X_INC,                   LABEL_X_INC},
-        {ICON_Y_INC,                   LABEL_Y_INC},
+        {ICON_Y_DEC,                   LABEL_Y_INC},
         {ICON_Z_INC,                   LABEL_Z_INC},
         {ICON_01_MM,                   LABEL_01_MM},
         {ICON_X_DEC,                   LABEL_X_DEC},
-        {ICON_Y_DEC,                   LABEL_Y_DEC},
+        {ICON_Y_INC,                   LABEL_Y_DEC},
         {ICON_Z_DEC,                   LABEL_Z_DEC},
         {ICON_BACK,                    LABEL_BACK},
       #endif
@@ -96,12 +98,12 @@ void menuMove(void)
   uint8_t table[TOTAL_AXIS][2] =
     #ifdef ALTERNATIVE_MOVE_MENU
       /*-------*-------*-------*---------*
-       | Z-(0) | Y+(1) | Z+(2) | unit(3) |
+       | Z-(0) | Y-(1) | Z+(2) | unit(3) |
        *-------*-------*-------*---------*
-       | X-(4) | Y-(5) | X+(6) | back(7) |
+       | X-(4) | Y+(5) | X+(6) | back(7) |
        *-------*-------*-------*---------*
        |X+ X-  |Y+ Y-  |Z+ Z-            */
-      {{6, 4}, {1, 5}, {2, 0}}
+      {{6, 4}, {5, 1}, {2, 0}}
     #else
       /*-------*-------*-------*---------*
        | X+(0) | Y+(1) | Z+(2) | unit(3) |
@@ -141,7 +143,7 @@ void menuMove(void)
     {
       #ifdef ALTERNATIVE_MOVE_MENU
         case KEY_ICON_0: storeMoveCmd(Z_AXIS, -amount); break;  // Z move down if no invert
-        case KEY_ICON_1: storeMoveCmd(Y_AXIS, amount); break;   // Y move increase if no invert
+        case KEY_ICON_1: storeMoveCmd(Y_AXIS, -amount); break;  // Y move decrease if no invert
         case KEY_ICON_2: storeMoveCmd(Z_AXIS, amount); break;   // Z move up if no invert
 
         case KEY_ICON_3:
@@ -154,7 +156,7 @@ void menuMove(void)
           break;
 
         case KEY_ICON_4: storeMoveCmd(X_AXIS, -amount); break;  // X move decrease if no invert
-        case KEY_ICON_5: storeMoveCmd(Y_AXIS, -amount); break;  // Y move decrease if no invert
+        case KEY_ICON_5: storeMoveCmd(Y_AXIS, amount); break;   // Y move increase if no invert
         case KEY_ICON_6: storeMoveCmd(X_AXIS, amount); break;   // X move increase if no invert
 
         case KEY_ICON_7: CLOSE_MENU(); break;


### PR DESCRIPTION
### Requirements

BTT or MKS TFT

### Description

This PR brings small cosmetics to the Move menu.

Y+ and Y- icons were confusing as the icon associated to Y+ clearly shows the bed moving to back and the icon associated to Y- clearly shows a bed mowing forward. As most of printers have the zero position when the bed is fully on the back, moving the bed to the back the Y coordinate decreases and moving the bed to forward the Y coordinate increases.
In this PR the icons representation now correspond to the actual movement of the bed.

The coordinate values on the top of the display got a small attention, they are moved to the same height as reminders and menu names are, when a reminder is displayed, it will remain visible until it naturally goes away, than the coordinate values are visible again.

Before:

![Move_2](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/assets/50251547/8f9d7be8-f874-421f-87f8-32f87053c3fd)

![Move_3](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/assets/50251547/6315dfd0-5646-4550-9a6d-669c7d59d794)



After:

![Move_0](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/assets/50251547/207488a8-9e6b-42c3-b023-6e4f76f5c1b9)

![Move_1](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/assets/50251547/ed985087-9587-4685-b73c-564a7bf6e5d6)

![Move_6](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/assets/50251547/11ffb5fd-a5a3-44b1-a1f9-b32a31368e29)
