### PR TITLE
Add USART6 pins to MKS TFT35 V1.0 variant so it doesn't fall back to the incorrect defaults

### DIFF
--- a/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
@@ -146,7 +146,7 @@
 // LCD Encoder pins
 // It can be added using available pins (PB0, PB1, PB4, PB5). Switch encoder/button to ground
 // Make sure to remap FIL_RUNOUT_PIN and PS_ON_PIN to unused pins to avoid conflicts (E.e. PE0, PE1, PE4, PE5)
-// Mostly usefull for Marlin mode, which is not available because there are not EXP1/2 connectors on the display
+// Mostly usefull for Marlin mode, which is not available because there are no EXP1/2 connectors on the display
 #ifndef LCD_ENCA_PIN
   #define LCD_ENCA_PIN PB0
   #define LCD_ENCB_PIN PB1

--- a/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
+++ b/TFT/src/User/Variants/pin_MKS_TFT35_V1_0.h
@@ -75,6 +75,10 @@
   #define LCD_DATA_16BIT 1
 #endif
 
+// USART6 pins for STM32F407VET6
+#define USART6_TX_PIN PC6
+#define USART6_RX_PIN PC7
+
 // SERIAL_PORT:   communicating with host (Marlin, RRF etc.)
 // SERIAL_PORT_X: communicating with other controllers (OctoPrint, ESP3D, other UART Touch Screen etc.)
 #ifndef SERIAL_PORT


### PR DESCRIPTION
Add USART6 pins to MKS TFT35 V1.0 variant so it doesn't fall back to the incorrect defaults

### Requirements

MKS TFT35 V1.0 Touch screen

### Description

Add USART6 pins to MKS TFT35 V1.0 variant so it doesn't fall back to the incorrect defaults. The TFT uses the STM32F407VET6 MCU in a 100 pin package. (https://github.com/makerbase-mks/MKS-TFT-Hardware/blob/master/MKS%20TFT35/MKS%20TFT35%20V1.0_003/MKS%20TFT35%20V1.0_003%20SCH.pdf).
So the correct USART6 pins are:
USART6_TX_PIN PC6
USART6_RX_PIN PC7

Confirmed on the actual hardware.

### Benefits
Working USART6 serial communication


### Related Issues

#3001
