### PR TITLE
Buzzer based on HW Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ OctoPrint, ESP3D, Pronterface etc, connected to a TFT's serial port, can browse 
 **NOTES:**
 - TFT's media devices, if any, does not need to be initialized/released
 - When present, the G-code's options (e.g. `M27 C`) have the same meaning like in Marlin fw
+- G-code **M300 TFT P0** (with a duration of 0 ms) will mute (with the exception of touch type sound, if enabled) the TFT if not already muted while a duration different than 0 will unmute the TFT if not already unmuted
 
 ### Printing from Remote Host
 

--- a/TFT/src/User/API/BuzzerControl.c
+++ b/TFT/src/User/API/BuzzerControl.c
@@ -1,10 +1,88 @@
 #include "BuzzerControl.h"
 #include "includes.h"
 
-#define SILENCE            0
-#define B_SUBOCTAVE3       494
+#ifdef BUZZER_PIN
+
+#define SILENCE              0
+
+#define C_SUBOCTAVE6         33
+#define C_SHARP_SUBOCTAVE6   35
+#define D_SUBOCTAVE6         37
+#define D_SHARP_SUBOCTAVE6   39
+#define E_SUBOCTAVE6         41
+#define F_SUBOCTAVE6         44
+#define F_SHARP_SUBOCTAVE6   46
+#define G_SUBOCTAVE6         49
+#define G_SHARP_SUBOCTAVE6   52
+#define A_SUBOCTAVE6         55
+#define A_SHARP_SUBOCTAVE6   58
+#define B_SUBOCTAVE6         62
+
+#define C_SUBOCTAVE5         65
+#define C_SHARP_SUBOCTAVE5   69
+#define D_SUBOCTAVE5         73
+#define D_SHARP_SUBOCTAVE5   78
+#define E_SUBOCTAVE5         82
+#define F_SUBOCTAVE5         87
+#define F_SHARP_SUBOCTAVE5   93
+#define G_SUBOCTAVE5         98
+#define G_SHARP_SUBOCTAVE5  104
+#define A_SUBOCTAVE5        110
+#define A_SHARP_SUBOCTAVE5  117
+#define B_SUBOCTAVE5        123
+
+#define C_SUBOCTAVE4        131
+#define C_SHARP_SUBOCTAVE4  139
+#define D_SUBOCTAVE4        147
+#define D_SHARP_SUBOCTAVE4  156
+#define E_SUBOCTAVE4        165
+#define F_SUBOCTAVE4        175
+#define F_SHARP_SUBOCTAVE4  185
+#define G_SUBOCTAVE4        196
+#define G_SHARP_SUBOCTAVE4  208
+#define A_SUBOCTAVE4        220
+#define A_SHARP_SUBOCTAVE4  233
+#define B_SUBOCTAVE4        247
+
+#define C_SUBOCTAVE3        262
+#define C_SHARP_SUBOCTAVE3  277
+#define D_SUBOCTAVE3        294
+#define D_SHARP_SUBOCTAVE3  311
+#define E_SUBOCTAVE3        330
+#define F_SUBOCTAVE3        349
+#define F_SHARP_SUBOCTAVE3  370
+#define G_SUBOCTAVE3        392
+#define G_SHARP_SUBOCTAVE3  415
+#define A_SUBOCTAVE3        440
+#define A_SHARP_SUBOCTAVE3  466
+#define B_SUBOCTAVE3        494
+
+#define C_SUBOCTAVE2        523
+#define C_SHARP_SUBOCTAVE2  554
+#define D_SUBOCTAVE2        587
+#define D_SHARP_SUBOCTAVE2  622
+#define E_SUBOCTAVE2        659
+#define F_SUBOCTAVE2        698
+#define F_SHARP_SUBOCTAVE2  740
+#define G_SUBOCTAVE2        784
+#define G_SHARP_SUBOCTAVE2  831
+#define A_SUBOCTAVE2        880
+#define A_SHARP_SUBOCTAVE2  932
+#define B_SUBOCTAVE2        988
+
+#define C_SUBOCTAVE1       1047
+#define C_SHARP_SUBOCTAVE1 1109
+#define D_SUBOCTAVE1       1175
+#define D_SHARP_SUBOCTAVE1 1245
+#define E_SUBOCTAVE1       1319
+#define F_SUBOCTAVE1       1397
 #define F_SHARP_SUBOCTAVE1 1480
