### PR TITLE
24 rollover bugfixes using ELAPSE and PENDING macros

### DIFF
--- a/TFT/src/User/API/AddonHardware.c
+++ b/TFT/src/User/API/AddonHardware.c
@@ -88,7 +88,7 @@ static bool FIL_NormalRunoutDetect(void)
   static int32_t trigBalance = 0;
   static uint32_t nextUpdateTime = 0;
 
-  if (OS_GetTimeMs() < nextUpdateTime)
+  if (PENDING(nextUpdateTime))
   {
     bool pinState = false;
     uint8_t toolNum = heatGetToolIndex();
@@ -160,7 +160,7 @@ static inline bool FIL_SmartRunoutDetect(void)
   do
   { // send M114 E to query extrude position continuously
 
-    if (OS_GetTimeMs() < nextUpdateTime)  // if next check time not yet elapsed, do nothing
+    if (PENDING(nextUpdateTime))  // if next check time not yet elapsed, do nothing
       break;
 
     nextUpdateTime = OS_GetTimeMs() + FIL_POS_E_REFRESH_TIME;  // extend next check time
@@ -230,7 +230,7 @@ void FIL_FE_CheckRunout(void)
     popupDialog(DIALOG_TYPE_ALERT, LABEL_WARNING, LABEL_FILAMENT_RUNOUT, LABEL_CONFIRM, LABEL_NULL, setRunoutAlarmFalse, NULL, NULL);
   }
 
-  if (OS_GetTimeMs() >= nextReminderTime && getRunoutAlarm())
+  if (!PENDING(nextReminderTime) && getRunoutAlarm())
   {
     BUZZER_PLAY(SOUND_ERROR);
     nextReminderTime = OS_GetTimeMs() + FIL_ALARM_REMINDER_TIME;

--- a/TFT/src/User/API/FanControl.c
+++ b/TFT/src/User/API/FanControl.c
@@ -78,7 +78,7 @@ void loopCheckFan(void)
 {
   static uint32_t nextUpdateTime = 0;
 
-  if (OS_GetTimeMs() < nextUpdateTime)  // avoid rapid fire, clogging the queue
+  if (PENDING(nextUpdateTime))  // avoid rapid fire, clogging the queue
     return;
 
   nextUpdateTime = OS_GetTimeMs() + FAN_REFRESH_TIME;  // extend next check time

--- a/TFT/src/User/API/LCD_Dimming.c
+++ b/TFT/src/User/API/LCD_Dimming.c
@@ -115,7 +115,7 @@ void LCD_CheckDimming(void)
     #endif
     )  // if touch screen not pressed and rotary encoder neither pressed nor rotated
   {
-    if (lcd_dim.dimmed || OS_GetTimeMs() < lcd_dim.next_idle_time)
+    if (lcd_dim.dimmed || PENDING(lcd_dim.next_idle_time))
       return;
 
     lcd_dim.locked = false;

--- a/TFT/src/User/API/LED_Event.c
+++ b/TFT/src/User/API/LED_Event.c
@@ -19,7 +19,7 @@ static inline bool nextUpdate(void)
 {
   static uint32_t lastUpdateTime = 0;
 
-  if (OS_GetTimeMs() - lastUpdateTime < LED_REFRESH_TIME)
+  if (!ELAPSED(lastUpdateTime, LED_REFRESH_TIME))
     return false;
 
   lastUpdateTime = OS_GetTimeMs();

--- a/TFT/src/User/API/ModeSwitching.c
+++ b/TFT/src/User/API/ModeSwitching.c
@@ -35,7 +35,7 @@ void Mode_Switch(void)
           heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
           heatSetNextUpdateTime();  // send "M105" after a delay, because of mega2560 will be hanged when received data at startup
 
-          TASK_LOOP_WHILE(OS_GetTimeMs() - startUpTime < BTT_BOOTSCREEN_TIME);  // display logo BTT_BOOTSCREEN_TIME ms
+          TASK_LOOP_WHILE(!ELAPSED(startUpTime, BTT_BOOTSCREEN_TIME) && !infoHost.connected);
 
           heatSetUpdateSeconds(TEMPERATURE_QUERY_SLOW_SECONDS);
           modeFreshBoot = false;

--- a/TFT/src/User/API/Notification.c
+++ b/TFT/src/User/API/Notification.c
@@ -125,7 +125,7 @@ static inline bool toastAvailable(void)
 void loopToast(void)
 {
   // if no new toast is available or it is not yet expired on screen or in case a full screen menu is displayed, do nothing
-  if (_toastAvailable == false || OS_GetTimeMs() < nextToastTime || getMenuType() == MENU_TYPE_FULLSCREEN)
+  if (_toastAvailable == false || PENDING(nextToastTime) || getMenuType() == MENU_TYPE_FULLSCREEN)
     return;
 
   if (toastAvailable())

--- a/TFT/src/User/API/Printing.c
+++ b/TFT/src/User/API/Printing.c
@@ -951,7 +951,7 @@ void loopPrintFromOnboard(void)
   do
   { // send M27 to query SD print status continuously
 
-    if (OS_GetTimeMs() < nextUpdateTime)  // if next check time not yet elapsed, do nothing
+    if (PENDING(nextUpdateTime))  // if next check time not yet elapsed, do nothing
       break;
 
     printSetNextUpdateTime();  // extend next check time

--- a/TFT/src/User/API/ProbeHeightControl.c
+++ b/TFT/src/User/API/ProbeHeightControl.c
@@ -111,7 +111,7 @@ void probeHeightQueryCoord(void)
 {
   static uint32_t nextUpdateTime = 0;
 
-  if (OS_GetTimeMs() < nextUpdateTime)
+  if (PENDING(nextUpdateTime))
     return;
 
   nextUpdateTime = OS_GetTimeMs() + PROBE_REFRESH_TIME;

--- a/TFT/src/User/API/RRFAckHandler.cpp
+++ b/TFT/src/User/API/RRFAckHandler.cpp
@@ -65,7 +65,7 @@ static void m291_cancel(void)
 
 static void m291_loop(void)
 {
-  if (m291_mode == -1 || (expire_time > 0 && OS_GetTimeMs() >= expire_time))
+  if ((m291_mode == -1) || (expire_time && !PENDING(expire_time)))
   {
     if (rrfStatusIsMacroBusy())
       rrfShowRunningMacro();

--- a/TFT/src/User/API/RRFStatusControl.c
+++ b/TFT/src/User/API/RRFStatusControl.c
@@ -122,7 +122,7 @@ void rrfStatusQuery(void)
   {
     static uint32_t rrf_next_query_time = 0;
 
-    if (OS_GetTimeMs() < rrf_next_query_time)
+    if (PENDING(rrf_next_query_time))
       return;
 
     rrf_next_query_time = OS_GetTimeMs() + rrf_query_interval;

--- a/TFT/src/User/API/SpeedControl.c
+++ b/TFT/src/User/API/SpeedControl.c
@@ -38,7 +38,7 @@ void loopCheckSpeed(void)
 {
   static uint32_t nextUpdateTime = 0;
 
-  if (OS_GetTimeMs() < nextUpdateTime)  // avoid rapid fire, clogging the queue
+  if (PENDING(nextUpdateTime))  // avoid rapid fire, clogging the queue
     return;
 
   nextUpdateTime = OS_GetTimeMs() + SPEED_REFRESH_TIME;  // extend next check time

--- a/TFT/src/User/API/Temperature.c
+++ b/TFT/src/User/API/Temperature.c
@@ -163,7 +163,7 @@ bool heatIsWaiting(void)
 
 bool heatIsWaitingTimedout(void)
 {
-  if (!heatIsWaiting() || OS_GetTimeMs() - heat_timestamp < HEATING_TIMEOUT)  // if no heater waiting for target temperature or no timeout
+  if (!heatIsWaiting() || !ELAPSED(heat_timestamp, HEATING_TIMEOUT))  // if no heater waiting for target temperature or no timeout
     return false;
 
   heat_timestamp = OS_GetTimeMs();  // update timestamp
@@ -260,7 +260,7 @@ void loopCheckHeater(void)
     // feature to automatically report the temperatures or (if M155 is supported) check temperature auto-report timeout
     // and resend M155 command in case of timeout expired
 
-    if (OS_GetTimeMs() < heat_next_update_time)  // if next check time not yet elapsed, do nothing
+    if (PENDING(heat_next_update_time))  // if next check time not yet elapsed, do nothing
       break;
 
     heatSetNextUpdateTime();  // extend next check time

--- a/TFT/src/User/API/Touch_Encoder.c
+++ b/TFT/src/User/API/Touch_Encoder.c
@@ -12,7 +12,7 @@ bool Touch_Enc_ReadPen(uint16_t duration)
     return false;
   }
 
-  if (OS_GetTimeMs() - lastTime < duration)  // if touch screen held pressed but provided duration not yet reached
+  if (!ELAPSED(lastTime, duration))  // if touch screen held pressed but provided duration not yet reached
     return false;
 
   // touch screen held pressed for the provided duration
@@ -38,7 +38,7 @@ bool Touch_Enc_ReadBtn(uint16_t duration)
     return false;
   }
 
-  if (OS_GetTimeMs() - lastTime < duration)  // if touch screen held pressed but provided duration not yet reached
+  if (!ELAPSED(lastTime, duration))  // if touch screen held pressed but provided duration not yet reached
     return false;
 
   // touch screen held pressed for the provided duration

--- a/TFT/src/User/API/UI/GUI.c
+++ b/TFT/src/User/API/UI/GUI.c
@@ -1179,7 +1179,7 @@ void Scroll_DispString(SCROLL * para, uint8_t align)
 
   if (para->totalPixelWidth > para->maxPixelWidth)
   {
-    if (OS_GetTimeMs() >= para->time)
+    if (!PENDING(para->time))
     {
       para->time = OS_GetTimeMs() + 50;  // 50ms
       GUI_SetRange(para->rect.x0, para->rect.y0, para->rect.x1, para->rect.y1);

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -616,7 +616,7 @@ void setReminderMsg(int16_t inf, SYS_STATUS status)
 
 void loopReminderManage(void)
 {
-  if (reminder.status == SYS_STATUS_IDLE || OS_GetTimeMs() < reminder.time)
+  if (reminder.status == SYS_STATUS_IDLE || PENDING(reminder.time))
     return;
 
   if (infoHost.connected == false)
@@ -664,7 +664,7 @@ void drawBusySign(void)
 
 void loopBusySignClear(void)
 {
-  if (busySign.status == SYS_STATUS_IDLE || OS_GetTimeMs() < busySign.time)
+  if (busySign.status == SYS_STATUS_IDLE || PENDING(busySign.time))
     return;
 
   busySign.status = SYS_STATUS_IDLE;  // clear busy signal status

--- a/TFT/src/User/Hal/LCD_Encoder.c
+++ b/TFT/src/User/Hal/LCD_Encoder.c
@@ -60,7 +60,7 @@ bool LCD_Enc_ReadBtn(uint16_t duration)
     return false;
   }
 
-  if (OS_GetTimeMs() - lastTime < duration)  // if rotary encoder button held pressed but provided duration not yet reached
+  if (!ELAPSED(lastTime, duration))  // if rotary encoder button held pressed but provided duration not yet reached
     return false;
 
   // rotary encoder button held pressed for the provided duration

--- a/TFT/src/User/Menu/Pid.c
+++ b/TFT/src/User/Menu/Pid.c
@@ -243,7 +243,7 @@ void menuPid(void)
       if (getMenuType() != MENU_TYPE_SPLASH)
         popupSplash(DIALOG_TYPE_INFO, LABEL_SCREEN_INFO, LABEL_BUSY);
 
-      if (OS_GetTimeMs() >= pidTimeout)
+      if (!PENDING(pidTimeout))
         pidUpdateStatus(PID_TIMEOUT);
 
       if (pidStatus != PID_RUNNING)

--- a/TFT/src/User/Menu/common.c
+++ b/TFT/src/User/Menu/common.c
@@ -98,7 +98,7 @@ bool nextScreenUpdate(uint32_t refreshTime)
 {
   static uint32_t lastTime = 0;
 
-  if (OS_GetTimeMs() - lastTime < refreshTime)
+  if (!ELAPSED(lastTime, refreshTime))
     return false;
 
   lastTime = OS_GetTimeMs();

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -43,15 +43,15 @@ extern "C" {
 // flip all bits
 #define FLIP_BITS(num) ~num
 
+// timer rollover safe functions
+#define PENDING(when)                ((int32_t)((when) - OS_GetTimeMs()) > 0)
+#define ELAPSED(starttime, interval) !PENDING((starttime) + (interval))
+
 // time conversion
 #define SEC_TO_MS(t)  (t * 1000)           // seconds to milliseconds
 #define MS_TO_SEC(t)  (t / 1000)           // milliseconds to seconds
 #define MIN_TO_SEC(t) (t * 60)             // minute to seconds
 #define MIN_TO_MS(t)  (SEC_TO_MS(t) * 60)  // minute to milliseconds
-
-// timer rollover safe functions
-#define PENDING(when)                ((int32_t)((when) - OS_GetTimeMs()) > 0)
-#define ELAPSED(starttime, interval) !PENDING((starttime) + (interval))
 
 #define HOURS(t)   (t / (60 * 60))       // hours completed
 #define MINUTES(t) (t % (60 * 60) / 60)  // minutes remaining to next hour

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -49,6 +49,10 @@ extern "C" {
 #define MIN_TO_SEC(t) (t * 60)             // minute to seconds
 #define MIN_TO_MS(t)  (SEC_TO_MS(t) * 60)  // minute to milliseconds
 
+// timer rollover safe functions
+#define PENDING(when)                ((int32_t)((when) - OS_GetTimeMs()) > 0)
+#define ELAPSED(starttime, interval) !PENDING((starttime) + (interval))
+
 #define HOURS(t)   (t / (60 * 60))       // hours completed
 #define MINUTES(t) (t % (60 * 60) / 60)  // minutes remaining to next hour
 #define SECONDS(t) (t % 60)              // seconds remaining to next minute

--- a/TFT/src/User/os_timer.c
+++ b/TFT/src/User/os_timer.c
@@ -97,7 +97,7 @@ void OS_TaskLoop(OS_TASK * task_t)
   if (task_t->is_exist == 0)
     return;
 
-  if (OS_GetTimeMs() < task_t->next_time)
+  if (PENDING(task_t->next_time))
     return;
 
   if (task_t->is_repeat == 0)


### PR DESCRIPTION
Solves 24 timer rollover bug using ELAPSED and PENDING macros.

### Requirements
None

### Description
This PR solves 24 timer rollover bugs I found in the code. These bugs can make the TFT behave erratically, but only after a long time. The cause is the 32 bit timer register rollover from 0xFFFFFFFF to 0. When using incorrect timer math the results can be incorrect.
To solve the bugs I use a strategy bored by Marlin, which uses macros to prevent issues. 

PENDING(when) with "when" a time in the future.
ELAPSED(starttime, interval) with starttime a time in the past, and the interval the time to check for if it has elapsed since the starttime.

### Benefits
1. No erratic TFT behavior after a long on time.
2. Set a good example for users who review the code base.
3. Improved code quality.

### Related Issues

#2992 
