### PR TITLE
Long press title bar freeze bug fix

### DIFF
--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -1229,7 +1229,7 @@ void loopCheckBackPress(void)
 
     TS_Sound = true;
 
-    if (tempKey != KEY_IDLE && getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held
+    if (tempKey < COUNT(getCurMenuItems()->items)) && getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held
     {
       BUZZER_PLAY(SOUND_OK);
 


### PR DESCRIPTION
Long press on the title bar freezes the TFT.

### Requirements
None, affects all TFTs, but perhaps in different ways.

### Description

The core issue is a read from an invalid address when the title bar is long pressed because the key that is pressed (tempKey) is used for as index: ` getCurMenuItems()->items[tempKey].label.index`. The title bar is not a menu item which causes a read from a undefined address which typically causes hard fault of the MCU. I can confirm that this freezes the BTT TFT35 V3.0, BTT TFT35 V3.01 and MKS TFT35 V1.0.

### Benefits

TFT doesn't freeze anymore when the title bar is long pressed.

### Related Issues

#2990