+#define G_SUBOCTAVE1       1568
+#define G_SHARP_SUBOCTAVE1 1661
+#define A_SUBOCTAVE1       1760
+#define A_SHARP_SUBOCTAVE1 1865
 #define B_SUBOCTAVE1       1976
+
 #define C_BASE             2093
 #define C_SHARP_BASE       2217
 #define D_BASE             2349
@@ -17,6 +95,7 @@
 #define A_BASE             3520
 #define A_SHARP_BASE       3729
 #define B_BASE             3951
+
 #define C_OCTAVE1          4186
 #define C_SHARP_OCTAVE1    4435
 #define D_OCTAVE1          4699
@@ -29,117 +108,122 @@
 #define A_OCTAVE1          7040
 #define A_SHARP_OCTAVE1    7459
 #define B_OCTAVE1          7902
-#define C_OCTAVE2          8372
-#define C_SHARP_OCTAVE2    8870
-#define D_OCTAVE2          9397
-#define D_SHARP_OCTAVE2    9956
-#define E_OCTAVE2          10548
-#define F_OCTAVE2          11175
-#define F_SHARP_OCTAVE2    11840
-#define G_OCTAVE2          12544
-#define G_SHARP_OCTAVE2    13290
-#define A_OCTAVE2          14080
-#define A_SHARP_OCTAVE2    14917
-#define B_OCTAVE2          15804
 
-#ifdef BUZZER_PIN
+#define NO_SOUNDS_SET 0xFF  // flag to indicate no sound set
 
-void Buzzer_play(SOUND sound)
+static uint8_t origSounds = NO_SOUNDS_SET;
+
+void Buzzer_HandleMute(bool mute)
+{
+  if (mute && origSounds == NO_SOUNDS_SET)  // if mute is requested and sounds not already muted, mute all sounds
+  {
+    origSounds = infoSettings.sounds;                                     // backup current sounds setting
+    infoSettings.sounds = infoSettings.sounds & (1 << SOUND_TYPE_TOUCH);  // mute all sounds with the exception of touch sound if enabled
+  }
+  else if (!mute && origSounds != NO_SOUNDS_SET)  // if unmute is requested and sounds not already unmuted, restore sounds setting
+  {
+    infoSettings.sounds = origSounds;  // restore original sounds setting
+    origSounds = NO_SOUNDS_SET;        // reset flag
+  }
+}
+
+void Buzzer_Play(SOUND sound)
 {
   switch (sound)
   {
-    case SOUND_OK:
-      if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
-      {
-        Buzzer_TurnOn(A_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 40);
-        Buzzer_TurnOn(E_OCTAVE1, 50);
-      }
-      break;
-
     case SOUND_SUCCESS:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
       {
-        Buzzer_TurnOn(A_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 50);
-        Buzzer_TurnOn(A_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 50);
-        Buzzer_TurnOn(A_BASE, 50);
+        Buzzer_AddSound(A_BASE, 50);
+        Buzzer_AddSound(SILENCE, 50);
+        Buzzer_AddSound(A_BASE, 50);
+        Buzzer_AddSound(SILENCE, 50);
+        Buzzer_AddSound(A_BASE, 50);
+      }
+      break;
+
+    case SOUND_ERROR:
+      if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
+      {
+        Buzzer_AddSound(C_SHARP_BASE, 200);
+        Buzzer_AddSound(SILENCE, 60);
+        Buzzer_AddSound(C_SHARP_BASE, 200);
+        Buzzer_AddSound(SILENCE, 60);
+        Buzzer_AddSound(C_SHARP_BASE, 200);
+      }
+      break;
+
+    case SOUND_OK:
+      if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
+      {
+        Buzzer_AddSound(G_BASE, 50);
+        Buzzer_AddSound(SILENCE, 40);
+        Buzzer_AddSound(C_OCTAVE1, 50);
       }
       break;
 
     case SOUND_CANCEL:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
       {
-        Buzzer_TurnOn(E_OCTAVE1, 50);
-        Buzzer_TurnOn(SILENCE, 20);
-        Buzzer_TurnOn(A_BASE, 40);
+        Buzzer_AddSound(E_OCTAVE1, 50);
+        Buzzer_AddSound(SILENCE, 20);
+        Buzzer_AddSound(A_BASE, 40);
       }
       break;
 
     case SOUND_NOTIFY:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
       {
-        Buzzer_TurnOn(G_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 50);
-        Buzzer_TurnOn(C_OCTAVE1, 50);
+        Buzzer_AddSound(G_BASE, 50);
+        Buzzer_AddSound(SILENCE, 50);
+        Buzzer_AddSound(C_OCTAVE1, 50);
       }
       break;
-
-    case SOUND_ERROR:
-    {
-      Buzzer_TurnOn(C_SHARP_BASE, 200);
-      Buzzer_TurnOn(SILENCE, 60);
-      Buzzer_TurnOn(C_SHARP_BASE, 200);
-      Buzzer_TurnOn(SILENCE, 60);
-      Buzzer_TurnOn(C_SHARP_BASE, 200);
-    }
-    break;
 
     case SOUND_DENY:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_ALERT))
       {
-        Buzzer_TurnOn(B_SUBOCTAVE3, 10);
-        Buzzer_TurnOn(E_OCTAVE2, 20);
+        Buzzer_AddSound(B_SUBOCTAVE3, 10);
+        Buzzer_AddSound(B_OCTAVE1, 20);
       }
       break;
 
     case SOUND_TOAST:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_TOAST))
       {
-        Buzzer_TurnOn(F_SHARP_SUBOCTAVE1, 30);
-        Buzzer_TurnOn(B_SUBOCTAVE1, 30);
+        Buzzer_AddSound(F_SHARP_SUBOCTAVE1, 30);
+        Buzzer_AddSound(B_SUBOCTAVE1, 30);
       }
       break;
 
     case SOUND_HEATED:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_HEATER))
       {
-        Buzzer_TurnOn(G_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 50);
-        Buzzer_TurnOn(B_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 100);
-        Buzzer_TurnOn(B_BASE, 50);
+        Buzzer_AddSound(G_BASE, 50);
+        Buzzer_AddSound(SILENCE, 50);
+        Buzzer_AddSound(B_BASE, 50);
+        Buzzer_AddSound(SILENCE, 100);
+        Buzzer_AddSound(B_BASE, 50);
       }
       break;
 
     case SOUND_COOLED:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_HEATER))
       {
-        Buzzer_TurnOn(B_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 50);
-        Buzzer_TurnOn(G_BASE, 50);
-        Buzzer_TurnOn(SILENCE, 100);
-        Buzzer_TurnOn(G_BASE, 50);
+        Buzzer_AddSound(B_BASE, 50);
+        Buzzer_AddSound(SILENCE, 50);
+        Buzzer_AddSound(G_BASE, 50);
+        Buzzer_AddSound(SILENCE, 100);
+        Buzzer_AddSound(G_BASE, 50);
       }
       break;
 
     case SOUND_KEYPRESS:
     default:
       if (GET_BIT(infoSettings.sounds, SOUND_TYPE_TOUCH))
