### PR TITLE
Bugfixes on top of last merged PR

### DIFF
--- a/TFT/src/User/API/LCD_Dimming.c
+++ b/TFT/src/User/API/LCD_Dimming.c
@@ -4,6 +4,29 @@
 
 #ifdef LCD_LED_PWM_CHANNEL
 
+// in percentage 0-100
+#define BRIGHTNESS_0     0
+#define BRIGHTNESS_5     5
+#define BRIGHTNESS_10   10
+#define BRIGHTNESS_20   20
+#define BRIGHTNESS_30   30
+#define BRIGHTNESS_40   40
+#define BRIGHTNESS_50   50
+#define BRIGHTNESS_60   60
+#define BRIGHTNESS_70   70
+#define BRIGHTNESS_80   80
+#define BRIGHTNESS_90   90
+#define BRIGHTNESS_100 100
+
+// in seconds
+#define IDLE_TIME_OFF   0  // off
+#define IDLE_TIME_5     5
+#define IDLE_TIME_10   10
+#define IDLE_TIME_30   30
+#define IDLE_TIME_60   60
+#define IDLE_TIME_120 120
+#define IDLE_TIME_300 300
+
 const uint8_t lcd_brightness[LCD_BRIGHTNESS_COUNT] = {
   BRIGHTNESS_0,
   BRIGHTNESS_5,
@@ -27,7 +50,7 @@ const uint16_t lcd_idle_times[LCD_IDLE_TIME_COUNT] = {
   IDLE_TIME_60,
   IDLE_TIME_120,
   IDLE_TIME_300,
-  IDLE_TIME_CUSTOM
+  IDLE_TIME_CUSTOM  // custom value predefined in Configuration.h
 };
 
 const LABEL lcd_idle_time_names[LCD_IDLE_TIME_COUNT] = {

--- a/TFT/src/User/API/LCD_Dimming.h
+++ b/TFT/src/User/API/LCD_Dimming.h
@@ -5,32 +5,10 @@
 extern "C" {
 #endif
 
-#include "variants.h"  // for LCD_LED_PWM_CHANNEL
+#include "variants.h"  // for LCD_LED_PWM_CHANNEL, KNOB_LED_COLOR_PIN etc...
 #include "menu.h"
 
 #ifdef LCD_LED_PWM_CHANNEL
-
-  #define BRIGHTNESS_0     0
-  #define BRIGHTNESS_5     5
-  #define BRIGHTNESS_10   10
-  #define BRIGHTNESS_20   20
-  #define BRIGHTNESS_30   30
-  #define BRIGHTNESS_40   40
-  #define BRIGHTNESS_50   50
-  #define BRIGHTNESS_60   60
-  #define BRIGHTNESS_70   70
-  #define BRIGHTNESS_80   80
-  #define BRIGHTNESS_90   90
-  #define BRIGHTNESS_100 100
-
-  #define IDLE_TIME_OFF              0  // Off
-  #define IDLE_TIME_5                5  // seconds
-  #define IDLE_TIME_10              10  // seconds
-  #define IDLE_TIME_30              30  // seconds
-  #define IDLE_TIME_60              60  // seconds
-  #define IDLE_TIME_120            120  // seconds
-  #define IDLE_TIME_300            300  // seconds
-  //#define IDLE_TIME_CUSTOM IDLE_TIME_5  // custom value predefined in Configuration.h
 
   typedef enum
   {
@@ -58,7 +36,7 @@ extern "C" {
     LCD_IDLE_TIME_60,
     LCD_IDLE_TIME_120,
     LCD_IDLE_TIME_300,
-    LCD_IDLE_TIME_CUSTOM,
+    LCD_IDLE_TIME_CUSTOM,  // the related custom value is IDLE_TIME_CUSTOM predefined in Configuration.h
     LCD_IDLE_TIME_COUNT
   } LCD_IDLE_TIME_;
 

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -14,8 +14,6 @@ const uint16_t default_z_speed[]       = {SPEED_Z_SLOW, SPEED_Z_NORMAL, SPEED_Z_
 const uint16_t default_ext_speed[]     = {EXTRUDE_SLOW_SPEED, EXTRUDE_NORMAL_SPEED, EXTRUDE_FAST_SPEED};
 const uint16_t default_pause_speed[]   = {NOZZLE_PAUSE_XY_FEEDRATE, NOZZLE_PAUSE_Z_FEEDRATE, NOZZLE_PAUSE_E_FEEDRATE};
 const uint16_t default_level_speed[]   = {LEVELING_XY_FEEDRATE, LEVELING_Z_FEEDRATE};
-const uint16_t default_preheat_ext[]   = PREHEAT_HOTEND;
-const uint16_t default_preheat_bed[]   = PREHEAT_BED;
 const uint8_t default_led_color[]      = {LED_R, LED_G, LED_B, LED_W, LED_P, LED_I};
 const uint8_t default_custom_enabled[] = CUSTOM_GCODE_ENABLED;
 

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -288,7 +288,7 @@ typedef struct
 typedef struct
 {
   char preheat_name[PREHEAT_COUNT][MAX_STRING_LENGTH + 1];
-  uint16_t preheat_temp[PREHEAT_COUNT];
+  uint16_t preheat_hotend[PREHEAT_COUNT];
   uint16_t preheat_bed[PREHEAT_COUNT];
 } PREHEAT_STORE;
 
@@ -365,8 +365,6 @@ extern const uint16_t default_move_speed[];
 extern const uint16_t default_ext_speed[];
 extern const uint16_t default_level_speed[];
 extern const uint16_t default_pause_speed[];
-extern const uint16_t default_preheat_ext[];
-extern const uint16_t default_preheat_bed[];
 extern const uint8_t default_custom_enabled[];
 
 // Init settings data with default values

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -91,9 +91,6 @@ void heatSetCurrentTemp(uint8_t index, const int16_t temp)
     return;
 
   heater.T[index].current = NOBEYOND(-99, temp, 999);
-
-  if (infoMachineSettings.autoReportTemp)
-    heatSetNextUpdateTime();  // set next timeout for temperature auto-report
 }
 
 int16_t heatGetCurrentTemp(uint8_t index)

--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -866,17 +866,25 @@ void _GUI_DispStringOnIcon(uint16_t iconIndex, GUI_POINT iconPoint, GUI_POINT te
 {
   if (p == NULL) return;
 
-  CHAR_INFO info;
   uint16_t _iconBuffer[LARGE_BYTE_WIDTH * LARGE_BYTE_HEIGHT];
+  BMP_INFO iconInfo = {.index = iconIndex, .address = 0};
+  CHAR_INFO info;
 
   iconBuffer = _iconBuffer;
   GUI_SetTextMode(GUI_TEXTMODE_ON_ICON);
 
+  getBMPsize(&iconInfo);
+
   while (*p)
   {
     getCharacterInfo(p, &info);
-    ICON_ReadBuffer(iconBuffer, textPos.x, textPos.y, info.pixelWidth, info.pixelHeight, iconIndex);
-    GUI_DispOne(iconPoint.x + textPos.x, iconPoint.y + textPos.y, &info);
+
+    if ((textPos.x >= 0 && textPos.x + info.pixelWidth <= iconInfo.width) &&
+        (textPos.y >= 0 && textPos.y + info.pixelHeight <= iconInfo.height))
+    {
+      ICON_ReadBuffer(iconBuffer, textPos.x, textPos.y, info.pixelWidth, info.pixelHeight, iconIndex);
+      GUI_DispOne(iconPoint.x + textPos.x, iconPoint.y + textPos.y, &info);
+    }
 
     textPos.x += info.pixelWidth;
     p += info.bytes;

--- a/TFT/src/User/API/UI/ui_draw.h
+++ b/TFT/src/User/API/UI/ui_draw.h
@@ -46,12 +46,9 @@ typedef struct
   uint16_t height;
 } BMP_INFO;
 
-// uint32_t _getBMPsizeAddr(uint8_t *w, uint8_t *h, uint32_t address);
-// uint32_t _getBMPsizeIndex(uint8_t *w, uint8_t *h, uint16_t index);
-
-//#define getBMPsize(x, y, c) _Generic(((c+0)), uint32_t: _getBMPsizeAddr, uint32_t*: _getBMPsizeAddr, default: _getBMPsizeIndex)(x, y, c)
-
 void lcd_buffer_display(uint16_t sx, uint16_t sy, uint16_t w, uint16_t h, uint16_t *buf, GUI_RECT *limit);
+
+void getBMPsize(BMP_INFO *bmp);
 
 void LOGO_ReadDisplay(void);
 void ICON_ReadDisplay(uint16_t sx, uint16_t sy, uint8_t icon);

--- a/TFT/src/User/API/config.c
+++ b/TFT/src/User/API/config.c
@@ -213,15 +213,17 @@ const GUI_RECT  recterrortxt      = {BYTE_WIDTH/2,    BYTE_HEIGHT*2+4,    LCD_WI
 const GUI_RECT  rectProgressframe = {BYTE_WIDTH/2-2, LCD_HEIGHT-(BYTE_HEIGHT*2+BYTE_HEIGHT/2), LCD_WIDTH-BYTE_WIDTH/2+2,LCD_HEIGHT-BYTE_HEIGHT/2};
 const GUI_POINT pointProgressText = {BYTE_WIDTH/2-2, LCD_HEIGHT-(BYTE_HEIGHT*4)};
 
-const char * const cgList[] = CUSTOM_GCODE_LIST;
-const char * const cgNames[] = CUSTOM_GCODE_LABELS;
 const char * const preheatNames[] = PREHEAT_LABELS;
+const uint16_t preheatHotend[]    = PREHEAT_HOTEND;
+const uint16_t preheatBed[]       = PREHEAT_BED;
+const char * const cgNames[]      = CUSTOM_GCODE_LABELS;
+const char * const cgList[]       = CUSTOM_GCODE_LIST;
 
 CONFIGFILE* CurConfigFile;
-CUSTOM_GCODES* configCustomGcodes = NULL;
-PRINT_GCODES* configPrintGcodes = NULL;
 STRINGS_STORE* configStringsStore = NULL;
 PREHEAT_STORE* configPreheatStore = NULL;
+PRINT_GCODES* configPrintGcodes   = NULL;
+CUSTOM_GCODES* configCustomGcodes = NULL;
 
 char * cur_line = NULL;
 uint16_t c_index = 0;
@@ -577,7 +579,7 @@ void parseConfigKey(uint16_t index)
 
       case C_INDEX_MARLIN_TITLE:
       {
-        char * pchr = strrchr(cur_line, ':') + 1;
+        char * pchr = strchr(cur_line, ':') + 1;
         int utf8len = getUTF8Length((uint8_t*)pchr);
         int bytelen = strlen(pchr) + 1;
         if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_STRING_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
@@ -763,7 +765,7 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_PREHEAT_NAME_6:
     {
       char pchr[LINE_MAX_CHAR];
-      strcpy(pchr, strrchr(cur_line, ':') + 1);
+      strcpy(pchr, strchr(cur_line, ':') + 1);
       int utf8len = getUTF8Length((uint8_t *)pchr);
       int bytelen = strlen(pchr) + 1;
       if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_STRING_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_STRING_LENGTH))
@@ -779,7 +781,7 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_PREHEAT_TEMP_6:
     {
       int val_index = index - C_INDEX_PREHEAT_TEMP_1;
-      if (key_seen("T")) SET_VALID_INT_VALUE(configPreheatStore->preheat_temp[val_index], MIN_TOOL_TEMP, MAX_TOOL_TEMP);
+      if (key_seen("T")) SET_VALID_INT_VALUE(configPreheatStore->preheat_hotend[val_index], MIN_TOOL_TEMP, MAX_TOOL_TEMP);
       if (key_seen("B")) SET_VALID_INT_VALUE(configPreheatStore->preheat_bed[val_index], MIN_BED_TEMP, MAX_BED_TEMP);
       break;
     }
@@ -925,7 +927,7 @@ void parseConfigKey(uint16_t index)
     case C_INDEX_CUSTOM_LABEL_15:
     {
       char pchr[LINE_MAX_CHAR];
-      strcpy(pchr, strrchr(cur_line, ':') + 1);
+      strcpy(pchr, strchr(cur_line, ':') + 1);
       int utf8len = getUTF8Length((uint8_t*)pchr);
       int bytelen = strlen(pchr) + 1;
       if (inLimit(utf8len, NAME_MIN_LENGTH, MAX_GCODE_NAME_LENGTH) && inLimit(bytelen, NAME_MIN_LENGTH, MAX_GCODE_LENGTH))
@@ -957,7 +959,7 @@ void parseConfigKey(uint16_t index)
     {
       int lineIndex = index - C_INDEX_CUSTOM_GCODE_1;  // actual gcode index in config file
       char pchr[LINE_MAX_CHAR];
-      strcpy(pchr, strrchr(cur_line, ':') + 1);
+      strcpy(pchr, strchr(cur_line, ':') + 1);
       int len = strlen(pchr) + 1;
       // check if gcode length is ok and the name was ok
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH) && (customcode_good[lineIndex] == 1))
@@ -977,7 +979,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_START_GCODE:
     {
-      char * pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
@@ -994,7 +996,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_END_GCODE:
     {
-      char * pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
@@ -1011,7 +1013,7 @@ void parseConfigKey(uint16_t index)
 
     case C_INDEX_CANCEL_GCODE:
     {
-      char * pchr = strrchr(cur_line, ':') + 1;
+      char * pchr = strchr(cur_line, ':') + 1;
       int len = strlen(pchr);
       if (inLimit(len, GCODE_MIN_LENGTH, MAX_GCODE_LENGTH))
       {
@@ -1195,10 +1197,10 @@ void writeConfig(uint8_t * dataBytes, uint16_t numBytes, uint32_t addr, uint32_t
 
 void saveConfig(void)
 {
-  writeConfig((uint8_t *)configCustomGcodes, sizeof(CUSTOM_GCODES), CUSTOM_GCODE_ADDR, CUSTOM_GCODE_MAX_SIZE);
-  writeConfig((uint8_t *)configPrintGcodes, sizeof(PRINT_GCODES), PRINT_GCODES_ADDR, PRINT_GCODES_MAX_SIZE);
   writeConfig((uint8_t *)configStringsStore, sizeof(STRINGS_STORE), STRINGS_STORE_ADDR, STRINGS_STORE_MAX_SIZE);
   writeConfig((uint8_t *)configPreheatStore, sizeof(PREHEAT_STORE), PREHEAT_STORE_ADDR, PREHEAT_STORE_MAX_SIZE);
+  writeConfig((uint8_t *)configPrintGcodes, sizeof(PRINT_GCODES), PRINT_GCODES_ADDR, PRINT_GCODES_MAX_SIZE);
+  writeConfig((uint8_t *)configCustomGcodes, sizeof(CUSTOM_GCODES), CUSTOM_GCODE_ADDR, CUSTOM_GCODE_MAX_SIZE);
 
   #ifdef CONFIG_DEBUG
     CUSTOM_GCODES tempgcode;  // = NULL;
@@ -1214,30 +1216,20 @@ void saveConfig(void)
 // Reset & store config settings
 void resetConfig(void)
 {
-  CUSTOM_GCODES tempCG;
   STRINGS_STORE tempST;
-  PRINT_GCODES tempPC;
   PREHEAT_STORE tempPH;
-
-  // restore custom gcode presets
-  int n = 0;
-  for (int i = 0; i < CUSTOM_GCODES_COUNT; i++)
-  {
-    if (default_custom_enabled[i] == 1)
-    {
-      strcpy(tempCG.gcode[n],cgList[i]);
-      strcpy(tempCG.name[n],cgNames[i]);
-      n++;
-    }
-  }
-  tempCG.count = n;
+  PRINT_GCODES tempPC;
+  CUSTOM_GCODES tempCG;
 
   // restore strings store
   strcpy(tempST.marlin_title, MARLIN_TITLE);
 
+  // restore preheat presets
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
     strcpy(tempPH.preheat_name[i], preheatNames[i]);
+    tempPH.preheat_hotend[i] = preheatHotend[i];
+    tempPH.preheat_bed[i] = preheatBed[i];
   }
 
   // restore print gcodes
@@ -1245,10 +1237,24 @@ void resetConfig(void)
   strcpy(tempPC.end_gcode, END_GCODE);
   strcpy(tempPC.cancel_gcode, CANCEL_GCODE);
 
+  // restore custom gcode presets
+  int n = 0;
+  for (int i = 0; i < CUSTOM_GCODES_COUNT; i++)
+  {
+    if (default_custom_enabled[i] == 1)
+    {
+      strcpy(tempCG.name[n], cgNames[i]);
+      strcpy(tempCG.gcode[n], cgList[i]);
+      n++;
+    }
+  }
+  tempCG.count = n;
+
   // write restored config
-  writeConfig((uint8_t *)&tempCG, sizeof(CUSTOM_GCODES), CUSTOM_GCODE_ADDR, CUSTOM_GCODE_MAX_SIZE);
-  writeConfig((uint8_t *)&tempPC, sizeof(PRINT_GCODES), PRINT_GCODES_ADDR, PRINT_GCODES_MAX_SIZE);
   writeConfig((uint8_t *)&tempST, sizeof(STRINGS_STORE), STRINGS_STORE_ADDR, STRINGS_STORE_MAX_SIZE);
+  writeConfig((uint8_t *)&tempPH, sizeof(PREHEAT_STORE), PREHEAT_STORE_ADDR, PREHEAT_STORE_MAX_SIZE);
+  writeConfig((uint8_t *)&tempPC, sizeof(PRINT_GCODES), PRINT_GCODES_ADDR, PRINT_GCODES_MAX_SIZE);
+  writeConfig((uint8_t *)&tempCG, sizeof(CUSTOM_GCODES), CUSTOM_GCODE_ADDR, CUSTOM_GCODE_MAX_SIZE);
 }
 
 bool getConfigFromFile(char * configPath)
@@ -1259,18 +1265,25 @@ bool getConfigFromFile(char * configPath)
     return false;
   }
 
-  CUSTOM_GCODES tempCustomGcodes;
-  PRINT_GCODES tempPrintCodes;
-  STRINGS_STORE tempStringStore;
-  PREHEAT_STORE tempPreheatStore;
-
-  // initialize all settings to default values before eventually overwriting them with values from configuration file
+  // initialize all settings to default values before eventually overwriting them with the values from configuration file.
+  // resetConfig() function is also invoked by initSettings() function just to initialize the following 4 data structures
+  // into the flash before loading them from the flash
   initSettings();
 
-  configCustomGcodes = &tempCustomGcodes;
-  configPrintGcodes = &tempPrintCodes;
+  STRINGS_STORE tempStringStore;
+  PREHEAT_STORE tempPreheatStore;
+  PRINT_GCODES tempPrintCodes;
+  CUSTOM_GCODES tempCustomGcodes;
+
+  W25Qxx_ReadBuffer((uint8_t*)&tempStringStore, STRINGS_STORE_ADDR, sizeof(STRINGS_STORE));
+  W25Qxx_ReadBuffer((uint8_t*)&tempPreheatStore, PREHEAT_STORE_ADDR, sizeof(PREHEAT_STORE));
+  W25Qxx_ReadBuffer((uint8_t*)&tempPrintCodes, PRINT_GCODES_ADDR, sizeof(PRINT_GCODES));
+  W25Qxx_ReadBuffer((uint8_t*)&tempCustomGcodes, CUSTOM_GCODE_ADDR, sizeof(CUSTOM_GCODES));
+
   configStringsStore = &tempStringStore;
   configPreheatStore = &tempPreheatStore;
+  configPrintGcodes = &tempPrintCodes;
+  configCustomGcodes = &tempCustomGcodes;
   customcode_index = 0;
   foundkeys = 0;
 
@@ -1286,13 +1299,16 @@ bool getConfigFromFile(char * configPath)
 
     PRINTDEBUG("\nCustom gcode stored at 1:");
     PRINTDEBUG(configCustomGcodes->gcode[1]);
+
     if (scheduleRotate)
     {
       LCD_RefreshDirection(infoSettings.rotated_ui);
       TS_Calibrate();
     }
+
     storePara();  // TODO: The touch sign will also be written if the touch calibration data is invalid
     saveConfig();
+
     PRINTDEBUG("config saved\n");
     return true;
   }

--- a/TFT/src/User/Menu/MeshValid.c
+++ b/TFT/src/User/Menu/MeshValid.c
@@ -48,7 +48,7 @@ void menuMeshValid(void)
       // MESHVALID NYLON
       case KEY_ICON_5:
         mustStoreCmd("G28\n");
-        mustStoreCmd("G26 H%u B%u R99\n", preheatStore.preheat_temp[key_num], preheatStore.preheat_bed[key_num]);
+        mustStoreCmd("G26 H%u B%u R99\n", preheatStore.preheat_hotend[key_num], preheatStore.preheat_bed[key_num]);
         mustStoreCmd("G1 Z10 F%d\n", infoSettings.level_feedrate[FEEDRATE_Z]);
         mustStoreCmd("G1 X0 F%d\n", infoSettings.level_feedrate[FEEDRATE_XY]);
         refreshPreheatIcon(&preheatStore, key_num, false);

--- a/TFT/src/User/Menu/PreheatMenu.c
+++ b/TFT/src/User/Menu/PreheatMenu.c
@@ -74,7 +74,7 @@ void refreshPreheatIcon(PREHEAT_STORE * preheatStore, uint8_t index, bool redraw
 
   char temptool[5];
   char tempbed[5];
-  sprintf(temptool, "%d", preheatStore->preheat_temp[index]);
+  sprintf(temptool, "%d", preheatStore->preheat_hotend[index]);
   sprintf(tempbed, "%d", preheatStore->preheat_bed[index]);
   lvIcon.lines[1].text = (uint8_t *)temptool;
   lvIcon.lines[2].text = (uint8_t *)tempbed;
@@ -105,9 +105,9 @@ void menuPreheat(void)
   PREHEAT_STORE preheatStore;
 
   setPreheatIcon(&preheatItems.items[KEY_ICON_6], nowHeater);
+  menuDrawPage(&preheatItems);
 
   W25Qxx_ReadBuffer((uint8_t*)&preheatStore, PREHEAT_STORE_ADDR, sizeof(PREHEAT_STORE));
-  menuDrawPage(&preheatItems);
 
   for (int i = 0; i < PREHEAT_COUNT; i++)
   {
@@ -117,6 +117,7 @@ void menuPreheat(void)
   while (MENU_IS(menuPreheat))
   {
     key_num = menuKeyGetValue();
+
     switch (key_num)
     {
       case KEY_ICON_0:
@@ -129,7 +130,7 @@ void menuPreheat(void)
         {
           case BOTH:
             heatSetTargetTemp(BED, preheatStore.preheat_bed[key_num], FROM_GUI);
-            heatSetTargetTemp(heatGetCurrentHotend(), preheatStore.preheat_temp[key_num], FROM_GUI);
+            heatSetTargetTemp(heatGetCurrentHotend(), preheatStore.preheat_hotend[key_num], FROM_GUI);
             break;
 
           case BED_PREHEAT:
@@ -137,17 +138,19 @@ void menuPreheat(void)
             break;
 
           case NOZZLE0_PREHEAT:
-            heatSetTargetTemp(heatGetCurrentHotend(), preheatStore.preheat_temp[key_num], FROM_GUI);
+            heatSetTargetTemp(heatGetCurrentHotend(), preheatStore.preheat_hotend[key_num], FROM_GUI);
             break;
 
           default:
             break;
         }
+
         refreshPreheatIcon(&preheatStore, key_num, false);
         break;
 
       case KEY_ICON_6:
         nowHeater = (TOOLPREHEAT)((nowHeater + 1) % PREHEAT_TOOL_COUNT);
+
         setPreheatIcon(&preheatItems.items[key_num], nowHeater);
         menuDrawItem(&preheatItems.items[key_num], key_num);
         break;

--- a/TFT/src/User/SanityCheck.h
+++ b/TFT/src/User/SanityCheck.h
@@ -227,13 +227,13 @@ extern "C" {
                               ENABLE_CUSTOM_5,  ENABLE_CUSTOM_6,  ENABLE_CUSTOM_7,  ENABLE_CUSTOM_8,  ENABLE_CUSTOM_9,\
                               ENABLE_CUSTOM_10, ENABLE_CUSTOM_11, ENABLE_CUSTOM_12, ENABLE_CUSTOM_13, ENABLE_CUSTOM_14}
 
-#define CUSTOM_GCODE_LIST    {CUSTOM_GCODE_0,  CUSTOM_GCODE_1,  CUSTOM_GCODE_2,  CUSTOM_GCODE_3,  CUSTOM_GCODE_4,\
-                              CUSTOM_GCODE_5,  CUSTOM_GCODE_6,  CUSTOM_GCODE_7,  CUSTOM_GCODE_8,  CUSTOM_GCODE_9,\
-                              CUSTOM_GCODE_10, CUSTOM_GCODE_11, CUSTOM_GCODE_12, CUSTOM_GCODE_13, CUSTOM_GCODE_14}
-
 #define CUSTOM_GCODE_LABELS  {CUSTOM_LABEL_0,  CUSTOM_LABEL_1,  CUSTOM_LABEL_2,  CUSTOM_LABEL_3,  CUSTOM_LABEL_4,\
                               CUSTOM_LABEL_5,  CUSTOM_LABEL_6,  CUSTOM_LABEL_7,  CUSTOM_LABEL_8,  CUSTOM_LABEL_9,\
                               CUSTOM_LABEL_10, CUSTOM_LABEL_11, CUSTOM_LABEL_12, CUSTOM_LABEL_13, CUSTOM_LABEL_14}
+
+#define CUSTOM_GCODE_LIST    {CUSTOM_GCODE_0,  CUSTOM_GCODE_1,  CUSTOM_GCODE_2,  CUSTOM_GCODE_3,  CUSTOM_GCODE_4,\
+                              CUSTOM_GCODE_5,  CUSTOM_GCODE_6,  CUSTOM_GCODE_7,  CUSTOM_GCODE_8,  CUSTOM_GCODE_9,\
+                              CUSTOM_GCODE_10, CUSTOM_GCODE_11, CUSTOM_GCODE_12, CUSTOM_GCODE_13, CUSTOM_GCODE_14}
 
 //====================================================================================================
 //============================ Settings Configurable At Compile Time Only ============================

--- a/TFT/src/User/os_timer.c
+++ b/TFT/src/User/os_timer.c
@@ -1,7 +1,7 @@
 #include "os_timer.h"
 #include "includes.h"
 
-OS_COUNTER os_counter = {0, 0};
+OS_COUNTER os_counter = {0, 1000};
 
 void OS_InitTimerMs(void)
 {
@@ -40,15 +40,15 @@ void TIMER6_IRQHandler(void)
     TIMER_INTF(TIMER6) &= ~TIMER_INTF_UPIF;  // clear interrupt flag
 
     os_counter.ms++;
-    os_counter.sec++;
+    os_counter.sec--;
 
-    if (os_counter.sec >= 1000)  // if one second has been elapsed
+    if (os_counter.sec == 0)  // if one second has been elapsed
     {
-      os_counter.sec = 0;  // reset one second counter
+      os_counter.sec = 1000;  // reset one second counter
 
-      AVG_KPIS();          // collect debug monitoring KPI
+      AVG_KPIS();             // collect debug monitoring KPI
 
-      updatePrintTime();   // if printing, update printing info
+      updatePrintTime();      // if printing, update printing info
     }
 
     TS_CheckPress();  // check touch screen once a millisecond
@@ -62,15 +62,15 @@ void TIM7_IRQHandler(void)
     TIM7->SR &= ~TIM_SR_UIF;  // clear interrupt flag
 
     os_counter.ms++;
-    os_counter.sec++;
+    os_counter.sec--;
 
-    if (os_counter.sec >= 1000)  // if one second has been elapsed
+    if (os_counter.sec == 0)  // if one second has been elapsed
     {
-      os_counter.sec = 0;  // reset one second counter
+      os_counter.sec = 1000;  // reset one second counter
 
-      AVG_KPIS();          // collect debug monitoring KPI
+      AVG_KPIS();             // collect debug monitoring KPI
 
-      updatePrintTime();   // if printing, update printing info
+      updatePrintTime();      // if printing, update printing info
     }
 
     TS_CheckPress();  // check touch screen once a millisecond

--- a/TFT/src/User/os_timer.h
+++ b/TFT/src/User/os_timer.h
@@ -7,11 +7,14 @@ extern "C" {
 
 #include <stdint.h>
 
-// NOTE: not needed to define "ms" attribute as "volatile"
+// NOTE: "ms" attribute defined as "volatile" to avoid freezes in case the inline OS_GetTimeMs()
+//       function is used on a loop statement such as "while (frameTimeStamp == OS_GetTimeMs());"
+//       in the Knob_LED_SetColor() function in Knob_LED.c (the value of OS_GetTimeMs() will be
+//       cached on a register and never updated causing no exit from the loop)
 typedef struct
 {
-  uint32_t ms;   // milliseconds
-  uint16_t sec;  // seconds
+  volatile uint32_t ms;  // milliseconds
+  uint16_t sec;          // seconds
 } OS_COUNTER;
 
 typedef void (*FP_TASK)(void *);


### PR DESCRIPTION
**BUGFIXES:**
- Fixed #2895: Bug introduced by #2889 and affecting TFT variants with a LED on knob (e.g. TFT35 E3 V3.0 etc.) in case `knob_led_idle` setting on `config.ini` file was enabled. The bug caused a freeze exiting from PID/MPC menus or during the `Event LED` process, if enabled, at the beginning of a print. The bug was due to the missing `volatile` qualifier on `ms` attribute of OS_COUNTER data struct.
  **NOTE:** The bug severity can be considered major for the affected TFT variants
- Fixed #2898: Bug causing a freeze entering on `Preheat` menu. The bug was present in case the names (e.g. `Poly Carbonate` etc.) defined in `config.ini` file required a pixel width wider that the underlying icon image displayed on the screen.
- Fixed missing default initialization on flash for preheat names and temperatures: Bug fixed in `Config.c`
- Minor cleanup

**PR STATE:** Ready for merge

fixes #2898
resolves #2896 (answer provided. Not an issue on TFT)
fixes #2895
resolves #2880 (tested and properly working. Not an issue on TFT (used wrong TFT fw or TFT resources)
resolves #2875 (answer provided. Not an issue on TFT)
resolves #2853 (zombie. Feedbacks provided but no more reply)
resolves #2821 (answer provided (very old TFT fw (2019) needed to be updated)
resolves #2796 (zombie)
resolves #2734 (answers provided)