### PR TITLE
Disable COMMAND_CHECKSUM by default

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -116,7 +116,7 @@
  *
  *   Options: [disable: 0, enable: 1]
  */
-#define COMMAND_CHECKSUM 1  // Default: 1
+#define COMMAND_CHECKSUM 0  // Default: 0
 
 /**
  * Emulated M600

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -181,7 +181,7 @@ advanced_ok:0
 #         and not all the pending commands.
 #
 #   Options: [disable: 0, enable: 1]
-command_checksum:1
+command_checksum:0
 
 #### Emulated M600
 # The TFT intercepts the M600 G-code (filament change) and emulates the handling logic

--- a/TFT/src/User/config_rrf.ini
+++ b/TFT/src/User/config_rrf.ini
@@ -144,7 +144,7 @@ advanced_ok:0
 #         and not all the pending commands.
 #
 #   Options: [disable: 0, enable: 1]
-command_checksum:1
+command_checksum:0
 
 #### Emulated M600
 # The TFT intercepts the M600 G-code (filament change) and emulates the handling logic


### PR DESCRIPTION
### Description

Fixes https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/2908

Disable `COMMAND_CHECKSUM` by default to prevent frequent false alarms / error popups. cc: @digant73

### Related Issues

- https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/2908