-        Buzzer_TurnOn(BUZZER_FREQUENCY_HZ, BUZZER_FREQUENCY_DURATION_MS);
+        Buzzer_AddSound(BUZZER_FREQUENCY_HZ, BUZZER_FREQUENCY_DURATION_MS);
       break;
   }
-} // Buzzer_play
+}
 
 #endif  // BUZZER_PIN

--- a/TFT/src/User/API/BuzzerControl.h
+++ b/TFT/src/User/API/BuzzerControl.h
@@ -5,26 +5,34 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include "variants.h"  // for BUZZER_PIN etc...
 
 typedef enum
 {
+  // alert sound types
   SOUND_SUCCESS = 0,
   SOUND_ERROR,
   SOUND_OK,
   SOUND_CANCEL,
   SOUND_NOTIFY,
   SOUND_DENY,
+  // toast sound types
   SOUND_TOAST,
-  SOUND_KEYPRESS,
+  // heater sound types
   SOUND_HEATED,
   SOUND_COOLED,
+  // touch sound types
+  SOUND_KEYPRESS,
 } SOUND;
 
 #ifdef BUZZER_PIN
-  void Buzzer_play(SOUND sound);
+  // mute (with the exception of touch type sound, if enabled) or unmute the TFT if not already muted/unmuted respectively
+  void Buzzer_HandleMute(bool mute);
 
-  #define BUZZER_PLAY(x) Buzzer_play(x)
+  void Buzzer_Play(SOUND sound);
+
+  #define BUZZER_PLAY(x) Buzzer_Play(x)
 #else
   #define BUZZER_PLAY(x)
 #endif

