### PR TITLE
Implement a simple wear leveling strategy, flash store cleanup

### DIFF
--- a/TFT/src/User/API/FlashStore.c
+++ b/TFT/src/User/API/FlashStore.c
@@ -54,7 +54,7 @@ void readStoredPara(void)
   #ifdef I2C_EEPROM  // added I2C_EEPROM suppport for MKS_TFT35_V1_0
     EEPROM_FlashRead((uint8_t*)data, PARA_SIZE);
   #else
-    HAL_FlashRead((uint8_t*)data, PARA_SIZE);
+    HAL_FlashRead(data, PARA_SIZE);
   #endif
 
   sign = data[index++];
@@ -102,7 +102,7 @@ void storePara(void)
   #ifdef I2C_EEPROM                      // added I2C_EEPROM suppport for MKS_TFT35_V1_0
     EEPROM_FlashWrite((uint8_t*)data, PARA_SIZE);  // store settings in I2C_EEPROM
   #else
-    HAL_FlashWrite((uint8_t*)data, PARA_SIZE);
+    HAL_FlashWrite(data, PARA_SIZE);
   #endif
 }
 

--- a/TFT/src/User/API/FlashStore.c
+++ b/TFT/src/User/API/FlashStore.c
@@ -47,17 +47,17 @@ static uint32_t byteToWord(uint8_t * bytes, uint8_t len)
 
 void readStoredPara(void)
 {
-  uint8_t data[PARA_SIZE];
+  uint32_t data[PARA_SIZE];
   uint32_t index = 0;
   uint32_t sign = 0;
 
   #ifdef I2C_EEPROM  // added I2C_EEPROM suppport for MKS_TFT35_V1_0
-    EEPROM_FlashRead(data, PARA_SIZE);
+    EEPROM_FlashRead((uint8_t*)data, PARA_SIZE);
   #else
-    HAL_FlashRead(data, PARA_SIZE);
+    HAL_FlashRead((uint8_t*)data, PARA_SIZE);
   #endif
 
-  sign = byteToWord(data + (index += 4), 4);
+  sign = data[index++];
 
   if (sign == TSC_SIGN)
   {
@@ -65,11 +65,11 @@ void readStoredPara(void)
 
     for (int i = 0; i < sizeof(TS_CalPara) / sizeof(TS_CalPara[0]); i++)
     {
-      TS_CalPara[i] = byteToWord(data + (index += 4), 4);
+      TS_CalPara[i] = data[index++];
     }
   }
 
-  sign = byteToWord(data + (index += 4), 4);
+  sign = data[index++];
 
   if (sign != PARA_SIGN)  // if the settings parameter is illegal, reset settings parameter
   {
@@ -78,30 +78,31 @@ void readStoredPara(void)
   }
   else
   {
-    memcpy(&infoSettings, data + (index += 4), sizeof(SETTINGS));
+    memcpy(&infoSettings, &data[index], sizeof(SETTINGS));
     //if ((paraStatus & PARA_TSC_EXIST) == 0) infoSettings.rotated_ui = DISABLED;  // unecessarily rotates UI to Default?
   }
 }
 
 void storePara(void)
 {
-  uint8_t data[PARA_SIZE];
+  uint32_t data[PARA_SIZE];
   uint32_t index = 0;
 
-  wordToByte(TSC_SIGN, data + (index += 4));
+  memset(data, 0xFF, sizeof(data)); // initialise buffer to unwritten flash memory
+  data[index++] = TSC_SIGN;
 
   for (int i = 0; i < sizeof(TS_CalPara) / sizeof(TS_CalPara[0]); i++)
   {
-    wordToByte(TS_CalPara[i], data + (index += 4));
+    data[index++] = TS_CalPara[i];
   }
 
-  wordToByte(PARA_SIGN, data + (index += 4));
-  memcpy(data + (index += 4), &infoSettings, sizeof(SETTINGS));
+  data[index++] = PARA_SIGN;
 
+  memcpy(&data[index], &infoSettings, sizeof(SETTINGS));
   #ifdef I2C_EEPROM                      // added I2C_EEPROM suppport for MKS_TFT35_V1_0
-    EEPROM_FlashWrite(data, PARA_SIZE);  // store settings in I2C_EEPROM
+    EEPROM_FlashWrite((uint8_t*)data, PARA_SIZE);  // store settings in I2C_EEPROM
   #else
-    HAL_FlashWrite(data, PARA_SIZE);
+    HAL_FlashWrite((uint8_t*)data, PARA_SIZE);
   #endif
 }
 

--- a/TFT/src/User/API/FlashStore.h
+++ b/TFT/src/User/API/FlashStore.h
@@ -6,8 +6,9 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#define EMPTY_FLASH_WORD 0xFFFFFFFF
 
-#define PARA_SIZE (128 * 3)  // max size of settings buffer to read/write
+#define PARA_SIZE (128 * 2)  // max size of settings buffer to read/write
 
 void readStoredPara(void);  // read settings parameter if exist, or reset settings parameter
 void storePara(void);

--- a/TFT/src/User/API/Settings.c
+++ b/TFT/src/User/API/Settings.c
@@ -1,7 +1,12 @@
 #include "Settings.h"
 #include "includes.h"
+#include <assert.h>
 
 SETTINGS infoSettings;
+
+// Ensure PARA_SIZE is defined large enough for user data
+static_assert(sizeof(infoSettings) <= PARA_SIZE - 36, "PARA_SIZE is too small"); // 4(TSC_SIGN) + (7 x 4)(TSC VALUES) + 4(PARA_SIGN) = 36 (see FlashStore.c)
+
 MACHINE_SETTINGS infoMachineSettings;
 
 static const uint8_t default_serial_port[]  = {SP_1, SP_2, SP_3, SP_4};
@@ -186,7 +191,7 @@ void initSettings(void)
   resetConfig();
 
   // calculate checksum excluding the CRC variable in infoSettings
