### PR TITLE
🚸 Update Marlin Mode defaults

### DIFF
--- a/TFT/src/User/Configuration.h
+++ b/TFT/src/User/Configuration.h
@@ -425,7 +425,7 @@
  * Show banner text at the top of the TFT in Marlin Mode.
  *   Options: [disable: 0, enable: 1]
  */
-#define MARLIN_SHOW_TITLE 1  // Default: 1
+#define MARLIN_SHOW_TITLE 0  // Default: 0
 
 /**
  * Marlin Mode Title

--- a/TFT/src/User/config.ini
+++ b/TFT/src/User/config.ini
@@ -449,7 +449,7 @@ serial_always_on:0
 marlin_background_color:1
 
 ## Marlin Mode font color
-marlin_font_color:8
+marlin_font_color:0
 
 #### Fullscreen Marlin Mode
 # Run Marlin Mode in fullscreen.
@@ -462,7 +462,7 @@ marlin_fullscreen:0
 #### Show Marlin Mode Title
 # Show banner text at the top of the TFT in Marlin Mode.
 #   Options: [disable: 0, enable: 1]
-marlin_show_title:1
+marlin_show_title:0
 
 #### Marlin Mode Title
 # Banner text displayed at the top of the TFT in Marlin Mode.

--- a/TFT/src/User/config_rrf.ini
+++ b/TFT/src/User/config_rrf.ini
@@ -412,7 +412,7 @@ serial_always_on:1
 marlin_background_color:1
 
 ## Marlin Mode font color
-marlin_font_color:8
+marlin_font_color:0
 
 #### Fullscreen Marlin Mode
 # Run Marlin Mode in fullscreen.


### PR DESCRIPTION
### Description

- White text is a better default than orange. This also matches the current defaults in `Configuration.h`: https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/blob/87b6fb332532ffcf2516cb0f7b37465c0d5f8ba2/TFT/src/User/Configuration.h#L407-L411
- Disable title text by default. You should already know that you're in "Marlin Mode" based on the lack of Touch Mode UI.

### Benefits

Better Marlin Mode defaults
