### PR TITLE
Add support for long pressing the touch screen so alternative actions can be executed for each button

### DIFF
--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -1094,7 +1094,7 @@ void displayExhibitValue(const char * valueStr)
 // the menus can check if the press was a long press
 bool menuKeyIsLongPress(void)
 {
-  return (longPressed);
+  return (longPressed && !TS_IsPressed());
 }
 
 // get button value
@@ -1183,7 +1183,7 @@ KEY_VALUES menuKeyGetValue(void)
 
   if (!TS_IsPressed())
   {
-    longPressed >>= 1;// 2-->1-->0, don't immediately cancel longPressed, delay by 1 cycle
+    longPressed >>= 1;// 4-->2-->1-->0, keep longPressed for some time/cycles
 
     #ifdef HAS_EMULATOR
       backHeld = false;
@@ -1223,7 +1223,7 @@ KEY_VALUES menuKeyGetValue(void)
 
     if (tempKey != KEY_IDLE && getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held
     {
-      longPressed = 2;  // enable longPressed status for at least 2 cycles
+      longPressed = 4;  // enable longPressed status for some time/cycles
       BUZZER_PLAY(SOUND_OK);
 
       if (getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held

--- a/TFT/src/User/API/menu.c
+++ b/TFT/src/User/API/menu.c
@@ -4,6 +4,7 @@
 #include "Notification.h"
 
 #define STATUS_BAR_REFRESH_TIME 2000  // refresh time in ms
+uint8_t longPressed = 0;
 
 const GUI_RECT exhibitRect = {
   #ifdef PORTRAIT_MODE
@@ -1090,72 +1091,75 @@ void displayExhibitValue(const char * valueStr)
   setFontSize(FONT_SIZE_NORMAL);
 }
 
+// the menus can check if the press was a long press
+bool menuKeyIsLongPress(void)
+{
+  return (longPressed);
+}
+
 // get button value
 KEY_VALUES menuKeyGetValue(void)
 {
   KEY_VALUES tempkey = KEY_IDLE;
 
-  if (tempkey == KEY_IDLE)
+  switch (menuType)
   {
-    switch (menuType)
+    case MENU_TYPE_ICON:
     {
-      case MENU_TYPE_ICON:
+      if (MENU_IS(menuStatus))
       {
-        if (MENU_IS(menuStatus))
-        {
-          tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keySS), rect_of_keySS);
-        }
-        else if (MENU_IS(menuPrinting))
-        {
-          if (isPrinting() || isPrintingFromOnboard())
-            tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyPS), rect_of_keyPS);
-          else
-            tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyPS_end), rect_of_keyPS_end);
-
-          if (tempkey == (KEY_VALUES)PS_KEY_TITLEBAR)
-            tempkey = KEY_TITLEBAR;
-        }
-        else if ((MENU_IS(menuHeat)) ||
-                 (MENU_IS(menuLoadUnload)) ||
-                 (MENU_IS(menuMPC)) ||
-                 (MENU_IS(menuPid)) ||
-                 (MENU_IS(menuTuneExtruder)) ||
-                 (MENU_IS(menuFan)) ||
-                 (MENU_IS(menuExtrude)) ||
-                 (MENU_IS(menuSpeed)) ||
-                 (MENU_IS(menuZOffset)) ||
-                 (MENU_IS(menuMBL)) ||
-                 (MENU_IS(menuBabystep)) ||
-                 (MENU_IS(menuMeshEditor)))
-        {
-          tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keysIN), rect_of_keysIN);
-        }
-        else
-        {
-          tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_key), rect_of_key);
-        }
-        break;
+        tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keySS), rect_of_keySS);
       }
-
-      case MENU_TYPE_LISTVIEW:
-        tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyListView), rect_of_keyListView);
-
-        if (tempkey == ITEM_PER_PAGE)
-          tempkey = KEY_TITLEBAR;
-        break;
-
-      case MENU_TYPE_OTHER:
-        if ((KEY_VALUES)KEY_GetValue(1, rect_of_titleBar) == 0)
-          tempkey = KEY_TITLEBAR;
+      else if (MENU_IS(menuPrinting))
+      {
+        if (isPrinting() || isPrintingFromOnboard())
+          tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyPS), rect_of_keyPS);
         else
-          tempkey = (KEY_VALUES)KEY_GetValue(curRectCount, curRect);
-        break;
+          tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyPS_end), rect_of_keyPS_end);
 
