### PR TITLE
Handle empty M117 notification correctly

### DIFF
--- a/TFT/src/User/API/Mainboard_CmdHandler.c
+++ b/TFT/src/User/API/Mainboard_CmdHandler.c
@@ -1086,6 +1086,9 @@ void sendQueueCmd(void)
             stripCmdChecksum(rawMsg);
             msgText = stripCmdHead(rawMsg);
 
+            if (msgText[0] == 0)  // ignore M117 call without message
+              break;
+
             statusSetMsg("M117", msgText);
 
             if (MENU_IS_NOT(menuStatus))


### PR DESCRIPTION
Handle empty M117 notification correctly

### Requirements
Any TFT

### Description

An M117 call without a message will cause an empty notification. This is used by Marlin to reset the status message, but for the TFT this is unwanted because it has a notification queue and the message does not need to be reset. ESP3D creates empty M117 messages to reset the status message, I'm not sure if slicers use the same approach.

### Benefits

No more empty notifications.

### Related Issues
None