### PR TITLE
Fix notification title text visible behind toast message

### DIFF
--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -828,7 +828,7 @@ void menuDrawTitle(void)
 
   // draw title
   uint16_t start_y = (TITLE_END_Y - BYTE_HEIGHT) / 2;
-  uint16_t start_x = 10;
+  uint16_t start_x = START_X;
   uint16_t end_x = drawTemperatureStatus();
 
   // NOTE: load the label just before displaying it. This is needed only in case a secondary language pack (.ini file) is used
@@ -841,12 +841,12 @@ void menuDrawTitle(void)
   if (titleString)
   {
     GUI_SetTextMode(GUI_TEXTMODE_NORMAL);
-    GUI_DispLenString(10, start_y, (uint8_t *) titleString, LCD_WIDTH - 20, true);
+    GUI_DispLenString(START_X, start_y, (uint8_t *) titleString, LCD_WIDTH - 2 * START_X, true);
 
     start_x += GUI_StrPixelWidth((uint8_t *) titleString);
 
-    if (start_x > LCD_WIDTH - 20)
-      start_x = LCD_WIDTH - 20;
+    if (start_x > LCD_WIDTH - 2 * START_X)
+      start_x = LCD_WIDTH - 2 * START_X;
   }
 
   GUI_ClearRect(start_x, start_y, end_x, start_y + BYTE_HEIGHT);


### PR DESCRIPTION
Fix notification title text partly visible behind toast message. Title position was hard coded (x=10), use START_X variable instead.

### Description

The notification menu title text is still partly visible behind a toast message. This is because the title text position is hard coded at x=10, while other graphics items use a framework based on calculated variables (START_X, START_Y etc.).
The toast icon starts at START_X, which is 12 for a  480x320 display. So 2 pixels of the title text will still be visible behind the toast message. 

### Benefits

Fixes graphical corruption/misalignment, improves consistency of graphical layout independent of the TFT resolution, no hardcoded positions, but calculated position like other graphical items on the screen.

### Related Issues

None