-      case MENU_TYPE_FULLSCREEN:
-      default:
-        tempkey = (KEY_VALUES)KEY_GetValue(curRectCount, curRect);
-        break;
+        if (tempkey == (KEY_VALUES)PS_KEY_TITLEBAR)
+          tempkey = KEY_TITLEBAR;
+      }
+      else if ((MENU_IS(menuHeat)) ||
+               (MENU_IS(menuLoadUnload)) ||
+               (MENU_IS(menuMPC)) ||
+               (MENU_IS(menuPid)) ||
+               (MENU_IS(menuTuneExtruder)) ||
+               (MENU_IS(menuFan)) ||
+               (MENU_IS(menuExtrude)) ||
+               (MENU_IS(menuSpeed)) ||
+               (MENU_IS(menuZOffset)) ||
+               (MENU_IS(menuMBL)) ||
+               (MENU_IS(menuBabystep)) ||
+               (MENU_IS(menuMeshEditor)))
+      {
+        tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keysIN), rect_of_keysIN);
+      }
+      else
+      {
+        tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_key), rect_of_key);
+      }
+      break;
     }
+
+    case MENU_TYPE_LISTVIEW:
+      tempkey = (KEY_VALUES)KEY_GetValue(COUNT(rect_of_keyListView), rect_of_keyListView);
+
+      if (tempkey == ITEM_PER_PAGE)
+        tempkey = KEY_TITLEBAR;
+      break;
+
+    case MENU_TYPE_OTHER:
+      if ((KEY_VALUES)KEY_GetValue(1, rect_of_titleBar) == 0)
+        tempkey = KEY_TITLEBAR;
+      else
+        tempkey = (KEY_VALUES)KEY_GetValue(curRectCount, curRect);
+      break;
+
+    case MENU_TYPE_FULLSCREEN:
+    default:
+      tempkey = (KEY_VALUES)KEY_GetValue(curRectCount, curRect);
+      break;
   }
 
   if (menuType != MENU_TYPE_FULLSCREEN && tempkey == KEY_TITLEBAR)
@@ -1170,56 +1174,44 @@ KEY_VALUES menuKeyGetValue(void)
       tempkey = LCD_Enc_KeyValue();
   #endif
 
-  return tempkey;
-}
-
-// smart home (long press on back button to go to status screen)
-#ifdef SMART_HOME
-
-void loopCheckBackPress(void)
-{
-  static bool longPress = false;
-
   #ifdef HAS_EMULATOR
     static bool backHeld = false;
   #endif
 
+  if (tempkey != KEY_IDLE)
+    lastKeyTime = OS_GetTimeMs();
+
   if (!TS_IsPressed())
   {
-    longPress = false;
+    longPressed >>= 1;// 2-->1-->0, don't immediately cancel longPressed, delay by 1 cycle
 
     #ifdef HAS_EMULATOR
       backHeld = false;
     #else
       Touch_Enc_ReadPen(0);  // reset TSC press timer
     #endif
-
-    return;
+    return tempkey;
   }
 
-  if (isPrinting())  // no jump to main menu while printing
-    return;
-
-  if (getMenuType() != MENU_TYPE_ICON)
-    return;
-
-  if ((infoMenu.cur == 0) || (MENU_IS(menuMode)))
-    return;
+  if (isPrinting() ||                     // no jump to "main menu" while printing
+      getMenuType() != MENU_TYPE_ICON ||  // only jump if in a "icon menu"
+      infoMenu.cur == 0 ||                // already in "main menu"
+      MENU_IS(menuMode))                  // no jump from "mode switching menu"
+    return tempkey;
 
   #ifdef HAS_EMULATOR
-    if (backHeld == true)  // prevent mode selection or screenshot if Back button is held
+    if (backHeld)  // prevent mode selection or screenshot if Back button is held
     {
       backHeld = Touch_Enc_ReadPen(0);
 
-      return;
+      return tempkey;
     }
   #endif
 
-  if (longPress == false && Touch_Enc_ReadPen(LONG_TOUCH))  // check if longpress already handled and check if TSC is pressed and held
+  if (!longPressed && Touch_Enc_ReadPen(LONG_TOUCH))  // detect long press
   {
     KEY_VALUES tempKey = KEY_IDLE;
 
-    longPress = true;
     TS_Sound = false;
 
     if (MENU_IS(menuPrinting))
@@ -1231,16 +1223,23 @@ void loopCheckBackPress(void)
 
     if (tempKey != KEY_IDLE && getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held
     {
+      longPressed = 2;  // enable longPressed status for at least 2 cycles
       BUZZER_PLAY(SOUND_OK);
 
-      #ifdef HAS_EMULATOR
-        backHeld = true;
-      #endif
+      if (getCurMenuItems()->items[tempKey].label.index == LABEL_BACK)  // check if Back button is held
+      {
+        #ifdef HAS_EMULATOR
+          backHeld = true;
+        #endif
 
-      infoMenu.menu[1] = infoMenu.menu[infoMenu.cur];  // prepare menu tree for jump to 0
-      infoMenu.cur = 1;
+        #ifdef SMART_HOME
+          BUZZER_PLAY(SOUND_OK);  // sound to indicate back to root menu is triggered
+          infoMenu.menu[1] = infoMenu.menu[infoMenu.cur];  // prepare menu tree for jump to 0
+          infoMenu.cur = 1;
+        #endif  // SMART_HOME
+      }
     }
   }
-}
 
-#endif  // SMART_HOME
+  return tempkey;
+}

