### PR TITLE
Fix MACHINE_TYPE with KINEMATICS in M115

### DIFF
--- a/TFT/src/User/API/Mainboard_AckHandler.c
+++ b/TFT/src/User/API/Mainboard_AckHandler.c
@@ -1273,7 +1273,9 @@ void parseAck(void)
         string = &ack_cache[ack_index];
         string_start = ack_index;
 
-        if (ack_seen("EXTRUDER_COUNT:"))
+        if (ack_seen("KINEMATICS:"))  // as of MarlinFirmware/Marlin@3fd175a
+          string_end = ack_index - sizeof("KINEMATICS:");
+        else if (ack_seen("EXTRUDER_COUNT:"))
         {
           if (MIXING_EXTRUDER == 0)
             infoSettings.ext_count = ack_value();


### PR DESCRIPTION
### Description

Fixes #2912

As of https://github.com/MarlinFirmware/Marlin/commit/3fd175af8ea56db48ea41d7f3d55e967f0df8cd8 / https://github.com/MarlinFirmware/Marlin/pull/26806, Marlin now outputs the `KINEMATICS` type in the `M115` report. This causes `KINEMATICS:<type>` to also be displayed after `MACHINE_TYPE` (printer name) on the main screen in the Status section and on the Info screen.

I tested the old & new `M115` output with this patch and it seems to work correctly.

### Benefits

`KINEMATICS:<type>` will no longer be appended to the `MACHINE_TYPE` (printer name).

### Related Issues

- #2912