-  infoSettings.CRC_checksum = calculateCRC16((uint8_t *) &infoSettings + sizeof(infoSettings.CRC_checksum),
+  infoSettings.CRC_checksum = calculateCRC32((uint8_t *) &infoSettings + sizeof(infoSettings.CRC_checksum),
                                                   sizeof(infoSettings) - sizeof(infoSettings.CRC_checksum));
 }
 
@@ -194,7 +199,7 @@ void initSettings(void)
 void saveSettings(void)
 {
   // calculate checksum excluding the CRC variable in infoSettings
-  uint32_t curCRC = calculateCRC16((uint8_t *) &infoSettings + sizeof(infoSettings.CRC_checksum),
+  uint32_t curCRC = calculateCRC32((uint8_t *) &infoSettings + sizeof(infoSettings.CRC_checksum),
                                         sizeof(infoSettings) - sizeof(infoSettings.CRC_checksum));
 
   if (curCRC != infoSettings.CRC_checksum)  // save to Flash only if CRC does not match

--- a/TFT/src/User/API/Settings.h
+++ b/TFT/src/User/API/Settings.h
@@ -167,7 +167,7 @@ typedef enum
 
 typedef struct
 {
-  uint16_t CRC_checksum;
+  uint32_t CRC_checksum;
 
   // General Settings
   uint8_t  serial_port[MAX_SERIAL_PORT_COUNT];

--- a/TFT/src/User/Hal/gd32f20x/HAL_Flash.c
+++ b/TFT/src/User/Hal/gd32f20x/HAL_Flash.c
@@ -1,6 +1,7 @@
 #include "HAL_Flash.h"
 #include "variants.h"  // for fmc_unlock etc.
 #include "my_misc.h"
+#include "FlashStore.h"
 
 /*
  * Page 0 0x0800 0000 - 0x0800 07FF 2 Kbyte
@@ -13,32 +14,57 @@
  */
 
 #define SIGN_ADDRESS (0x08040000 - 0x800)  // reserve the last page (2KB) to save user parameters
+#define FLASH_SECTOR_SIZE 0x800            // 2KByte flash sector
+
+uint32_t Find_EmptyFlashSlot()
+{
+  for (uint32_t i = 0; i < (FLASH_SECTOR_SIZE / PARA_SIZE); i++)
+  {
+    if (*((volatile uint32_t *)(SIGN_ADDRESS + (i * PARA_SIZE) + 1)) == EMPTY_FLASH_WORD)
+      return i; // found
+  }
+
+  return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
+}
 
 void HAL_FlashRead(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
 
+  uint32_t slot = Find_EmptyFlashSlot();
+  if (slot) // read from slot before empty slot
+    slot--;
+
   for (i = 0; i < len; i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + i));
+    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
   }
 }
 
 void HAL_FlashWrite(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
+ 
+  // find an empty flash slot
+  uint32_t slot = Find_EmptyFlashSlot();
 
   fmc_unlock();
-  fmc_page_erase(SIGN_ADDRESS);
-  fmc_flag_clear(FMC_FLAG_BANK0_END);
-  fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
-  fmc_flag_clear(FMC_FLAG_BANK0_PGERR);
+
+  if (slot == (FLASH_SECTOR_SIZE / PARA_SIZE)) // no more empty slots, start over
+  {
+    fmc_page_erase(SIGN_ADDRESS);
+    fmc_flag_clear(FMC_FLAG_BANK0_END);
+    fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
+    fmc_flag_clear(FMC_FLAG_BANK0_PGERR);
+
+    slot = 0; // restart from the first slot
+  }
 
   for (i = 0; i < len; i += 2)
   {
     uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // gd32f20x needs to write at least 16 bits at a time
 
-    fmc_halfword_program(SIGN_ADDRESS + i, data16);
+    fmc_halfword_program(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
     fmc_flag_clear(FMC_FLAG_BANK0_END);
     fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
     fmc_flag_clear(FMC_FLAG_BANK0_PGERR);

--- a/TFT/src/User/Hal/gd32f20x/HAL_Flash.c
+++ b/TFT/src/User/Hal/gd32f20x/HAL_Flash.c
@@ -1,7 +1,7 @@
 #include "HAL_Flash.h"
 #include "variants.h"  // for fmc_unlock etc.
 #include "my_misc.h"
-#include "FlashStore.h"
+#include "FlashStore.h" // for PARA_SIZE
 
 /*
  * Page 0 0x0800 0000 - 0x0800 07FF 2 Kbyte
@@ -27,24 +27,20 @@ uint32_t Find_EmptyFlashSlot()
   return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
 }
 
-void HAL_FlashRead(uint8_t * data, uint32_t len)
+void HAL_FlashRead(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
-
   uint32_t slot = Find_EmptyFlashSlot();
   if (slot) // read from slot before empty slot
     slot--;
 
-  for (i = 0; i < len; i++)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
+    data[i] = *((volatile uint32_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2)));
   }
 }
 
-void HAL_FlashWrite(uint8_t * data, uint32_t len)
+void HAL_FlashWrite(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
- 
   // find an empty flash slot
   uint32_t slot = Find_EmptyFlashSlot();
 
@@ -60,11 +56,9 @@ void HAL_FlashWrite(uint8_t * data, uint32_t len)
     slot = 0; // restart from the first slot
   }
 
-  for (i = 0; i < len; i += 2)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // gd32f20x needs to write at least 16 bits at a time
-
-    fmc_halfword_program(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
+    fmc_word_program(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2), data[i]);
     fmc_flag_clear(FMC_FLAG_BANK0_END);
     fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
     fmc_flag_clear(FMC_FLAG_BANK0_PGERR);

--- a/TFT/src/User/Hal/gd32f20x/HAL_Flash.h
+++ b/TFT/src/User/Hal/gd32f20x/HAL_Flash.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void HAL_FlashRead(uint8_t * data, uint32_t len);
-void HAL_FlashWrite(uint8_t * data, uint32_t len);
+void HAL_FlashRead(uint32_t * data, uint32_t len);
+void HAL_FlashWrite(uint32_t * data, uint32_t len);
 
 #endif

--- a/TFT/src/User/Hal/gd32f30x/HAL_Flash.c
+++ b/TFT/src/User/Hal/gd32f30x/HAL_Flash.c
@@ -27,24 +27,20 @@ uint32_t Find_EmptyFlashSlot()
   return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
 }
 
-void HAL_FlashRead(uint8_t * data, uint32_t len)
+void HAL_FlashRead(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
-
   uint32_t slot = Find_EmptyFlashSlot();
   if (slot) // read from slot before empty slot
     slot--;
 
-  for (i = 0; i < len; i++)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
+    data[i] = *((volatile uint32_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2)));
   }
 }
 
-void HAL_FlashWrite(uint8_t * data, uint32_t len)
+void HAL_FlashWrite(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
- 
   // find an empty flash slot
   uint32_t slot = Find_EmptyFlashSlot();
 
@@ -60,11 +56,9 @@ void HAL_FlashWrite(uint8_t * data, uint32_t len)
     slot = 0; // restart from the first slot
   }
 
-  for (i = 0; i < len; i += 2)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // gd32f20x needs to write at least 16 bits at a time
-
-    fmc_halfword_program(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
+    fmc_word_program(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2), data[i]);
     fmc_flag_clear(FMC_FLAG_BANK0_END);
     fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
     fmc_flag_clear(FMC_FLAG_BANK0_PGERR);

--- a/TFT/src/User/Hal/gd32f30x/HAL_Flash.c
+++ b/TFT/src/User/Hal/gd32f30x/HAL_Flash.c
@@ -1,6 +1,7 @@
 #include "HAL_Flash.h"
 #include "variants.h"  // for fmc_unlock etc.
 #include "my_misc.h"
+#include "FlashStore.h"
 
 /*
  * Page 0 0x0800 0000 - 0x0800 07FF 2 Kbyte
@@ -13,32 +14,57 @@
  */
 
 #define SIGN_ADDRESS (0x08040000 - 0x800)  // reserve the last page (2KB) to save user parameters
+#define FLASH_SECTOR_SIZE 0x800            // 2KBytes flash sector
+
+uint32_t Find_EmptyFlashSlot()
+{
+  for (uint32_t i = 0; i < (FLASH_SECTOR_SIZE / PARA_SIZE); i++)
+  {
+    if (*((volatile uint32_t *)(SIGN_ADDRESS + (i * PARA_SIZE) + 1)) == EMPTY_FLASH_WORD)
+      return i; // found
+  }
+
+  return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
+}
 
 void HAL_FlashRead(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
 
+  uint32_t slot = Find_EmptyFlashSlot();
+  if (slot) // read from slot before empty slot
+    slot--;
+
   for (i = 0; i < len; i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + i));
+    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
   }
 }
 
 void HAL_FlashWrite(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
+ 
+  // find an empty flash slot
+  uint32_t slot = Find_EmptyFlashSlot();
 
   fmc_unlock();
-  fmc_page_erase(SIGN_ADDRESS);
-  fmc_flag_clear(FMC_FLAG_BANK0_END);
-  fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
-  fmc_flag_clear(FMC_FLAG_BANK0_PGERR);
+
+  if (slot == (FLASH_SECTOR_SIZE / PARA_SIZE)) // no more empty slots, start over
+  {
+    fmc_page_erase(SIGN_ADDRESS);
+    fmc_flag_clear(FMC_FLAG_BANK0_END);
+    fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
+    fmc_flag_clear(FMC_FLAG_BANK0_PGERR);
+
+    slot = 0; // restart from the first slot
+  }
 
   for (i = 0; i < len; i += 2)
   {
     uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // gd32f20x needs to write at least 16 bits at a time
 
-    fmc_halfword_program(SIGN_ADDRESS + i, data16);
+    fmc_halfword_program(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
     fmc_flag_clear(FMC_FLAG_BANK0_END);
     fmc_flag_clear(FMC_FLAG_BANK0_WPERR);
     fmc_flag_clear(FMC_FLAG_BANK0_PGERR);

--- a/TFT/src/User/Hal/gd32f30x/HAL_Flash.h
+++ b/TFT/src/User/Hal/gd32f30x/HAL_Flash.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void HAL_FlashRead(uint8_t * data, uint32_t len);
-void HAL_FlashWrite(uint8_t * data, uint32_t len);
+void HAL_FlashRead(uint32_t * data, uint32_t len);
+void HAL_FlashWrite(uint32_t * data, uint32_t len);
 
 #endif

--- a/TFT/src/User/Hal/stm32f10x/HAL_Flash.c
+++ b/TFT/src/User/Hal/stm32f10x/HAL_Flash.c
@@ -17,24 +17,20 @@ uint32_t Find_EmptyFlashSlot()
   return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
 }
 
-void HAL_FlashRead(uint8_t * data, uint32_t len)
+void HAL_FlashRead(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
-
   uint32_t slot = Find_EmptyFlashSlot();
   if (slot) // read from slot before empty slot
     slot--;
 
-  for (i = 0; i < len; i++)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
+    data[i] = *((volatile uint32_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2)));
   }
 }
 
-void HAL_FlashWrite(uint8_t * data, uint32_t len)
+void HAL_FlashWrite(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
- 
   // find an empty flash slot
   uint32_t slot = Find_EmptyFlashSlot();
 
@@ -46,11 +42,10 @@ void HAL_FlashWrite(uint8_t * data, uint32_t len)
     slot = 0; // restart from the first slot
   }
 
-  for (i = 0; i < len; i += 2)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // stm32f10x needs to write at least 16 bits at a time
 
-    FLASH_ProgramHalfWord(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
+    FLASH_ProgramWord(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2), data[i]);
   }
 
   FLASH_Lock();

--- a/TFT/src/User/Hal/stm32f10x/HAL_Flash.c
+++ b/TFT/src/User/Hal/stm32f10x/HAL_Flash.c
@@ -1,31 +1,56 @@
 #include "HAL_Flash.h"
 #include "variants.h"  // for FLASH_Unlock etc.
 #include "my_misc.h"
+#include "FlashStore.h"
 
 #define SIGN_ADDRESS (0x08040000 - 0x800)  // reserve the last page (2KB) to save user parameters
+#define FLASH_SECTOR_SIZE 0x800 // 2KB flash sector
+
+uint32_t Find_EmptyFlashSlot()
+{
+  for (uint32_t i = 0; i < (FLASH_SECTOR_SIZE / PARA_SIZE); i++)
+  {
+    if (*((volatile uint32_t *)(SIGN_ADDRESS + (i * PARA_SIZE) + 1)) == EMPTY_FLASH_WORD)
+      return i; // found
+  }
+
+  return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
+}
 
 void HAL_FlashRead(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
 
+  uint32_t slot = Find_EmptyFlashSlot();
+  if (slot) // read from slot before empty slot
+    slot--;
+
   for (i = 0; i < len; i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + i));
+    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
   }
 }
 
 void HAL_FlashWrite(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
+ 
+  // find an empty flash slot
+  uint32_t slot = Find_EmptyFlashSlot();
 
   FLASH_Unlock();
-  FLASH_ErasePage(SIGN_ADDRESS);
+
+  if (slot == (FLASH_SECTOR_SIZE / PARA_SIZE)) // no more empty slots, start over
+  {
+    FLASH_ErasePage(SIGN_ADDRESS);
+    slot = 0; // restart from the first slot
+  }
 
   for (i = 0; i < len; i += 2)
   {
     uint16_t data16 = data[i] | (data[MIN(i + 1, len - 1)] << 8);  // stm32f10x needs to write at least 16 bits at a time
 
-    FLASH_ProgramHalfWord(SIGN_ADDRESS + i, data16);
+    FLASH_ProgramHalfWord(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data16);
   }
 
   FLASH_Lock();

--- a/TFT/src/User/Hal/stm32f10x/HAL_Flash.h
+++ b/TFT/src/User/Hal/stm32f10x/HAL_Flash.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void HAL_FlashRead(uint8_t * data, uint32_t len);
-void HAL_FlashWrite(uint8_t * data, uint32_t len);
+void HAL_FlashRead(uint32_t * data, uint32_t len);
+void HAL_FlashWrite(uint32_t * data, uint32_t len);
 
 #endif

--- a/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
+++ b/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
@@ -1,6 +1,7 @@
 #include "HAL_Flash.h"
 #include "variants.h"  // for MKS_TFT35_V1_0, FLASH_Unlock etc.
 #include "my_misc.h"
+#include "FlashStore.h"
 
 /*
  * Sector 0 0x0800 0000 - 0x0800 3FFF 16 Kbyte
@@ -16,39 +17,31 @@
  * Sector 11 0x080E 0000 - 0x080F FFFF 128 Kbyte
  */
 
-#if defined(MKS_TFT35_V1_0)  // added for MKS TFT 35 V1.0 support. MKS_TFT35_V1_0 bootloader is 48KB, adjust flash mapping
-  #define ADDR_FLASH_SECTOR_0  ((uint32_t)0x08000000)  // base @ of sector 0, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_1  ((uint32_t)0x08004000)  // base @ of sector 1, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_2  ((uint32_t)0x08008000)  // base @ of sector 2, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_3  ((uint32_t)0x0800C000)  // base @ of sector 3, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_4  ((uint32_t)0x08010000)  // base @ of sector 4, 64 Kbytes
-  #define ADDR_FLASH_SECTOR_5  ((uint32_t)0x08020000)  // base @ of sector 5, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_6  ((uint32_t)0x08040000)  // base @ of sector 6, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_7  ((uint32_t)0x08060000)  // base @ of sector 7, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_8  ((uint32_t)0x08080000)  // base @ of sector 8, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_9  ((uint32_t)0x080A0000)  // base @ of sector 9, 128 Kbytes
+#if defined(MKS_TFT35_V1_0)  // MKS_TFT35_V1_0 bootloader uses sector 0, 1 and 2 (48Kbytes)
+  #define ADDR_FLASH_SECTOR_0  ((uint32_t)0x08000000)  // base @ of sector  0,  16 Kbytes
+  #define ADDR_FLASH_SECTOR_1  ((uint32_t)0x08004000)  // base @ of sector  1,  16 Kbytes
+  #define ADDR_FLASH_SECTOR_2  ((uint32_t)0x08008000)  // base @ of sector  2,  16 Kbytes
+  #define ADDR_FLASH_SECTOR_3  ((uint32_t)0x0800C000)  // base @ of sector  3,  16 Kbytes
+  #define ADDR_FLASH_SECTOR_4  ((uint32_t)0x08010000)  // base @ of sector  4,  64 Kbytes
+  #define ADDR_FLASH_SECTOR_5  ((uint32_t)0x08020000)  // base @ of sector  5, 128 Kbytes
+  #define ADDR_FLASH_SECTOR_6  ((uint32_t)0x08040000)  // base @ of sector  6, 128 Kbytes
+  #define ADDR_FLASH_SECTOR_7  ((uint32_t)0x08060000)  // base @ of sector  7, 128 Kbytes
+  #define ADDR_FLASH_SECTOR_8  ((uint32_t)0x08080000)  // base @ of sector  8, 128 Kbytes
+  #define ADDR_FLASH_SECTOR_9  ((uint32_t)0x080A0000)  // base @ of sector  9, 128 Kbytes
   #define ADDR_FLASH_SECTOR_10 ((uint32_t)0x080C0000)  // base @ of sector 10, 128 Kbytes
   #define ADDR_FLASH_SECTOR_11 ((uint32_t)0x080E0000)  // base @ of sector 11, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_12 ((uint32_t)0x08100000)  // base @ of sector 0, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_13 ((uint32_t)0x08104000)  // base @ of sector 1, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_14 ((uint32_t)0x08108000)  // base @ of sector 2, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_15 ((uint32_t)0x0810C000)  // base @ of sector 3, 16 Kbytes
-  #define ADDR_FLASH_SECTOR_16 ((uint32_t)0x08110000)  // base @ of sector 4, 64 Kbytes
-  #define ADDR_FLASH_SECTOR_17 ((uint32_t)0x08120000)  // base @ of sector 5, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_18 ((uint32_t)0x08140000)  // base @ of sector 6, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_19 ((uint32_t)0x08160000)  // base @ of sector 7, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_20 ((uint32_t)0x08180000)  // base @ of sector 8, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_21 ((uint32_t)0x081A0000)  // base @ of sector 9, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_22 ((uint32_t)0x081C0000)  // base @ of sector 10, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_23 ((uint32_t)0x081E0000)  // base @ of sector 11, 128 Kbytes
+  #define ADDR_FLASH_SECTOR_12 ((uint32_t)0x08100000)  // base @ of sector 12, dummy
 
-  // use darkspr1te alternative small loader to fix this issue and return to using 16kb lower flash for param storage
-  // or switch to I2C if we use getsector routine it returns this value anyway, so FLASH_SECTOR is not used
-  #define SIGN_ADDRESS (0x08040000)    // reserve the last 128k for user params or we damage the boot loader on this board
-  #define FLASH_SECTOR FLASH_Sector_6  // points to an available sector (0x08040000 - 0x0805FFFF)
+
+  // Default is use I2C AT24C16 2KBytes EEPROM
+  // Thanks to darkspr1te for the implementation
+  #define SIGN_ADDRESS (0x08060000)    // reserve the last 128KB for user params or we damage the boot loader on this board
+  #define FLASH_SECTOR FLASH_Sector_7  // points to an available sector (0x08060000 - 0x0807FFFF)
+  #define FLASH_SECTOR_SIZE 0x4000     // 16KBytes flash sector
 #else
   #define SIGN_ADDRESS (0x08004000)    // reserve the second sector (16KB) to save user parameters
   #define FLASH_SECTOR FLASH_Sector_1
+  #define FLASH_SECTOR_SIZE 0x4000 // 16KB flash sector
 #endif
 
 #if defined(MKS_TFT35_V1_0)
@@ -87,31 +80,54 @@ static inline uint32_t GetSector(uint32_t address)
 
 #endif  // MKS_TFT35_V1_0
 
+uint32_t Find_EmptyFlashSlot()
+{
+  for (uint32_t i = 0; i < (FLASH_SECTOR_SIZE / PARA_SIZE); i++)
+  {
+    if (*((volatile uint32_t *)(SIGN_ADDRESS + (i * PARA_SIZE) + 1)) == EMPTY_FLASH_WORD)
+      return i; // found
+  }
+
+  return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
+}
+
 void HAL_FlashRead(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
 
+  uint32_t slot = Find_EmptyFlashSlot();
+  if (slot) // read from slot before empty slot
+    slot--;
+
   for (i = 0; i < len; i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + i));
+    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
   }
 }
 
 void HAL_FlashWrite(uint8_t * data, uint32_t len)
 {
   uint32_t i = 0;
+ 
+  // find an empty flash slot
+  uint32_t slot = Find_EmptyFlashSlot();
 
   FLASH_Unlock();
 
-  #if defined(MKS_TFT35_V1_0)  // added for MKS_TFT35_V1_0 support
-    FLASH_EraseSector(GetSector(SIGN_ADDRESS), VoltageRange_1);
-  #else
-    FLASH_EraseSector(FLASH_SECTOR, VoltageRange_1);
-  #endif
+  if (slot == (FLASH_SECTOR_SIZE / PARA_SIZE)) // no more empty slots, start over
+  {
+    #if defined(MKS_TFT35_V1_0)  // added for MKS_TFT35_V1_0 support
+      FLASH_EraseSector(GetSector(SIGN_ADDRESS), VoltageRange_1);
+    #else
+      FLASH_EraseSector(FLASH_SECTOR, VoltageRange_1);
+    #endif
+
+    slot = 0; // restart from the first slot
+  }
 
   for (i = 0; i < len; i++)
   {
-    FLASH_ProgramByte(SIGN_ADDRESS + i, data[i]);
+    FLASH_ProgramByte(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data[i]);
   }
 
   FLASH_Lock();

--- a/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
+++ b/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
@@ -4,32 +4,33 @@
 #include "FlashStore.h"
 
 /*
- * Sector 0 0x0800 0000 - 0x0800 3FFF 16 Kbyte
- * Sector 1 0x0800 4000 - 0x0800 7FFF 16 Kbyte
- * Sector 2 0x0800 8000 - 0x0800 BFFF 16 Kbyte
- * Sector 3 0x0800 C000 - 0x0800 FFFF 16 Kbyte
- * Sector 4 0x0801 0000 - 0x0801 FFFF 64 Kbyte
- * Sector 5 0x0802 0000 - 0x0803 FFFF 128 Kbyte  // 256KByte
- * Sector 6 0x0804 0000 - 0x0805 FFFF 128 Kbyte
- * ...
- * ...
- * ...
- * Sector 11 0x080E 0000 - 0x080F FFFF 128 Kbyte
+ * Sector  0 0x0800 0000 - 0x0800 3FFF  16KByte
+ * Sector  1 0x0800 4000 - 0x0800 7FFF  16KByte
+ * Sector  2 0x0800 8000 - 0x0800 BFFF  16KByte
+ * Sector  3 0x0800 C000 - 0x0800 FFFF  16KByte
+ * Sector  4 0x0801 0000 - 0x0801 FFFF  64KByte
+ * Sector  5 0x0802 0000 - 0x0803 FFFF 128KByte ___256KByte
+ * Sector  6 0x0804 0000 - 0x0805 FFFF 128KByte
+ * Sector  7 0x0804 0000 - 0x0807 FFFF 128KByte ___512KByte
+ * Sector  8 0x0804 0000 - 0x0809 FFFF 128KByte
+ * Sector  9 0x0804 0000 - 0x080B FFFF 128KByte
+ * Sector 10 0x0804 0000 - 0x080D FFFF 128KByte
+ * Sector 11 0x080E 0000 - 0x080F FFFF 128KByte ___1MByte
  */
 
-#if defined(MKS_TFT35_V1_0)  // MKS_TFT35_V1_0 bootloader uses sector 0, 1 and 2 (48Kbytes)
-  #define ADDR_FLASH_SECTOR_0  ((uint32_t)0x08000000)  // base @ of sector  0,  16 Kbytes
-  #define ADDR_FLASH_SECTOR_1  ((uint32_t)0x08004000)  // base @ of sector  1,  16 Kbytes
-  #define ADDR_FLASH_SECTOR_2  ((uint32_t)0x08008000)  // base @ of sector  2,  16 Kbytes
-  #define ADDR_FLASH_SECTOR_3  ((uint32_t)0x0800C000)  // base @ of sector  3,  16 Kbytes
-  #define ADDR_FLASH_SECTOR_4  ((uint32_t)0x08010000)  // base @ of sector  4,  64 Kbytes
-  #define ADDR_FLASH_SECTOR_5  ((uint32_t)0x08020000)  // base @ of sector  5, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_6  ((uint32_t)0x08040000)  // base @ of sector  6, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_7  ((uint32_t)0x08060000)  // base @ of sector  7, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_8  ((uint32_t)0x08080000)  // base @ of sector  8, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_9  ((uint32_t)0x080A0000)  // base @ of sector  9, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_10 ((uint32_t)0x080C0000)  // base @ of sector 10, 128 Kbytes
-  #define ADDR_FLASH_SECTOR_11 ((uint32_t)0x080E0000)  // base @ of sector 11, 128 Kbytes
+#if defined(MKS_TFT35_V1_0)  // MKS_TFT35_V1_0 bootloader uses sector 0, 1 and 2 (48KBytes)
+  #define ADDR_FLASH_SECTOR_0  ((uint32_t)0x08000000)  // base @ of sector  0,  16 KBytes
+  #define ADDR_FLASH_SECTOR_1  ((uint32_t)0x08004000)  // base @ of sector  1,  16 KBytes
+  #define ADDR_FLASH_SECTOR_2  ((uint32_t)0x08008000)  // base @ of sector  2,  16 KBytes
+  #define ADDR_FLASH_SECTOR_3  ((uint32_t)0x0800C000)  // base @ of sector  3,  16 KBytes
+  #define ADDR_FLASH_SECTOR_4  ((uint32_t)0x08010000)  // base @ of sector  4,  64 KBytes
+  #define ADDR_FLASH_SECTOR_5  ((uint32_t)0x08020000)  // base @ of sector  5, 128 KBytes
+  #define ADDR_FLASH_SECTOR_6  ((uint32_t)0x08040000)  // base @ of sector  6, 128 KBytes
+  #define ADDR_FLASH_SECTOR_7  ((uint32_t)0x08060000)  // base @ of sector  7, 128 KBytes
+  #define ADDR_FLASH_SECTOR_8  ((uint32_t)0x08080000)  // base @ of sector  8, 128 KBytes
+  #define ADDR_FLASH_SECTOR_9  ((uint32_t)0x080A0000)  // base @ of sector  9, 128 KBytes
+  #define ADDR_FLASH_SECTOR_10 ((uint32_t)0x080C0000)  // base @ of sector 10, 128 KBytes
+  #define ADDR_FLASH_SECTOR_11 ((uint32_t)0x080E0000)  // base @ of sector 11, 128 KBytes
   #define ADDR_FLASH_SECTOR_12 ((uint32_t)0x08100000)  // base @ of sector 12, dummy
 
 
@@ -46,36 +47,23 @@
 
 #if defined(MKS_TFT35_V1_0)
 
-static inline uint32_t GetSector(uint32_t address)
-{
-  uint32_t sector = 0;
+// returns in which sector id (NOT 0-11!) a flash memory address is located
+uint8_t HAL_FlashGetSector(uint32_t flash_address)
+{ // Sector lookup table, 1 byte represents 16KB 
+  if (flash_address < FLASH_BASE)
+    return 0;
+  
+  static const uint8_t sector_data1[4] = {
+    FLASH_Sector_0, FLASH_Sector_1, FLASH_Sector_2, FLASH_Sector_3 };   // Sector  0-3  16KB
 
-  if ((address < ADDR_FLASH_SECTOR_1) && (address >= ADDR_FLASH_SECTOR_0))
-    sector = FLASH_Sector_0;
-  else if ((address < ADDR_FLASH_SECTOR_2) && (address >= ADDR_FLASH_SECTOR_1))
-    sector = FLASH_Sector_1;
-  else if ((address < ADDR_FLASH_SECTOR_3) && (address >= ADDR_FLASH_SECTOR_2))
-    sector = FLASH_Sector_2;
-  else if ((address < ADDR_FLASH_SECTOR_4) && (address >= ADDR_FLASH_SECTOR_3))
-    sector = FLASH_Sector_3;
-  else if ((address < ADDR_FLASH_SECTOR_5) && (address >= ADDR_FLASH_SECTOR_4))
-    sector = FLASH_Sector_4;
-  else if ((address < ADDR_FLASH_SECTOR_6) && (address >= ADDR_FLASH_SECTOR_5))
-    sector = FLASH_Sector_5;
-  else if ((address < ADDR_FLASH_SECTOR_7) && (address >= ADDR_FLASH_SECTOR_6))
-    sector = FLASH_Sector_6;
-  else if ((address < ADDR_FLASH_SECTOR_8) && (address >= ADDR_FLASH_SECTOR_7))
-    sector = FLASH_Sector_7;
-  else if ((address < ADDR_FLASH_SECTOR_9) && (address >= ADDR_FLASH_SECTOR_8))
-    sector = FLASH_Sector_8;
-  else if ((address < ADDR_FLASH_SECTOR_10) && (address >= ADDR_FLASH_SECTOR_9))
-    sector = FLASH_Sector_9;
-  else if ((address < ADDR_FLASH_SECTOR_11) && (address >= ADDR_FLASH_SECTOR_10))
-    sector = FLASH_Sector_10;
-  else if ((address < ADDR_FLASH_SECTOR_12) && (address >= ADDR_FLASH_SECTOR_11))
-    sector = FLASH_Sector_11;
+  static const uint8_t sector_data2[8] = {
+    FLASH_Sector_4, FLASH_Sector_5, FLASH_Sector_6,  FLASH_Sector_7,    // Sector    4  64KB
+    FLASH_Sector_8, FLASH_Sector_9, FLASH_Sector_10, FLASH_Sector_11 }; // Sector 5-11 128KB
 
-  return sector;
+  if (flash_address < FLASH_SECTOR_4_ADDR)
+    return sector_data1[((flash_address - FLASH_BASE) >> 14) % 4];
+
+  return sector_data2[((flash_address - FLASH_BASE) >> 17) % 8];
 }
 
 #endif  // MKS_TFT35_V1_0
@@ -91,24 +79,20 @@ uint32_t Find_EmptyFlashSlot()
   return (FLASH_SECTOR_SIZE / PARA_SIZE); // nothing found, indicate impossible slot
 }
 
-void HAL_FlashRead(uint8_t * data, uint32_t len)
+void HAL_FlashRead(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
-
   uint32_t slot = Find_EmptyFlashSlot();
   if (slot) // read from slot before empty slot
     slot--;
 
-  for (i = 0; i < len; i++)
+  for (uint32_t i = 0; i < (len >> 2); i++)
   {
-    data[i] = *((volatile uint8_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + i));
+    data[i] = *((volatile uint32_t *)(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2)));
   }
 }
 