--- a/TFT/src/User/API/LCD_Colors.h
+++ b/TFT/src/User/API/LCD_Colors.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
-#include "Configuration.h"  // for KEYBOARD_MATERIAL_THEME etc...
+#include "Configuration.h"  // for KEYBOARD_MATERIAL_THEME, LIVE_TEXT_COMMON_COLOR etc...
 #include "menu.h"
 
 // Color Definition

--- a/TFT/src/User/API/Mainboard_FlowControl.c
+++ b/TFT/src/User/API/Mainboard_FlowControl.c
@@ -76,11 +76,6 @@ void loopBackEnd(void)
   if (infoMachineSettings.onboardSD == ENABLED)
     loopPrintFromOnboard();
 
-  // buzzer handling
-  #ifdef BUZZER_PIN
-    loopBuzzer();
-  #endif
-
   // check filament runout status
   #ifdef FIL_RUNOUT_PIN
     FIL_BE_CheckRunout();

--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -1396,7 +1396,7 @@
  * Enable alternative Move Menu Buttons Layout matching the direction
  * of actual printer axis Update the icons from alternate icon folder.
  */
-//#define ALTERNATIVE_MOVE_MENU  // Default: uncommented (enabled)
+#define ALTERNATIVE_MOVE_MENU  // Default: uncommented (enabled)
 
 /**
  * Friendly Z Offset Language

--- a/TFT/src/User/Hal/buzzer.c
+++ b/TFT/src/User/Hal/buzzer.c
@@ -4,31 +4,28 @@
 
 #ifdef BUZZER_PIN
 
-#define BUZZER_CACHE_SIZE 5
+#define BUZZER_CACHE_SIZE 16  // queue to store 16 sounds (1 sound takes 4 bytes)
+#define SILENCE_FREQ      0   // frequency of 0 indicates silence/pause in the sound
 
-typedef struct
+typedef volatile struct
 {
-  uint32_t frequency[BUZZER_CACHE_SIZE];
-  uint32_t duration[BUZZER_CACHE_SIZE];
-  uint16_t wIndex;
-  uint16_t rIndex;
-  uint16_t count;
+  uint16_t frequency[BUZZER_CACHE_SIZE];
+  uint16_t duration[BUZZER_CACHE_SIZE];
+  uint32_t wIndex;
+  uint32_t rIndex;
+  int32_t toggles;  // number of half periods for the sound
 } BUZZER;
 
 static BUZZER buzzer;
-volatile uint32_t buzzerEndTime = 0;
-volatile uint32_t toggles = 0;
 
-void TIM3_Config(void)
+void Buzzer_ConfigTimer(void)
 {
 #if defined(GD32F2XX) || defined(GD32F3XX)
-  nvic_irq_enable(TIMER2_IRQn, 1U, 0U);
-
-  rcu_periph_clock_enable(RCU_TIMER2);
-  TIMER_CTL0(TIMER2)     &= ~TIMER_CTL0_CEN;
-  TIMER_DMAINTEN(TIMER2) |= TIMER_DMAINTEN_UPIE;
-  TIMER_INTF(TIMER2)     &= ~TIMER_INTF_UPIF;
-  TIMER_CAR(TIMER2)      = mcuClocks.PCLK1_Timer_Frequency / 1000000 - 1;
+  rcu_periph_clock_enable(RCU_TIMER2);                                // enable timer clock
+  TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;                              // disable timer
+  TIMER_INTF(TIMER2) &= ~TIMER_INTF_UPIF;                             // clear update interrupt flag
+  TIMER_DMAINTEN(TIMER2) |= TIMER_DMAINTEN_UPIE;                      // enable update interrupt
+  TIMER_CAR(TIMER2) = mcuClocks.PCLK1_Timer_Frequency / 1000000 - 1;  // 1 count = 1us
 #else
   NVIC_InitTypeDef NVIC_InitStructure;
 
@@ -38,122 +35,170 @@ void TIM3_Config(void)
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
 
-  RCC->APB1ENR |= RCC_APB1Periph_TIM3;
-  TIM3->CR1 &= ~TIM_CR1_CEN;
-  TIM3->DIER |= TIM_DIER_UIE;
-  TIM3->SR &= ~TIM_SR_UIF;
-  TIM3->ARR = mcuClocks.PCLK1_Timer_Frequency / 1000000 - 1;  // 20hz to 1Mhz
+  RCC->APB1ENR |= RCC_APB1Periph_TIM3;                        // enable timer clock
+  TIM3->CR1 &= ~TIM_CR1_CEN;                                  // disable timer
+  TIM3->SR &= ~TIM_SR_UIF;                                    // clear update interrupt flag
+  TIM3->DIER |= TIM_DIER_UIE;                                 // enable update interrupt
+  TIM3->ARR = mcuClocks.PCLK1_Timer_Frequency / 1000000 - 1;  // 1 count = 1us
 #endif
 }
-
-#if defined(GD32F2XX) || defined(GD32F3XX)
-void TIMER2_IRQHandler(void)
-{
-  if ((TIMER_INTF(TIMER2) & TIMER_INTF_UPIF) != 0)  // update interrupt flag
-  {
-    if (toggles != 0)
-    {
-      toggles--;
-      GPIO_ToggleLevel(BUZZER_PIN);
-    }
-    else
-    {
-      TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;  // stop timer
-    }
-    TIMER_INTF(TIMER2) &= ~TIMER_INTF_UPIF;  // clear interrupt flag
-  }
-}
-#else
-void TIM3_IRQHandler(void)
-{
-  if ((TIM3->SR & TIM_SR_UIF) != 0)  // update interrupt flag
-  {
-    if (toggles != 0)
-    {
-      toggles--;
-      GPIO_ToggleLevel(BUZZER_PIN);
-    }
-    else
-    {
-      TIM3->CR1 &= ~TIM_CR1_CEN;  // stop timer
-    }
-    TIM3->SR &= ~TIM_SR_UIF;  // clear interrupt flag
-  }
-}
-#endif
 
 void Buzzer_Config(void)
 {
   GPIO_InitSet(BUZZER_PIN, MGPIO_MODE_OUT_PP, 0);
-  TIM3_Config();
+  Buzzer_ConfigTimer();
+  buzzer.wIndex = buzzer.rIndex = buzzer.toggles = 0;
 }
 
 void Buzzer_DeConfig(void)
 {
   GPIO_InitSet(BUZZER_PIN, MGPIO_MODE_IPN, 0);
-}
+  buzzer.wIndex = buzzer.rIndex = buzzer.toggles = 0;
 
-void Buzzer_TurnOn(const uint16_t frequency, const uint16_t duration)
-{
-  while (buzzer.count == BUZZER_CACHE_SIZE)
-  {
-    loopBuzzer();
-  }
-  buzzer.duration[buzzer.wIndex] = duration;
-  buzzer.frequency[buzzer.wIndex] = frequency;
-  buzzer.wIndex = (buzzer.wIndex + 1) % BUZZER_CACHE_SIZE;
-  buzzer.count++;
-}
-
-void tone(const uint16_t frequency, const uint16_t duration)
-{
-  if (frequency == 0 || duration == 0) return;
 #if defined(GD32F2XX) || defined(GD32F3XX)
-  nvic_irq_disable(TIMER2_IRQn);
-  toggles = 2 * (frequency * duration / 1000);  // must have an even value
-
-  TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;  // disable timer2
-  TIMER_CNT(TIMER2) = 0;
-  TIMER_PSC(TIMER2) = (1000000 / (2 * frequency)) - 1;
-  TIMER_CTL0(TIMER2) |= TIMER_CTL0_CEN;
-
-  nvic_irq_enable(TIMER2_IRQn, 1, 0);
+  nvic_irq_disable(TIMER2_IRQn);          // disable timer interrupt
+  TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;  // stop timer
 #else
-  NVIC_DisableIRQ(TIM3_IRQn);
-  toggles = 2 * (frequency * duration / 1000);  // must have an even value
-
-  TIM3->CR1 &= ~TIM_CR1_CEN;
-  TIM3->CNT =0;
-  TIM3->PSC = (1000000 / (2 * frequency)) - 1;
-  TIM3->CR1 |= TIM_CR1_CEN;
-
-  NVIC_EnableIRQ(TIM3_IRQn);
+  NVIC_DisableIRQ(TIM3_IRQn);             // disable timer interrupt
+  TIM3->CR1 &= ~TIM_CR1_CEN;              // stop timer
 #endif
 }
 
-void loopBuzzer(void)
+// play a tone with the help of interrupts
+void Buzzer_PlaySound(uint16_t frequency, const uint16_t duration)
 {
-  if (!buzzerEndTime)
+  uint32_t silence = (frequency == SILENCE_FREQ);       // frequency == 0 indicates silence/pause in the sound
+
+  if (silence)
+    frequency = 1000;                                   // give 1ms resolution for silence
+
+#if defined(GD32F2XX) || defined(GD32F3XX)
+  nvic_irq_disable(TIMER2_IRQn);                        // disable timer interrupt
+  buzzer.toggles = 2 * (frequency * duration / 1000);   // 2 toggles per period
+  TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;                // disable timer
+  TIMER_CNT(TIMER2) = 0;                                // reset counter
+  TIMER_PSC(TIMER2) = (1000000 / (2 * frequency)) - 1;  // prescaler, half period time in us
+  TIMER_CTL0(TIMER2) |= TIMER_CTL0_CEN;                 // enable timer
+  nvic_irq_enable(TIMER2_IRQn, 1U, 0U);                 // enable timer interrupt
+#else
+  NVIC_DisableIRQ(TIM3_IRQn);                           // disable timer interrupt
+  buzzer.toggles = 2 * (frequency * duration / 1000);   // 2 toggles per period
+  TIM3->CR1 &= ~TIM_CR1_CEN;                            // disable timer
+  TIM3->CNT = 0;                                        // reset counter
+  TIM3->PSC = (1000000 / (2 * frequency)) - 1;          // prescaler, half period time in us
+  TIM3->CR1 |= TIM_CR1_CEN;                             // enable timer
+  NVIC_EnableIRQ(TIM3_IRQn);                            // enable interrupt
+#endif
+
+  if (silence)
+    buzzer.toggles = -buzzer.toggles;                   // setup for silence, negative toggles
+}
+
+// play a sound from sound queue. Called by timer interrupt and Buzzer_AddSound() function
+void Buzzer_GetSound(void)
+{
+  // stop timer
+#if defined(GD32F2XX) || defined(GD32F3XX)
+  TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;
+#else
+  TIM3->CR1 &= ~TIM_CR1_CEN;
+#endif
+
+  if (buzzer.rIndex != buzzer.wIndex)  // play a queued sound, if any
   {
-    if (buzzer.count == 0) return;
-    buzzerEndTime = OS_GetTimeMs() + buzzer.duration[buzzer.rIndex];
-    if (buzzer.frequency[buzzer.rIndex] > 0)
-    {
-      tone(buzzer.frequency[buzzer.rIndex], buzzer.duration[buzzer.rIndex]);
-    }
-    buzzer.rIndex = (buzzer.rIndex + 1) % BUZZER_CACHE_SIZE;
-    buzzer.count--;
+    Buzzer_PlaySound(buzzer.frequency[buzzer.rIndex], buzzer.duration[buzzer.rIndex]);
+
+    if (++buzzer.rIndex >= BUZZER_CACHE_SIZE)  // update and check rIndex
+      buzzer.rIndex = 0;
   }
-  else if (OS_GetTimeMs() > buzzerEndTime && toggles == 0)
+  else
   {
-    buzzerEndTime = 0;
-  #if defined(GD32F2XX) || defined(GD32F3XX)
-    TIMER_CTL0(TIMER2) &= ~TIMER_CTL0_CEN;
-  #else
-    TIM3->CR1 &= ~TIM_CR1_CEN;  // stop timer (for safety)
-  #endif
-    GPIO_SetLevel(BUZZER_PIN, BUZZER_STOP_LEVEL);
+    GPIO_SetLevel(BUZZER_PIN, BUZZER_STOP_LEVEL);  // make sure to leave the buzzer in the unpowered state
   }
 }
+
+// store the sound in the queue, and start the sound if no sound is already playing
+void Buzzer_AddSound(const uint16_t frequency, const uint16_t duration)
+{
+  if (duration == 0)  // in case of a duration of 0 (it indicates silence), nothing to do
+    return;
+
+  // in case of sound queue full, overwrite the old sound data with the newest one
+
+  buzzer.duration[buzzer.wIndex] = duration;    // store sound duration
+  buzzer.frequency[buzzer.wIndex] = frequency;  // store sound frequency
+
+  if (++buzzer.wIndex >= BUZZER_CACHE_SIZE)     // update and check wIndex
+    buzzer.wIndex = 0;
+
+  // check if timer is running before playing the next queued sound
+#if defined(GD32F2XX) || defined(GD32F3XX)
+  if ((TIMER_CTL0(TIMER2) & TIMER_CTL0_CEN))
+    return;
+#else
+  if ((TIM3->CR1 & TIM_CR1_CEN))
+    return;
+#endif
+
+  Buzzer_GetSound();  // play next queued sound
+}
+
+#if defined(GD32F2XX) || defined(GD32F3XX)
+
+void TIMER2_IRQHandler(void)  // GD32F2XX and GD32F3XX timer ISR
+{
+  if ((TIMER_INTF(TIMER2) & TIMER_INTF_UPIF) != 0)  // check for timer2 interrupt flag
+  {
+    TIMER_INTF(TIMER2) &= ~TIMER_INTF_UPIF;         // clear interrupt flag
+
+    if (buzzer.toggles > 0)                           // if a sound has to be played
+    {
+      buzzer.toggles--;
+      GPIO_SetLevel(BUZZER_PIN, buzzer.toggles & 1);  // play sound
+    }
+    else
+    {
+      if (buzzer.toggles == 0)          // if a sound has been played
+      {
+        nvic_irq_disable(TIMER2_IRQn);  // disable timer interrupt
+        Buzzer_GetSound();              // play next queued sound
+      }
+      else                              // if a silence (buzzer.toggles < 0))
+      {
+        buzzer.toggles++;               // silence, no toggling, only counting
+      }
+    }
+  }
+}
+
+#else
+
+void TIM3_IRQHandler(void)  // STM32FXX timer ISR
+{
+  if ((TIM3->SR & TIM_SR_UIF) != 0)  // check for TIM3 interrupt flag
+  {
+    TIM3->SR &= ~TIM_SR_UIF;         // clear interrupt flag
+
+    if (buzzer.toggles > 0)                           // if a sound has to be played
+    {
+      buzzer.toggles--;
+      GPIO_SetLevel(BUZZER_PIN, buzzer.toggles & 1);  // play sound
+    }
+    else
+    {
+      if (buzzer.toggles == 0)       // if a sound has been played
+      {
+        NVIC_DisableIRQ(TIM3_IRQn);  // disable timer interrupt
+        Buzzer_GetSound();           // play next queued sound
+      }
+      else                           // if a silence (buzzer.toggles < 0))
+      {
+        buzzer.toggles++;            // silence, no toggling, only counting
+      }
+    }
+  }
+}
+
+#endif  // GD32F2XX and GD32F3XX
 
 #endif  // BUZZER_PIN

--- a/TFT/src/User/Hal/buzzer.h
+++ b/TFT/src/User/Hal/buzzer.h
@@ -11,8 +11,7 @@ extern "C" {
 #ifdef BUZZER_PIN
   void Buzzer_Config(void);
   void Buzzer_DeConfig(void);
-  void Buzzer_TurnOn(const uint16_t frequency, const uint16_t duration);
-  void loopBuzzer(void);
+  void Buzzer_AddSound(const uint16_t frequency, const uint16_t duration);
 #endif
 
 #ifdef __cplusplus

--- a/TFT/src/User/Menu/ConnectionSettings.c
+++ b/TFT/src/User/Menu/ConnectionSettings.c
@@ -26,10 +26,7 @@ void refreshConnection(void)
     #endif
   }
 
-  #ifdef BUZZER_PIN
-    BUZZER_PLAY(SOUND_KEYPRESS);
-    loopBuzzer();
-  #endif
+  BUZZER_PLAY(SOUND_KEYPRESS);
 
   while (TS_IsPressed())
   {

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -7,10 +7,10 @@
     moveItems.items[p1].label.index = LABEL_##axis##_##dir1; \
   } while (0)
 
-#define X_MOVE_GCODE "G0 X%.2f F%d\n"
-#define Y_MOVE_GCODE "G0 Y%.2f F%d\n"
-#define Z_MOVE_GCODE "G0 Z%.2f F%d\n"
-#define GANTRY_UPDATE_DELAY 500  // 1 seconds is 1000
+#define X_MOVE_GCODE        "G0 X%.2f F%d\n"  // X axis gcode
+#define Y_MOVE_GCODE        "G0 Y%.2f F%d\n"  // Y axis gcode
+#define Z_MOVE_GCODE        "G0 Z%.2f F%d\n"  // Z axis gcode
+#define GANTRY_REFRESH_TIME 500               // 1 seconds is 1000
 
 #ifdef PORTRAIT_MODE
   #define OFFSET 0
@@ -26,7 +26,7 @@ void storeMoveCmd(const AXIS xyz, const float amount)
 {
   // if invert is true, use 'amount' multiplied by -1
   storeCmd(xyzMoveCmd[xyz], GET_BIT(infoSettings.inverted_axis, xyz) ? -amount : amount,
-           ((xyz != Z_AXIS) ? infoSettings.xy_speed[infoSettings.move_speed] : infoSettings.z_speed[infoSettings.move_speed]));
+           xyz != Z_AXIS ? infoSettings.xy_speed[infoSettings.move_speed] : infoSettings.z_speed[infoSettings.move_speed]);
 
   nowAxis = xyz;  // update now axis
 }
@@ -53,7 +53,7 @@ void drawXYZ(void)
 
 static inline void updateGantry(void)
 {
-  if (nextScreenUpdate(GANTRY_UPDATE_DELAY))
+  if (nextScreenUpdate(GANTRY_REFRESH_TIME))
   {
     coordinateQuery(0);  // query position manually for delay less than 1 second
     drawXYZ();


### PR DESCRIPTION
As discussed with **@rondlh**, just posting here his reviewed PR #2852 to possibly speedup its merge. I used his buzzer implementation based on HW event since a lot of time with no issue at all. All credits to **@rondlh**.
IMHO, with this PR all the more important/useful features have been provided in the TFT and probably it will require from my side just a minor support for maintenance/real bug fixes if any will be reported by users.
This PR also includes a bug fix introduced by last merged PR #2889 causing an infinite sending loop for a gcode purged by the TFT.

Below just the description of this PR as provided by rondlh in his PR #2852.

**IMPROVEMENTS:**
This pull request consists out of 4 parts, here they are in order of importance:

**1. Print hesitation bugfix.** The current TFT sound playback system has a queue of 5 slots that stores the sounds to be played before playback starts. The problem with the current implementation is that if the queue is full, the sound system will block all processes until a sound queue slot becomes available. During this time even printing will be paused because the system is just waiting for a sound slot to become available. This behavior can cause hesitations in the printing process. This PR solves this issue by prioritizing the printing process over sound playback system so no print hesitation can occur because of sound playback.

**2. Event driven sounds, no polling.** Currently sounds are stored in the sound queue by gcode commands or if the system wants to playback a notification/error/warning sound. These events don't actually start the playback of the sounds. This happens in the main processLoop, where a check is done to see if there are sounds ready for playback in the queue. This process is called polling. This PR makes this process **event driven**, which means that the arrival of a sound for playback immediately start the sound playback, and the playback of any sounds that arrived afterwards. No check is required in the main loopProcess anymore. This will result in a small efficiency/speed improvement, and can serve as a example of how to efficiently implement event driven processes. Polling should be avoided when possible.

**3. Host sounds.** Most printer motherboards do not have a speaker/buzzer, one can be added of course, buy why not use the buzzer of the TFT? This process is supported by the Marlin ExtUI interface and works by forwarding the sound that should be played by the motherboard to the TFT. The TFT then takes care of the playback. This PR adds this capability.

**4. Remote sound mute/unmute.** Additional functionality is added to give the user remote sound control by allowing sounds to be enabled and disabled via the M300 commands. A ESP3D can be used to mute or unmute sounds remotely without using the touch screen.

### Benefits
1. Preventing possible printing hesitations causes by the sound playback when the sound queue is full.
2. Improving the TFT efficiency by not needing to poll the buzzer queue anymore, and showing how event triggering can be used to prevent polling.
3. TFT is capable of playing back sounds for the motherboard.
4. Remote mute/unmute sound control (via Wifi)

### Note
This PR affects hardware dependent code (interrupts), which requires testing to make sure the code works on all supported hardware platforms. Actually the changes made are quite small, sounds were already using interrupts. The main difference is that when a sound playback is completed, the process doesn't just exit to let the loopProcess restart it, instead the process check if more sounds need to be played and starts this task immediately, so no attention from loopProcess is needed. This code has been tested on STM32F1xx, STM32F2xx, STM32F4xx and GD32F2xx.

**BUG FIXES:**
- fixed a bug introduced by #2889 causing an infinite sending loop for a gcode purged by the TFT

resolves #2845
