### PR TITLE
🔨 CI fixes: Bump Checkout to V3, use Python 3.7 and update README Badges

### DIFF
--- a/.github/workflows/buildBinary.yml
+++ b/.github/workflows/buildBinary.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.7'
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.7'
 
       - name: Install PlatformIO
         run: |

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # BigTreeTech TFT Touchscreen
 
-![GitHub](https://img.shields.io/github/license/bigtreetech/bigtreetech-TouchScreenFirmware.svg)
+<a href="https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/blob/master/LICENSE"><img alt="license" src="https://img.shields.io/github/license/bigtreetech/bigtreetech-TouchScreenFirmware.svg"></a>
 [![GitHub contributors](https://img.shields.io/github/contributors/bigtreetech/bigtreetech-TouchScreenFirmware.svg)](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/graphs/contributors)
-![GitHub Release Date](https://img.shields.io/github/release-date/bigtreetech/bigtreetech-TouchScreenFirmware.svg)
-[![Build Status](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/workflows/Build%20Test/badge.svg?branch=master)](https://github.com/bigtreetech/bigtreetech-TouchScreenFirmware/actions)
+<a href="https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/archive/refs/heads/master.zip"><img alt="release date" src="https://img.shields.io/github/last-commit/bigtreetech/BIGTREETECH-TouchScreenFirmware/master.svg?label=release%20date"></a>
+[![Build Binaries](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/actions/workflows/buildBinary.yml/badge.svg)](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/actions/workflows/buildBinary.yml)
 
 Important information related to BigTreeTech's TFT touchscreen 3D printer controllers
 


### PR DESCRIPTION
### Description

- CI fixes:
  - Bump Checkout to V3
  - Use Python 3.7
- Update badges in README:
  - Link to License
  - Use last commit as release date and link to master.zip
  - Fix Build Binary CI badge

_Note: The Build Binaries action will run after the next PR merge/commit since the `.github` folder & `*.md` files are excluded._

### Benefits

PR checks & build binary scripts will work again.

### Related Issues

None. Noticed that CI tasks were broken again.