--- a/TFT/src/User/API/menu.h
+++ b/TFT/src/User/API/menu.h
@@ -198,6 +198,7 @@ void displayExhibitHeader(const char * titleStr, const char * unitStr);
 void displayExhibitValue(const char * valueStr);
 
 KEY_VALUES menuKeyGetValue(void);
+bool menuKeyIsLongPress(void);
 
 // smart home
 #ifdef SMART_HOME

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -62,6 +62,7 @@ void menuExtrude(void)
   while (MENU_IS(menuExtrude))
   {
     key_num = menuKeyGetValue();
+    bool longPressed = menuKeyIsLongPress();
 
     switch (key_num)
     {
@@ -84,25 +85,28 @@ void menuExtrude(void)
       case KEY_ICON_4:
         if (infoSettings.ext_count > 1)
         {
-          curExtruder_index = (curExtruder_index + 1) % infoSettings.ext_count;
-
-          extruderReDraw(curExtruder_index, extrAmount, true);
-        }
-        else
-        {
-          heatSetCurrentIndex(curExtruder_index);  // preselect current nozzle for "Heat" menu
-
-          OPEN_MENU(menuHeat);
-          menuHeat();  // call from here to retain E axis parameters
-
-          if (MENU_IS(menuExtrude))  // user exited from heating menu by short pressing "Back"
+          if (longPressed) // IRON, jump to heating 
           {
-            menuDrawPage(&extrudeItems);
-            extruderReDraw(curExtruder_index, extrAmount, true);
+            heatSetCurrentIndex(curExtruder_index);  // preselect current nozzle for "Heat" menu
+
+            OPEN_MENU(menuHeat);
+            menuHeat();  // call from here to retain E axis parameters
+
+            if (MENU_IS(menuExtrude))  // user exited from heating menu by short pressing "Back"
+            {
+              menuDrawPage(&extrudeItems);
+              extruderReDraw(curExtruder_index, extrAmount, true);
+            }
+            else  // user exited from heating menu by long pressing "Back"
+            {
+              eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
+            }
           }
-          else  // user exited from heating menu by long pressing "Back"
+          else
           {
-            eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
+            curExtruder_index = (curExtruder_index + 1) % infoSettings.ext_count;
+
+            extruderReDraw(curExtruder_index, extrAmount, true);
           }
         }
         break;

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -87,8 +87,18 @@ void menuExtrude(void)
         {
           if (longPressed) 
           {
-             OPEN_MENU(menuHeat);
-             menuHeat();
+            OPEN_MENU(menuHeat);
+            menuHeat();
+
+            if (MENU_IS(menuExtrude))  // user exited from heating menu by short pressing "Back"
+            {
+              menuDrawPage(&extrudeItems);
+              extruderReDraw(curExtruder_index, extrAmount, true);
+            }
+            else  // user exited from heating menu by long pressing "Back"
+            {
+              eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
+            }
           }
           else
           {

--- a/TFT/src/User/Menu/Extrude.c
+++ b/TFT/src/User/Menu/Extrude.c
@@ -38,7 +38,7 @@ void menuExtrude(void)
 
   menuDrawPage(&extrudeItems);
 
-  if (eAxisBackup.handled == false)
+  if (!eAxisBackup.handled)
   {
     TASK_LOOP_WHILE(isNotEmptyCmdQueue());  // wait for the communication to be clean
 
@@ -54,7 +54,7 @@ void menuExtrude(void)
 
   extruderReDraw(curExtruder_index, extrAmount, true);
 
-  if (eAxisBackup.relative == false)  // set extruder to relative
+  if (!eAxisBackup.relative)  // set extruder to relative
     mustStoreCmd("M83\n");
 
   heatSetUpdateSeconds(TEMPERATURE_QUERY_FAST_SECONDS);
@@ -85,28 +85,33 @@ void menuExtrude(void)
       case KEY_ICON_4:
         if (infoSettings.ext_count > 1)
         {
-          if (longPressed) // IRON, jump to heating 
+          if (longPressed) 
           {
-            heatSetCurrentIndex(curExtruder_index);  // preselect current nozzle for "Heat" menu
-
-            OPEN_MENU(menuHeat);
-            menuHeat();  // call from here to retain E axis parameters
-
-            if (MENU_IS(menuExtrude))  // user exited from heating menu by short pressing "Back"
-            {
-              menuDrawPage(&extrudeItems);
-              extruderReDraw(curExtruder_index, extrAmount, true);
-            }
-            else  // user exited from heating menu by long pressing "Back"
-            {
-              eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
-            }
+             OPEN_MENU(menuHeat);
+             menuHeat();
           }
           else
           {
             curExtruder_index = (curExtruder_index + 1) % infoSettings.ext_count;
 
             extruderReDraw(curExtruder_index, extrAmount, true);
+          }
+        }
+        else
+        {
+          heatSetCurrentIndex(curExtruder_index);  // preselect current nozzle for "Heat" menu
+
+          OPEN_MENU(menuHeat);
+          menuHeat();  // call from here to retain E axis parameters
+
+          if (MENU_IS(menuExtrude))  // user exited from heating menu by short pressing "Back"
+          {
+            menuDrawPage(&extrudeItems);
+            extruderReDraw(curExtruder_index, extrAmount, true);
+          }
+          else  // user exited from heating menu by long pressing "Back"
+          {
+            eAxisBackup.handled = false;  // exiting from Extrude menu, trigger E axis parameters restore
           }
         }
         break;

--- a/TFT/src/User/Menu/Heat.c
+++ b/TFT/src/User/Menu/Heat.c
@@ -50,12 +50,16 @@ void menuHeat(void)
     actCurrent = heatGetCurrentTemp(tool_index);
     actTarget = setTarget = heatGetTargetTemp(tool_index);
     key_num = menuKeyGetValue();
+    bool longPressed = menuKeyIsLongPress();
 
     switch (key_num)
     {
       case KEY_ICON_0:
       case KEY_DECREASE:
-        setTarget -= degreeSteps[degreeSteps_index];
+        if (longPressed)
+          setTarget = 0;
+        else
+          setTarget -= degreeSteps[degreeSteps_index];
         break;
 
       case KEY_INFOBOX:
@@ -68,7 +72,18 @@ void menuHeat(void)
 
       case KEY_ICON_3:
       case KEY_INCREASE:
-        setTarget += degreeSteps[degreeSteps_index];
+        if (longPressed)
+        {
+          BUZZER_PLAY(SOUND_OK);
+          if (tool_index < infoSettings.hotend_count
+            setTarget = 200;
+          else
+            setTarget = 75;
+        }
+        else
+        {
+          setTarget += degreeSteps[degreeSteps_index];
+        }
         break;
 
       case KEY_ICON_4:

--- a/TFT/src/User/Menu/Move.c
+++ b/TFT/src/User/Menu/Move.c
@@ -143,6 +143,7 @@ void menuMove(void)
   while (MENU_IS(menuMove))
   {
     key_num = menuKeyGetValue();
+    bool longPressed = menuKeyIsLongPress();
 
     switch (key_num)
     {
@@ -152,12 +153,26 @@ void menuMove(void)
         case KEY_ICON_2: storeMoveCmd(Z_AXIS, amount); break;   // Z move up if no invert
 
         case KEY_ICON_3:
-          item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
-          moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
+          if (longPressed)
+          {
+            infoSettings.move_speed = (infoSettings.move_speed + 1) % ITEM_SPEED_NUM;
+            if (infoSettings.move_speed == 0)
+              addToast(DIALOG_TYPE_INFO, (char *) textSelect(LABEL_SLOW));
+            if (infoSettings.move_speed == 1)
+              addToast(DIALOG_TYPE_INFO, (char *) textSelect(LABEL_NORMAL));
+            if (infoSettings.move_speed == 2)
+              addToast(DIALOG_TYPE_INFO, (char *) textSelect(LABEL_FAST));
+          }
+          else
+          {
+            item_moveLen_index = (item_moveLen_index + 1) % ITEM_MOVE_LEN_NUM;
+            moveItems.items[key_num] = itemMoveLen[item_moveLen_index];
 
-          menuDrawItem(&moveItems.items[key_num], key_num);
+            menuDrawItem(&moveItems.items[key_num], key_num);
 
-          amount = moveLenSteps[item_moveLen_index];
+            amount = moveLenSteps[item_moveLen_index];
+          }
+
           break;
 
         case KEY_ICON_4: storeMoveCmd(X_AXIS, -amount); break;  // X move decrease if no invert


### PR DESCRIPTION
Add support for long pressing the touch screen

### Description

This allows the user to select alternative function for each key. The menus can call menuKeyIsLongPress() to get the longpress key status so they can handle a long press action.

Long press handler added to:
  Extrude.c, long pressing the E0/E1 selector in an multi extruder system allows to jump to the heating menu (Heating is not available on this screen in this setup).
  Heat.c, long pressing the "=" jumps directly to 200 degrees, which is especially useful for use without an encoder.
  Move.c, long pressing the "move length" button allows to adjust the move speed. Speed control is not available in this menu at all without this feature.

### Benefits

More user friendly touchscreen operation, it's now easy to add long press functions to any key, not only the back key.