-void HAL_FlashWrite(uint8_t * data, uint32_t len)
+void HAL_FlashWrite(uint32_t * data, uint32_t len)
 {
-  uint32_t i = 0;
- 
   // find an empty flash slot
   uint32_t slot = Find_EmptyFlashSlot();
 
@@ -117,17 +101,19 @@ void HAL_FlashWrite(uint8_t * data, uint32_t len)
   if (slot == (FLASH_SECTOR_SIZE / PARA_SIZE)) // no more empty slots, start over
   {
     #if defined(MKS_TFT35_V1_0)  // added for MKS_TFT35_V1_0 support
-      FLASH_EraseSector(GetSector(SIGN_ADDRESS), VoltageRange_1);
+      FLASH_EraseSector(HAL_FlashGetSector(SIGN_ADDRESS), VoltageRange_3);
     #else
-      FLASH_EraseSector(FLASH_SECTOR, VoltageRange_1);
+      FLASH_EraseSector(FLASH_SECTOR, VoltageRange_3);
     #endif
-
     slot = 0; // restart from the first slot
   }
 
   for (i = 0; i < len; i++)
   {
     FLASH_ProgramByte(SIGN_ADDRESS + (slot * PARA_SIZE) + i, data[i]);
+  for (uint32_t i = 0; i < (len >> 2); i++)
+  {
+    FLASH_ProgramWord(SIGN_ADDRESS + (slot * PARA_SIZE) + (i << 2), data[i]);
   }
 
   FLASH_Lock();

--- a/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
+++ b/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.c
@@ -19,20 +19,18 @@
  */
 
 #if defined(MKS_TFT35_V1_0)  // MKS_TFT35_V1_0 bootloader uses sector 0, 1 and 2 (48KBytes)
-  #define ADDR_FLASH_SECTOR_0  ((uint32_t)0x08000000)  // base @ of sector  0,  16 KBytes
-  #define ADDR_FLASH_SECTOR_1  ((uint32_t)0x08004000)  // base @ of sector  1,  16 KBytes
-  #define ADDR_FLASH_SECTOR_2  ((uint32_t)0x08008000)  // base @ of sector  2,  16 KBytes
-  #define ADDR_FLASH_SECTOR_3  ((uint32_t)0x0800C000)  // base @ of sector  3,  16 KBytes
-  #define ADDR_FLASH_SECTOR_4  ((uint32_t)0x08010000)  // base @ of sector  4,  64 KBytes
-  #define ADDR_FLASH_SECTOR_5  ((uint32_t)0x08020000)  // base @ of sector  5, 128 KBytes
-  #define ADDR_FLASH_SECTOR_6  ((uint32_t)0x08040000)  // base @ of sector  6, 128 KBytes
-  #define ADDR_FLASH_SECTOR_7  ((uint32_t)0x08060000)  // base @ of sector  7, 128 KBytes
-  #define ADDR_FLASH_SECTOR_8  ((uint32_t)0x08080000)  // base @ of sector  8, 128 KBytes
-  #define ADDR_FLASH_SECTOR_9  ((uint32_t)0x080A0000)  // base @ of sector  9, 128 KBytes
-  #define ADDR_FLASH_SECTOR_10 ((uint32_t)0x080C0000)  // base @ of sector 10, 128 KBytes
-  #define ADDR_FLASH_SECTOR_11 ((uint32_t)0x080E0000)  // base @ of sector 11, 128 KBytes
-  #define ADDR_FLASH_SECTOR_12 ((uint32_t)0x08100000)  // base @ of sector 12, dummy
-
+  #define FLASH_SECTOR_0_ADDR  ((uint32_t)0x08000000)  // base @ of sector  0,  16 KBytes
+  #define FLASH_SECTOR_1_ADDR  ((uint32_t)0x08004000)  // base @ of sector  1,  16 KBytes
+  #define FLASH_SECTOR_2_ADDR  ((uint32_t)0x08008000)  // base @ of sector  2,  16 KBytes
+  #define FLASH_SECTOR_3_ADDR  ((uint32_t)0x0800C000)  // base @ of sector  3,  16 KBytes
+  #define FLASH_SECTOR_4_ADDR  ((uint32_t)0x08010000)  // base @ of sector  4,  64 KBytes
+  #define FLASH_SECTOR_5_ADDR  ((uint32_t)0x08020000)  // base @ of sector  5, 128 KBytes
+  #define FLASH_SECTOR_6_ADDR  ((uint32_t)0x08040000)  // base @ of sector  6, 128 KBytes
+  #define FLASH_SECTOR_7_ADDR  ((uint32_t)0x08060000)  // base @ of sector  7, 128 KBytes
+  #define FLASH_SECTOR_8_ADDR  ((uint32_t)0x08080000)  // base @ of sector  8, 128 KBytes
+  #define FLASH_SECTOR_9_ADDR  ((uint32_t)0x080A0000)  // base @ of sector  9, 128 KBytes
+  #define FLASH_SECTOR_10_ADDR ((uint32_t)0x080C0000)  // base @ of sector 10, 128 KBytes
+  #define FLASH_SECTOR_11_ADDR ((uint32_t)0x080E0000)  // base @ of sector 11, 128 KBytes
 
   // Default is use I2C AT24C16 2KBytes EEPROM
   // Thanks to darkspr1te for the implementation

--- a/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.h
+++ b/TFT/src/User/Hal/stm32f2_f4xx/HAL_Flash.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-void HAL_FlashRead(uint8_t * data, uint32_t len);
-void HAL_FlashWrite(uint8_t * data, uint32_t len);
+void HAL_FlashRead(uint32_t * data, uint32_t len);
+void HAL_FlashWrite(uint32_t * data, uint32_t len);
 
 #endif

--- a/TFT/src/User/my_misc.c
+++ b/TFT/src/User/my_misc.c
@@ -4,7 +4,8 @@
 #include "printf/printf.h"
 #include <stddef.h>
 
-#define CRC_POLY 0xA001
+#define CRC16_POLY_REVERSED     0xA001
+#define CRC32_POLY_REVERSED 0xEDB88320
 
 uint8_t inRange(int cur, int tag , int range)
 {
@@ -32,13 +33,25 @@ uint32_t calculateCRC16(const uint8_t * data, uint32_t length)
     for (uint8_t j = 0; j < 8; j++)
     {
       if (crc & 1)
-        crc = (crc >> 1) ^ CRC_POLY;
+        crc = (crc >> 1) ^ CRC16_POLY_REVERSED;
       else
         crc = crc >> 1;
     }
   }
 
   return crc;
+}
+
+uint32_t calculateCRC32(const uint8_t * data, uint32_t length)
+{
+  uint32_t crc = 0xFFFFFFFF;  
+  for (int i = 0; i < length; i++)
+  {
+    crc = crc ^ data[i];
+    for (int j = 8; j; j--)
+       crc = (crc >> 1) ^ (CRC32_POLY_REVERSED & -(crc & 1));
+  }
+  return ~crc;
 }
 
 // string convert to uint8, MSB ("2C" to 0x2C)

--- a/TFT/src/User/my_misc.h
+++ b/TFT/src/User/my_misc.h
@@ -74,6 +74,7 @@ uint8_t inRange(int cur, int tag , int range);
 long map(long x, long in_min, long in_max, long out_min, long out_max);
 
 uint32_t calculateCRC16(const uint8_t * data, uint32_t length);  // calculate CRC16 checksum
+uint32_t calculateCRC32(const uint8_t * data, uint32_t length);  // calculate CRC32 checksum
 
 uint8_t string_2_uint8(const uint8_t * str);                                // string convert to uint8, MSB ("2C" to 0x2C)
 uint8_t * uint8_2_string(uint8_t num, uint8_t * str);                       // uint8 convert to string, MSB (0x2C to "2C")


### PR DESCRIPTION
This PR implements a simple flash wear leveling on various hardware.

Flash wear leveling
============
User settings are stored in the MCU onboard flash memory (except for the MKS TFT35 V1.0 which uses an AT24C16 EEPROM).
The STM datasheet guarantees 10K writes. The onboard SPI flash guarantees 100K writes, and the AT24C16 guarantees 1 million writes. So the SPI flash seems to be a good candidate to hold user settings, but the onboard program memory was selected.
For example, the BTT TFT35 V3.0 uses a 16K flash sector to hold less than 256 bytes of data. The whole sector is erased every time a user parameter is changed. This not only takes time, but also wears out the flash memory. The implemented wear leveling algorithm improves the wear leveling by a factor of 64, allowing 640K writes. Also responsiveness is improved as interrupt are disabled during flash erase cycles.
For other hardware like the BTT TFT35 V3.0.1 the benefit is less, but still an improvement of a factor of 8 is achieved, the improvement is less because the used flash sector is only 2KB, this could be increased if required.
Part of the improvement is achieve by not writing more data than needed. The settings are less than 256 bytes, but still always 384 bytes were written to flash. The unused data values are usually 0, which is the worst case scenario for flash memory. It would be better to initialize the data record to the status of erased flash (0xFF) so the cells that do not need to change are not changed.

FlashStore cleanup
============
The flash store did some odd things which were improved.
1. It skipped the first 32 bit word of the record it reads and writes.
2. It changes the endianness of some data, like the signatures, which is not needed and actually makes the data harder to find (when using CubeProgrammer etc.). When loading back the data the endianness is changed back again. The additional code to handle this is not needed.
3. Generally the code was difficult to read:
```
wordToByte(PARA_SIGN, data + (index += 4));
memcpy(data + (index += 4), &infoSettings, sizeof(SETTINGS));

```
4. A 16 bit CRC was used to check if the old and new data are different and thus saving is required. This allows for odd cases were data cannot be saved just because by accident the CRC value is the same (1 in 65K cases). This has been improved by using a 32bit CRC value.
5. An assert was added to make sure the user settings fit into the reserved area, currently 12 bytes are still available for more user settings.

### Requirements
Any TFT, except MKS TFT35 V1.0

### Benefits
Flash wear leveling
More responsive saving of user settings
Some flash store code cleanup and assert
More reliable flash storage handling