### PR TITLE
Fix display not showing Machine Type

### DIFF
--- a/TFT/src/User/API/Mainboard_AckHandler.c
+++ b/TFT/src/User/API/Mainboard_AckHandler.c
@@ -1283,7 +1283,7 @@ void parseAck(void)
       {
         string = &ack_cache[ack_index];
         string_start = ack_index;
-        string_end = string_start;
+        string_end = ack_index - sizeof("MACHINE_TYPE:");;
 
         if (ack_seen("KINEMATICS:"))  // as of MarlinFirmware/Marlin@3fd175a
           string_end = ack_index - sizeof("KINEMATICS:");


### PR DESCRIPTION
### Description

As of https://github.com/MarlinFirmware/Marlin/commit/3fd175af8ea56db48ea41d7f3d55e967f0df8cd8, Display stop showing MACHINE_TYPE (printer name) on the main screen, in the Status section, and on the Information screen.
I tested the old & new M115 output with this patch and it seems to work correctly.

### Benefits

Back to normal display shows MACHINE_TYPE when ready

### Related Issues

Issue not reported yet
